### PR TITLE
Simplify profile README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 | `/llms.txt` | Complementary file containing creative context & tone. |
 | `/subtitles/` | Downloaded `.srt` caption files populated by `fetch_subtitles.py`. |
 | `video_ids.txt` | Canonical list of YouTube IDs referenced by helper scripts. |
+| `INSTRUCTIONS.md` | Extended setup steps and roadmap. |
 
 ## Coding Conventions
 
@@ -56,7 +57,8 @@ When Phase 7 hits (see README roadmap) an additional `make render VIDEO=YYYYMMDD
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): onboarding & roadmap.
+- [README](README.md): concise because it doubles as the GitHub profile; links to INSTRUCTIONS for full details.
+- [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
 - [RUNBOOK](RUNBOOK.md): production checklist.
 - [Ideas guide](ideas/README.md): idea-file schema.
 

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,51 @@
+# Futuroptimist Repository Guide
+
+This document collects the full workflow for managing video scripts and metadata for the Futuroptimist YouTube channel. It mirrors the previous README content.
+
+## Current State
+
+1. **video_ids.txt** – list of the canonical YouTube IDs for each long-form video (no Shorts).
+2. **subtitles/** – English subtitle files (`.srt`) downloaded directly from YouTube. Use the helper script below to populate this folder.
+3. **scripts/** – helper utilities such as subtitle fetchers.
+4. **RUNBOOK.md** – living production checklist covering the end-to-end video workflow.
+5. **llms.txt** and **AGENTS.md** – guidance files that help AI assistants understand the codebase structure, conventions and workflows.
+
+> Video scripts live in `scripts/YYYYMMDD_slug/script.md` (auto-scaffolded). Idea files are collected in `ideas/` as checklists without date prefixes.
+
+## Quick Start
+```bash
+# 1. Install dependencies (yt-dlp only for now)
+pip install -r requirements.txt
+
+# 2. Download available English subtitles into ./subtitles
+python scripts/fetch_subtitles.py
+
+# 3. Run the full test suite (schema, naming, e2e)
+make test
+```
+The script pulls **manual** subtitles when present, falling back to **auto-generated** captions as needed. Files are saved as `subtitles/<videoid>.srt`.
+
+## Next Steps
+* Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).
+* Convert `.srt` caption timing into fully-fledged markdown scripts.
+* Build a lightweight RAG pipeline that indexes past scripts for rapid outline generation of future videos.
+
+## 🌱 Roadmap / Flywheel Enhancements
+The goal: turn this repo into a self-reinforcing engine that **accelerates Futuroptimist content velocity**.
+
+| Phase | Feature | Impact |
+|-------|---------|--------|
+| 1️⃣  Plumbing | • CI action that runs tests + subtitle fetcher on every push.<br>• Pre-commit hooks (black, ruff) | Confidence & code quality |
+| 2️⃣  Metadata Automation | • YouTube Data API sync to enrich markdown front-matter (title, publish date, views, tags).<br>• Slug auto-generation + filename rename helper. | Less manual bookkeeping |
+| 3️⃣  Script Intelligence | • SRT → Markdown converter that preserves timing blocks.<br>• Semantic chunker + embeddings (OpenAI / local) into `data/index` for RAG. | Opens door to AI-assisted new scripts |
+| 4️⃣  Creative Toolkit | • Prompt library for hook/headline generation trained on past hits.<br>• Thumbnail text predictor (CTR estimation) using small vision model. | Higher audience retention |
+| 5️⃣  Distribution Insights | • Analytics ingester (YouTube Analytics API) to pull watch-time & click-through data.<br>• Dashboards (Streamlit) to visualise topic performance vs retention. | Data-driven ideation |
+| 6️⃣  Community | • GitHub Discussions integration for crowdsourced fact-checks.<br>• Scheduled newsletter builder that stitches new scripts + links. | Audience feedback loop |
+| 7️⃣  Production Pipeline | • Adopt OpenTimelineIO as canonical timeline format.<br>• Asset manifest (audio, b-roll, gfx) auto-generated from `videos/<id>` folders.<br>• FFmpeg rendering scripts for rough-cut assembly and caption burn-in.<br>• CLI wrapper `make render VIDEO=xyz` → `dist/xyz.mp4`. | End-to-end reproducible builds |
+| 8️⃣  Publish Orchestration | • YouTube Data API V3 upload endpoint (draft/private).<br>• Automatic thumbnail + metadata attach from repo files.<br>• Post-publish annotation back into metadata.json (video url, processing times). | One-command release |
+
+*(Tick items as we progress!)*
+
+---
+
+© 2025 Futuroptimist – All rights reserved.

--- a/README.md
+++ b/README.md
@@ -1,56 +1,10 @@
-# Futuroptimist Video Scripts Repository
+# Futuroptimist
 
-This repository tracks metadata and (eventually) full scripts for the long-form videos published on the [Futuroptimist YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ).
+Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details and contribution guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
 
-## Current State
-
-1. **video_ids.txt** – list of the canonical YouTube IDs for each long-form video (no Shorts).
-2. **subtitles/** – when available, English subtitle files (`.srt`) downloaded directly from YouTube.  
-   Use the helper script below to populate this folder.
-3. **scripts/** – helper utilities such as subtitle fetchers.
-4. **RUNBOOK.md** – living production checklist covering the end-to-end video workflow.
-5. **llms.txt** and **AGENTS.md** – guidance files that help AI assistants understand and navigate the codebase structure, conventions and workflows.
-
-> Video scripts live in `scripts/YYYYMMDD_slug/script.md` (auto-scaffolded). Idea files are collected in `ideas/` as checklists without date prefixes.
-
-## Quick Start
-
-```bash
-# 1.  Install dependencies (yt-dlp only for now)
-pip install -r requirements.txt
-
-# 2.  Download available English subtitles into ./subtitles
-python scripts/fetch_subtitles.py
-
-# 3.  Run the full test suite (schema, naming, e2e)
-make test
-```
-
-The script pulls **manual** subtitles when present, falling back to **auto-generated** captions as needed. Files are saved as `subtitles/<videoid>.srt`.
-
-## Next Steps
-
-* Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).
-* Convert `.srt` caption timing into fully-fledged markdown scripts.
-* Build a lightweight RAG pipeline that indexes past scripts for rapid outline generation of future videos.
-
-## 🌱 Roadmap / Flywheel Enhancements
-
-The goal: turn this repo into a self-reinforcing engine that **accelerates Futuroptimist content velocity**.
-
-| Phase | Feature | Impact |
-|-------|---------|--------|
-| 1️⃣  Plumbing | • CI action that runs tests + subtitle fetcher on every push.<br>• Pre-commit hooks (black, ruff) | Confidence & code quality |
-| 2️⃣  Metadata Automation | • YouTube Data API sync to enrich markdown front-matter (title, publish date, views, tags).<br>• Slug auto-generation + filename rename helper. | Less manual bookkeeping |
-| 3️⃣  Script Intelligence | • SRT → Markdown converter that preserves timing blocks.<br>• Semantic chunker + embeddings (OpenAI / local) into `data/index` for RAG. | Opens door to AI-assisted new scripts |
-| 4️⃣  Creative Toolkit | • Prompt library for hook/headline generation trained on past hits.<br>• Thumbnail text predictor (CTR estimation) using small vision model. | Higher audience retention |
-| 5️⃣  Distribution Insights | • Analytics ingester (YouTube Analytics API) to pull watch-time & click-through data.<br>• Dashboards (Streamlit) to visualise topic performance vs retention. | Data-driven ideation |
-| 6️⃣  Community | • GitHub Discussions integration for crowdsourced fact-checks.<br>• Scheduled newsletter builder that stitches new scripts + links. | Audience feedback loop |
-| 7️⃣  Production Pipeline | • Adopt OpenTimelineIO as canonical timeline format.<br>• Asset manifest (audio, b-roll, gfx) auto-generated from `videos/<id>` folders.<br>• FFmpeg rendering scripts for rough-cut assembly and caption burn-in.<br>• CLI wrapper `make render VIDEO=xyz` → `dist/xyz.mp4`. | End-to-end reproducible builds |
-| 8️⃣  Publish Orchestration | • YouTube Data API V3 upload endpoint (draft/private).<br>• Automatic thumbnail + metadata attach from repo files.<br>• Post-publish annotation back into metadata.json (video url, processing times). | One-command release |
-
-*(Tick items as we progress!)*
-
----
-
-© 2025 Futuroptimist – All rights reserved. 
+## Other Projects
+- **[token.place](https://token.place)** – p2p generative AI platform ([repo](https://github.com/futuroptimist/token.place))
+- **[DSPACE](https://democratized.space)** – open-source space exploration idle game ([repo](https://github.com/democratizedspace/dspace))
+- **sigma** – open-source AI pin device ([repo](https://github.com/futuroptimist/sigma))
+- **gabriel** – guardian angel LLM ([repo](https://github.com/futuroptimist/gabriel))
+- **f2clipboard** – quickly copy multiple files from nested directories for LLM conversations ([repo](https://github.com/futuroptimist/f2clipboard))


### PR DESCRIPTION
## Summary
- fix link formatting in the Other Projects section for parallelism
- clarify AGENTS.md that README is intentionally concise

## Testing
- `python -m venv .venv && .venv/bin/pip install -r requirements.txt`
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847d6808fc8832fb8d1afade5dc0286