### PR TITLE
Add Insta360 segment and update guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Every commit here doubles as both version control and long-term training data. K
 
 | Path | Purpose |
 |------|---------|
-| `/scripts/` | Helper utilities and per-video script folders (`YYYYMMDD_slug/`). |
+| `/scripts/` | Helper utilities and per-video script folders (`YYYYMMDD_slug/`). Use `scaffold_videos.py` to generate them from `video_ids.txt`. |
 | `/ideas/` | Checklist-style idea files – raw, WIP content. |
 | `/schemas/` | JSON-Schemas (e.g. `video_metadata.schema.json`). |
 | `/tests/` | Pytest suites; keep parity with production code. |
@@ -59,9 +59,10 @@ When Phase 7 hits (see README roadmap) an additional `make render VIDEO=YYYYMMDD
 
 1. Fork & branch.
 2. `make setup` then `make test`.
-3. Optionally run `make subtitles` to verify caption downloads.
-4. Add or update code **and** matching tests.
-5. Commit with descriptive message; open PR.
+3. `python scripts/scaffold_videos.py` to create new script folders from `video_ids.txt`.
+4. Optionally run `make subtitles` to verify caption downloads.
+5. Add or update code **and** matching tests.
+6. Commit with descriptive message; open PR.
 
 ## Additional Resources (File List)
 

--- a/scripts/20250701_indoor-aquariums-tour/script.md
+++ b/scripts/20250701_indoor-aquariums-tour/script.md
@@ -31,6 +31,15 @@
 
 [NARRATOR]: Finally there's a tiny 5 gallon that was neglected for a bit, so right now it only holds snails and microfauna. Because three tanks are lidless, evaporation is fast. I keep two five‑gallon buckets above the tanks and siphon water down with gravity.
 
+[NARRATOR]: To show how each tank looks from the inside, I've waterproofed an Insta360 and dropped it into the water.
+[VISUAL]: Slow shot of the camera sinking into the 20 gallon, followed by 360° footage of guppies all around.
+
+[NARRATOR]: Next up, it tours the fry tank and that cycling betta setup.
+[VISUAL]: Quick montage from inside the fry tank, then the betta tank.
+
+[NARRATOR]: Even the little 5 gallon gets a spin—tiny but lively.
+[VISUAL]: 360° clip from the 5 gallon.
+
 [NARRATOR]: I top off those buckets often and check parameters, sometimes dosing with products like Quick Start. The guppies eat flakes, pellets, and live foods, plus the occasional pinch of nutritional yeast—mmm. I've kept guppies going for about 16 months now, but Daphnia cultures crash easily, so I'm experimenting with green water and leaf litter for stability.
 
 [VISUAL]: B-roll of siphoning from buckets, adding Quick Start, feeding flakes and yeast.


### PR DESCRIPTION
## Summary
- add new Insta360 underwater shot segment in the Indoor Aquarium Tour script
- document `scaffold_videos.py` in AGENTS guide and update contribution steps

## Testing
- `python3 -m venv .venv && .venv/bin/pip install -r requirements.txt`
- `export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847df45834c832f9fdb1417e0eb24b1