### PR TITLE
Improve scaffolding with metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Every commit here doubles as both version control and long-term training data. K
 
 | Path | Purpose |
 |------|---------|
-| `/scripts/` | Helper utilities and per-video script folders (`YYYYMMDD_slug/`). Use `scaffold_videos.py` to generate them from `video_ids.txt`. |
+| `/scripts/` | Helper utilities and per-video script folders (`YYYYMMDD_slug/`). Run `scaffold_videos.py` to fetch titles/dates and create them from `video_ids.txt`. |
 | `/ideas/` | Checklist-style idea files – raw, WIP content. |
 | `/schemas/` | JSON-Schemas (e.g. `video_metadata.schema.json`). |
 | `/tests/` | Pytest suites; keep parity with production code. |
@@ -59,7 +59,7 @@ When Phase 7 hits (see README roadmap) an additional `make render VIDEO=YYYYMMDD
 
 1. Fork & branch.
 2. `make setup` then `make test`.
-3. `python scripts/scaffold_videos.py` to create new script folders from `video_ids.txt`.
+3. `python scripts/scaffold_videos.py` to pull metadata and create dated script folders from `video_ids.txt` (commit new folders).
 4. Optionally run `make subtitles` to verify caption downloads.
 5. Add or update code **and** matching tests.
 6. Commit with descriptive message; open PR.

--- a/scripts/20210917_how-tesla-bots-could-benefit-humanity/metadata.json
+++ b/scripts/20210917_how-tesla-bots-could-benefit-humanity/metadata.json
@@ -1,0 +1,9 @@
+{
+  "youtube_id": "KJVz2f4Fn_U",
+  "title": "How Tesla Bots could benefit humanity",
+  "publish_date": "2021-09-17",
+  "duration_seconds": 0,
+  "keywords": [],
+  "status": "draft",
+  "description": ""
+}

--- a/scripts/20210917_how-tesla-bots-could-benefit-humanity/script.md
+++ b/scripts/20210917_how-tesla-bots-could-benefit-humanity/script.md
@@ -1,0 +1,8 @@
+# How Tesla Bots could benefit humanity
+
+> Draft script for video `KJVz2f4Fn_U`
+
+## Script
+
+[NARRATOR]: <!-- narrator lines here -->
+[VISUAL]: <!-- b-roll, graphics, or stage directions -->

--- a/scripts/20211001_why-tesla-s-full-self-driving-is-taking-so-long/metadata.json
+++ b/scripts/20211001_why-tesla-s-full-self-driving-is-taking-so-long/metadata.json
@@ -1,0 +1,9 @@
+{
+  "youtube_id": "RDEKyxDIuLQ",
+  "title": "Why Tesla's Full Self Driving is taking so long",
+  "publish_date": "2021-10-01",
+  "duration_seconds": 0,
+  "keywords": [],
+  "status": "draft",
+  "description": ""
+}

--- a/scripts/20211001_why-tesla-s-full-self-driving-is-taking-so-long/script.md
+++ b/scripts/20211001_why-tesla-s-full-self-driving-is-taking-so-long/script.md
@@ -1,0 +1,8 @@
+# Why Tesla's Full Self Driving is taking so long
+
+> Draft script for video `RDEKyxDIuLQ`
+
+## Script
+
+[NARRATOR]: <!-- narrator lines here -->
+[VISUAL]: <!-- b-roll, graphics, or stage directions -->

--- a/scripts/20211015_things-we-need-to-figure-out-before-sending-humans-to-mars-starship-microgravity-and-radiation/metadata.json
+++ b/scripts/20211015_things-we-need-to-figure-out-before-sending-humans-to-mars-starship-microgravity-and-radiation/metadata.json
@@ -1,0 +1,9 @@
+{
+  "youtube_id": "whafgZUxj0Q",
+  "title": "Things we need to figure out before sending humans to Mars - Starship, microgravity, and radiation",
+  "publish_date": "2021-10-15",
+  "duration_seconds": 0,
+  "keywords": [],
+  "status": "draft",
+  "description": ""
+}

--- a/scripts/20211015_things-we-need-to-figure-out-before-sending-humans-to-mars-starship-microgravity-and-radiation/script.md
+++ b/scripts/20211015_things-we-need-to-figure-out-before-sending-humans-to-mars-starship-microgravity-and-radiation/script.md
@@ -1,0 +1,8 @@
+# Things we need to figure out before sending humans to Mars - Starship, microgravity, and radiation
+
+> Draft script for video `whafgZUxj0Q`
+
+## Script
+
+[NARRATOR]: <!-- narrator lines here -->
+[VISUAL]: <!-- b-roll, graphics, or stage directions -->

--- a/scripts/20211102_we-re-probably-in-a-simulation-because-we-make-them-already/metadata.json
+++ b/scripts/20211102_we-re-probably-in-a-simulation-because-we-make-them-already/metadata.json
@@ -1,0 +1,9 @@
+{
+  "youtube_id": "TqshQq5A5mQ",
+  "title": "We're probably in a simulation because we make them already",
+  "publish_date": "2021-11-02",
+  "duration_seconds": 0,
+  "keywords": [],
+  "status": "draft",
+  "description": ""
+}

--- a/scripts/20211102_we-re-probably-in-a-simulation-because-we-make-them-already/script.md
+++ b/scripts/20211102_we-re-probably-in-a-simulation-because-we-make-them-already/script.md
@@ -1,0 +1,8 @@
+# We're probably in a simulation because we make them already
+
+> Draft script for video `TqshQq5A5mQ`
+
+## Script
+
+[NARRATOR]: <!-- narrator lines here -->
+[VISUAL]: <!-- b-roll, graphics, or stage directions -->

--- a/scripts/20211115_why-augmented-reality-and-the-metaverse-will-change-everything-eventually/metadata.json
+++ b/scripts/20211115_why-augmented-reality-and-the-metaverse-will-change-everything-eventually/metadata.json
@@ -1,0 +1,9 @@
+{
+  "youtube_id": "8ADRe3t-2qI",
+  "title": "Why augmented reality and the metaverse will change everything... eventually",
+  "publish_date": "2021-11-15",
+  "duration_seconds": 0,
+  "keywords": [],
+  "status": "draft",
+  "description": ""
+}

--- a/scripts/20211115_why-augmented-reality-and-the-metaverse-will-change-everything-eventually/script.md
+++ b/scripts/20211115_why-augmented-reality-and-the-metaverse-will-change-everything-eventually/script.md
@@ -1,0 +1,8 @@
+# Why augmented reality and the metaverse will change everything... eventually
+
+> Draft script for video `8ADRe3t-2qI`
+
+## Script
+
+[NARRATOR]: <!-- narrator lines here -->
+[VISUAL]: <!-- b-roll, graphics, or stage directions -->

--- a/scripts/20220111_6-of-the-biggest-ways-starship-will-transform-the-space-industry-forever/metadata.json
+++ b/scripts/20220111_6-of-the-biggest-ways-starship-will-transform-the-space-industry-forever/metadata.json
@@ -1,0 +1,9 @@
+{
+  "youtube_id": "en01vo9ErpY",
+  "title": "6 of the BIGGEST ways Starship will TRANSFORM the space industry forever",
+  "publish_date": "2022-01-11",
+  "duration_seconds": 0,
+  "keywords": [],
+  "status": "draft",
+  "description": ""
+}

--- a/scripts/20220111_6-of-the-biggest-ways-starship-will-transform-the-space-industry-forever/script.md
+++ b/scripts/20220111_6-of-the-biggest-ways-starship-will-transform-the-space-industry-forever/script.md
@@ -1,0 +1,8 @@
+# 6 of the BIGGEST ways Starship will TRANSFORM the space industry forever
+
+> Draft script for video `en01vo9ErpY`
+
+## Script
+
+[NARRATOR]: <!-- narrator lines here -->
+[VISUAL]: <!-- b-roll, graphics, or stage directions -->

--- a/scripts/scaffold_videos.py
+++ b/scripts/scaffold_videos.py
@@ -1,6 +1,9 @@
 import json
 import pathlib
 import sys
+import urllib.request
+import re
+import datetime
 
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 IDS_FILE = BASE_DIR / "video_ids.txt"
@@ -24,33 +27,60 @@ TEMPLATE_META = {
     "duration_seconds": 0,
     "keywords": [],
     "status": "draft",
-    "description": ""
+    "description": "",
 }
+
+
+def read_video_ids():
+    return [l.strip() for l in IDS_FILE.read_text().splitlines() if l.strip()]
+
+
+def slugify(text: str) -> str:
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-")
+
+
+def fetch_video_info(video_id: str):
+    url = f"https://r.jina.ai/https://www.youtube.com/watch?v={video_id}"
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    html = urllib.request.urlopen(req).read().decode("utf-8", "ignore")
+    title_match = re.search(r"^Title: (.+)", html, re.MULTILINE)
+    date_match = re.search(r"([A-Z][a-z]+ [0-9]{1,2}, [0-9]{4})", html)
+    if not (title_match and date_match):
+        raise RuntimeError(f"Unable to parse metadata for {video_id}")
+    title = title_match.group(1).strip()
+    date = datetime.datetime.strptime(date_match.group(1), "%b %d, %Y")
+    return title, date.strftime("%Y%m%d")
 
 
 def main():
     if not IDS_FILE.exists():
         sys.exit("video_ids.txt not found")
 
-    # Ensure root scripts directory exists (already does) but create subfolders for videos.
-    for vid in [l.strip() for l in IDS_FILE.read_text().splitlines() if l.strip()]:
-        vdir = VIDEO_SCRIPT_ROOT / vid
+    for vid in read_video_ids():
+        title, date_str = fetch_video_info(vid)
+        slug = slugify(title)
+        folder_name = f"{date_str}_{slug}"
+        vdir = VIDEO_SCRIPT_ROOT / folder_name
         vdir.mkdir(exist_ok=True)
 
-        # Metadata JSON
         meta_path = vdir / "metadata.json"
         if not meta_path.exists():
             data = TEMPLATE_META.copy()
             data["youtube_id"] = vid
+            data["title"] = title
+            data["publish_date"] = datetime.datetime.strptime(
+                date_str, "%Y%m%d"
+            ).strftime("%Y-%m-%d")
             meta_path.write_text(json.dumps(data, indent=2))
             print(f"Created {meta_path}")
 
-        # Script Markdown
         script_path = vdir / "script.md"
         if not script_path.exists():
-            script_path.write_text(TEMPLATE_MD.format(title="TODO", youtube_id=vid))
+            script_path.write_text(TEMPLATE_MD.format(title=title, youtube_id=vid))
             print(f"Created {script_path}")
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -16,14 +16,18 @@ def test_e2e_pipeline(monkeypatch):
         monkeypatch.setattr(scaffold, "BASE_DIR", base)
         monkeypatch.setattr(scaffold, "IDS_FILE", base / "video_ids.txt")
         monkeypatch.setattr(scaffold, "VIDEO_SCRIPT_ROOT", base)
+        monkeypatch.setattr(
+            scaffold, "fetch_video_info", lambda vid: ("Video", "20240202")
+        )
 
         # 1a. Scaffold
         scaffold.main()
-        vdir = base / vid
+        vdir = base / "20240202_video"
         assert vdir.exists(), "Video directory created"
         assert (vdir / "script.md").exists()
         meta_data = json.loads((vdir / "metadata.json").read_text())
         assert meta_data["youtube_id"] == vid
+        assert meta_data["publish_date"] == "2024-02-02"
 
         # 2. Fetch subtitles mocked
         calls = []
@@ -45,4 +49,4 @@ def test_e2e_pipeline(monkeypatch):
         # We expect two subprocess calls (primary + fallback)
         assert len(calls) == 2
         # verify fallback without --convert-subs
-        assert "--convert-subs" not in calls[1] 
+        assert "--convert-subs" not in calls[1]

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -10,10 +10,15 @@ def test_scaffold_creates_files(monkeypatch):
         monkeypatch.setattr(sv, "IDS_FILE", base / "video_ids.txt")
         monkeypatch.setattr(sv, "VIDEO_SCRIPT_ROOT", base)
 
+        monkeypatch.setattr(
+            sv, "fetch_video_info", lambda vid: ("Test Title", "20240102")
+        )
+
         sv.main()
 
-        vid_dir = base / "ABC"
+        vid_dir = base / "20240102_test-title"
         assert vid_dir.is_dir()
         assert (vid_dir / "script.md").exists()
         meta = json.loads((vid_dir / "metadata.json").read_text())
-        assert meta["youtube_id"] == "ABC" 
+        assert meta["youtube_id"] == "ABC"
+        assert meta["publish_date"] == "2024-01-02"


### PR DESCRIPTION
## Summary
- scaffold_videos now pulls title and publish date from YouTube pages
- create dated slug folders for each id in `video_ids.txt`
- adjust tests for new directory naming
- clarify scaffolding instructions in AGENTS guide

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847e1428d4c832faa26312363774ad9