### PR TITLE
Add hiatus montage cues and metadata reminder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ directions. Use `[NARRATOR]:` for spoken lines and `[VISUAL]:` for b-roll or
 graphics cues. Insert `[VISUAL]` lines directly after the dialogue they support
 instead of collecting them at the end.
 - Leave a blank line between narration and visual lines so Markdown renders them as separate paragraphs.
+- Each script folder must include a `metadata.json` file conforming to `schemas/video_metadata.schema.json`.
 
 ## Testing & CI
 
@@ -43,6 +44,7 @@ make setup   # venv + deps (or ./setup.ps1)
 make test
 ```
 If `make setup` fails on your platform, run `python3 -m venv .venv && .venv/bin/pip install -r requirements.txt` then `pytest -q`.
+If `yt-dlp` cannot be located during tests, prefix your command with `PATH=.venv/bin:$PATH` so the venv's executables are discoverable.
 
 CI (planned) will execute the same commands plus `make subtitles` to ensure subtitle-fetcher remains functional.
 

--- a/llms.txt
+++ b/llms.txt
@@ -12,6 +12,7 @@ Script format:
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.
+- Each script folder includes a `metadata.json` validated against `schemas/video_metadata.schema.json`.
 
 Run tests with:
 ```bash
@@ -19,6 +20,7 @@ make setup
 make test
 ```
 If that fails, run `python3 -m venv .venv && .venv/bin/pip install -r requirements.txt` then `pytest -q`.
+If `yt-dlp` isn't found during tests, prefix the command with `PATH=.venv/bin:$PATH`.
 
 Key directories:
 - `/scripts/` helper utilities and per-video folders (`YYYYMMDD_slug/`)

--- a/scripts/20250701_indoor-aquariums-tour/script.md
+++ b/scripts/20250701_indoor-aquariums-tour/script.md
@@ -2,7 +2,7 @@
 
 [NARRATOR]: Well, it's time for another video—I haven't uploaded in four years. A lot has happened since then.
 
-[VISUAL]: Supercut of recent world events timed to the line "A lot has happened since then."
+[VISUAL]: Supercut of news clips, trending memes, and an old shot of me promising "regular uploads soon" timed to the line "A lot has happened since then."
 
 
 [NARRATOR]: but I'm back! Hi, I'm Daniel and you're watching Futuroptimist.
@@ -22,7 +22,7 @@
 
 [VISUAL]: Quick shot of the mulm entry on Wikipedia.
 
-[VISUAL]: Close-ups of guppies, shrimp, and microfauna.
+[VISUAL]: Macro lens close-ups of guppies, shrimp, scuds, Daphnia, and moina.
 
 
 [NARRATOR]: Early on the water turned cloudy and even took on a strong green hue—likely a mix of algae and bacteria. After a lot of digging through forums, I learned that adding a deep sand bed could give anaerobic bacteria room to work, and it cleared up almost overnight.
@@ -67,6 +67,9 @@
 [NARRATOR]: Long term I'd love to automate water changes and feeding with peristaltic pumps and microcontrollers, maybe even run everything off solar. The grow lights already follow a custom schedule through smart plugs, and my indoor tanks use PLA 3D‑printed baskets for hydroponic plants—they'll slowly degrade but that's fine. I'm also starting to work on some outdoor aquarium setups with similar aquaponic techniques, and work is well underway!
 
 [VISUAL]: Photos of the aluminum extrusion frame for solar panels, the panels themselves, tubs of aquatic sand with plants, plus the charge controller and battery.
+
+[NARRATOR]: Quick takeaways before we wrap up.
+[VISUAL]: On-screen list: "Deep sand beds clear cloudy water", "Macro lens B-roll shows the microfauna", "Automation coming soon".
 
 
 [NARRATOR]: What do you think of my setup? I'm just an amateur trying random things, so let me know if you spot mistakes or things I could do less stupidly. This is the roughest version you'll see, of course. Stick around as I level things up and make this the most reliable and robust aquarium setup I can imagine, and don't forget to subscribe!


### PR DESCRIPTION
## Summary
- integrate hiatus callback, macro B-roll, and quick takeaways into 2025 aquarium script
- remind contributors every script folder needs metadata.json
- sync the same note in llms.txt

## Testing
- `PATH=.venv/bin:$PATH .venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490f9380cc832f90bfdb7ff2942e19