### PR TITLE
Update AGENTS with make test fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ make setup   # venv + deps (or ./setup.ps1)
 make test
 ```
 If `make setup` fails on your platform, run `python3 -m venv .venv && .venv/bin/pip install -r requirements.txt` then `pytest -q`.
+If `make test` errors about `.venv/Scripts/python`, use `PATH=.venv/bin:$PATH pytest -q` instead.
 If `yt-dlp` cannot be located during tests, prefix your command with `PATH=.venv/bin:$PATH` so the venv's executables are discoverable.
 
 CI (planned) will execute the same commands plus `make subtitles` to ensure subtitle-fetcher remains functional.

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,7 @@ make setup
 make test
 ```
 If that fails, run `python3 -m venv .venv && .venv/bin/pip install -r requirements.txt` then `pytest -q`.
+If `make test` complains about `.venv/Scripts/python`, run `PATH=.venv/bin:$PATH pytest -q`.
 If `yt-dlp` isn't found during tests, prefix the command with `PATH=.venv/bin:$PATH`.
 
 Key directories:


### PR DESCRIPTION
## Summary
- clarify how to run tests when `make` uses Windows paths
- sync `llms.txt` with the new guidance

## Testing
- `python3 -m venv .venv && .venv/bin/pip install -r requirements.txt`
- `PATH=.venv/bin:$PATH pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684914d0a034832fae38636e905e0b75