### PR TITLE
Keep README brief, move dev notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ When Phase 7 hits (see the roadmap in INSTRUCTIONS.md) an additional `make rende
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile; links to INSTRUCTIONS for full details.
+- [README](README.md): concise because it doubles as the GitHub profile; keep development details in INSTRUCTIONS instead.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
 - [RUNBOOK](RUNBOOK.md): production checklist.
 - [Ideas guide](ideas/README.md): idea-file schema.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -25,6 +25,25 @@ make test
 ```
 The script pulls **manual** subtitles when present, falling back to **auto-generated** captions as needed. Files are saved as `subtitles/<videoid>.srt`.
 
+## Development Workflow
+
+Use the Makefile for common tasks:
+
+```bash
+make setup      # create .venv and install deps
+make test       # run unit tests
+make subtitles  # download captions listed in video_ids.txt
+make clean      # remove the virtualenv and caches
+```
+
+Create new script folders from the IDs in `video_ids.txt`:
+
+```bash
+python scripts/scaffold_videos.py
+```
+
+This fetches titles and dates to generate `scripts/YYYYMMDD_slug` directories for drafting. Format code with `black .` and `ruff check --fix .` before committing.
+
 ## Next Steps
 * Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).
 * Convert `.srt` caption timing into fully-fledged markdown scripts.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,6 @@
 # Futuroptimist
 
-Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details and contribution guidelines, see [INSTRUCTIONS.md](INSTRUCTIONS.md).
-
-## Development
-
-Use the Makefile to set up a virtual environment and run the tests:
-
-```bash
-make setup  # install dependencies into .venv
-make test   # run unit tests
-make subtitles  # download YouTube captions listed in video_ids.txt
-make clean      # remove the virtual environment and caches
-```
-
-Create new script folders from the YouTube IDs listed in `video_ids.txt`:
-
-```bash
-python scripts/scaffold_videos.py
-```
-
-This fetches titles and dates and generates `scripts/YYYYMMDD_slug` directories for drafting.
-
-Formatting is enforced with `black` and `ruff` – run `black .` and `ruff check --fix .` before committing.
+Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
 
 ## Other Projects
 - **[token.place](https://token.place)** – p2p generative AI platform ([repo](https://github.com/futuroptimist/token.place))
@@ -30,4 +9,3 @@ Formatting is enforced with `black` and `ruff` – run `black .` and `ruff check
 - **gabriel** – guardian angel LLM ([repo](https://github.com/futuroptimist/gabriel))
 - **f2clipboard** – quickly copy multiple files from nested directories for LLM conversations ([repo](https://github.com/futuroptimist/f2clipboard))
 
-For repository structure and AI guidelines see [AGENTS.md](AGENTS.md). Brainstorm files live in the [ideas/](ideas) directory.

--- a/llms.txt
+++ b/llms.txt
@@ -36,7 +36,7 @@ Key directories:
 - `video_ids.txt` canonical YouTube ID list
 
 ## Core Docs
-- [README](README.md): high-level overview & roadmap
+- [README](README.md): intentionally brief because it appears on my GitHub profile; development notes live in INSTRUCTIONS.
 - [Agents guide](AGENTS.md): repository structure, coding conventions, test commands
 - [Runbook](RUNBOOK.md): production workflow checklist
 - [Contributors](CONTRIBUTORS.md): PR guidelines & Code of Conduct


### PR DESCRIPTION
## Summary
- prune README to a short overview
- move Makefile usage and formatting tips into INSTRUCTIONS
- clarify AGENTS and llms guidelines about keeping README small

## Testing
- `make setup`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6849234065a0832fbadcf2b601b08a62