### PR TITLE
Enforce manual-only subtitle fetch

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -23,7 +23,7 @@ python scripts/fetch_subtitles.py
 # 3. Run the full test suite (schema, naming, e2e)
 make test
 ```
-The script pulls **manual** subtitles when present, falling back to **auto-generated** captions as needed. Files are saved as `subtitles/<videoid>.srt`.
+The script fetches **manual** subtitles only. Videos without manual captions are skipped. Files are saved as `subtitles/<videoid>.srt`.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
 
+English subtitles are pulled directly from each upload using [scripts/fetch_subtitles.py](scripts/fetch_subtitles.py). Only **manual** captions are downloaded so transcripts stay accurate.
+
 ## Other Projects
 - **[token.place](https://token.place)** – p2p generative AI platform ([repo](https://github.com/futuroptimist/token.place))
 - **[DSPACE](https://democratized.space)** – open-source space exploration idle game ([repo](https://github.com/democratizedspace/dspace))

--- a/scripts/fetch_subtitles.py
+++ b/scripts/fetch_subtitles.py
@@ -26,7 +26,7 @@ def read_video_ids():
 
 def download_subtitles(video_id: str):
     url = f"https://www.youtube.com/watch?v={video_id}"
-    # --skip-download avoids video download; --write-auto-sub tries auto subs; --write-sub gets manual subs.
+    # --skip-download avoids video download; --write-sub fetches manual captions only.
     cmd = [
         "yt-dlp",
         "--skip-download",

--- a/tests/test_fetch_subtitles.py
+++ b/tests/test_fetch_subtitles.py
@@ -30,3 +30,4 @@ def test_download_subtitles_constructs_command(monkeypatch):
     assert "https://www.youtube.com/watch?v=XYZ123" in cmd
     assert "--skip-download" in cmd
     assert "--write-sub" in cmd
+    assert "--write-auto-sub" not in cmd


### PR DESCRIPTION
## Summary
- clarify that only manual subtitles are fetched
- document manual-only subtitle download in INSTRUCTIONS and README
- update fetch_subtitles comment to mention manual captions only
- test that auto subtitles are never requested

## Testing
- `black .`
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849277f70c4832fb155441b23f43c84