### PR TITLE
Remove subtitle details from README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ When Phase 7 hits (see the roadmap in INSTRUCTIONS.md) an additional `make rende
 
 ### Documentation
 - [README](README.md): concise because it doubles as the GitHub profile; keep development details in INSTRUCTIONS instead.
+- Avoid detailed how-tos like subtitle downloading; store them in other docs.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
 - [RUNBOOK](RUNBOOK.md): production checklist.
 - [Ideas guide](ideas/README.md): idea-file schema.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
 
-English subtitles are pulled directly from each upload using [scripts/fetch_subtitles.py](scripts/fetch_subtitles.py). Only **manual** captions are downloaded so transcripts stay accurate.
-Captions can be converted into script format with [`scripts/srt_to_markdown.py`](scripts/srt_to_markdown.py), which also converts `<i>` tags into Markdown italics and keeps emoji/unicode intact. The result is a rough first draft—run it through an LLM with the prompts in `llms.txt` for smoother narration.
-
-Test coverage is exercised automatically via GitHub Actions.
-
 ## Other Projects
 - **[token.place](https://token.place)** – p2p generative AI platform ([repo](https://github.com/futuroptimist/token.place))
 - **[DSPACE](https://democratized.space)** – open-source space exploration idle game ([repo](https://github.com/democratizedspace/dspace))

--- a/llms.txt
+++ b/llms.txt
@@ -42,6 +42,7 @@ Key directories:
 
 ## Core Docs
 - [README](README.md): intentionally brief because it appears on my GitHub profile; development notes live in INSTRUCTIONS.
+- Skip detailed steps like subtitle fetching; keep README short.
 - [Agents guide](AGENTS.md): repository structure, coding conventions, test commands
 - [Runbook](RUNBOOK.md): production workflow checklist
 - [Contributors](CONTRIBUTORS.md): PR guidelines & Code of Conduct

--- a/tests/test_fetch_subtitles.py
+++ b/tests/test_fetch_subtitles.py
@@ -30,6 +30,7 @@ def test_download_subtitles_constructs_command(monkeypatch):
     assert "--write-sub" in cmd
     assert "--write-auto-sub" not in cmd
 
+
 def test_ensure_requirements_missing(monkeypatch):
     monkeypatch.setattr(fs.shutil, "which", lambda _: None)
     with pytest.raises(SystemExit):
@@ -72,11 +73,6 @@ def test_main_handles_failure(monkeypatch, tmp_path):
 
     monkeypatch.setattr(fs, "download_subtitles", fail_download)
     fs.main()
-
-
-def test_entrypoint(monkeypatch, tmp_path):
-    monkeypatch.setattr(shutil, "which", lambda _: "yt-dlp")
-    monkeypatch.setattr(fs, "IDS_FILE", tmp_path / "ids.txt")
 
 
 def test_entrypoint(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- trim README to keep it concise
- clarify in AGENTS and llms that README should avoid step-by-step instructions
- fix duplicate test definition flagged by ruff

## Testing
- `black tests/test_fetch_subtitles.py`
- `ruff check --fix tests/test_fetch_subtitles.py`
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492cf89a40832fa5b799ae50949eba