### PR TITLE
Enhance transcript sync with YouTube API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,10 @@ instead of collecting them at the end.
 - Break long transcript sentences at punctuation boundaries so each `[NARRATOR]` line contains a single, complete thought.
 - Start each script with a level-one heading containing the video title,
   followed by a blockquote referencing the YouTube ID and a `## Script` section header.
-- Each script folder must include a `metadata.json` file conforming to `schemas/video_metadata.schema.json`.
+- Each script folder must include a `metadata.json` file conforming to `schemas/video_metadata.schema.json`. Optional fields like `slug`, `thumbnail`, `transcript_file`, and `summary` enrich automation but aren't required.
 - Each script folder may include a `sources.txt` file with one URL per line. Any downloaded articles or clips are for reference only—check usage rights and cite sources in **APA style** rather than redistributing content.
 - Each script folder may also contain a `footage.md` checklist to track B-roll or CGI shots to gather. Note existing archive vs new footage, and flag generative AI segments so they don't look like "AI slop".
+- Run `python scripts/update_transcript_links.py` to sync `transcript_file` paths; with `YOUTUBE_API_KEY` set it also fetches missing captions via YouTube Data API.
 
 ## Testing & CI
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Futuroptimist
 
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
+`metadata.json` files under each video folder now support optional fields like `slug`, `thumbnail`, `transcript_file`, and `summary` for richer automation.
 
 English subtitles are pulled directly from each upload using [scripts/fetch_subtitles.py](scripts/fetch_subtitles.py). Only **manual** captions are downloaded so transcripts stay accurate.
+`scripts/update_transcript_links.py` can then populate the optional `transcript_file` field. If a `YOUTUBE_API_KEY` environment variable is set, it fetches missing transcripts via the YouTube Data API.
 
 Test coverage is exercised automatically via GitHub Actions.
 

--- a/schemas/video_metadata.schema.json
+++ b/schemas/video_metadata.schema.json
@@ -16,6 +16,10 @@
       "type": "string",
       "enum": ["draft", "live", "private"]
     },
-    "description": {"type": "string"}
+    "description": {"type": "string"},
+    "slug": {"type": "string"},
+    "thumbnail": {"type": "string"},
+    "transcript_file": {"type": "string"},
+    "summary": {"type": "string"}
   }
 }

--- a/scripts/20250701_indoor-aquariums-tour/metadata.json
+++ b/scripts/20250701_indoor-aquariums-tour/metadata.json
@@ -3,7 +3,18 @@
   "title": "Indoor Aquarium Tour",
   "publish_date": "2025-07-01",
   "duration_seconds": 240,
-  "keywords": ["aquarium", "guppies", "walstad", "betta", "microfauna", "aquaponics"],
+  "keywords": [
+    "aquarium",
+    "guppies",
+    "walstad",
+    "betta",
+    "microfauna",
+    "aquaponics"
+  ],
   "status": "draft",
-  "description": "After four years away, Daniel tours four indoor aquariums: a Walstad guppy tank, a fry-filled 10 gallon, a cycling betta setup on a flimsy shelf, and a tiny shrimp tank. He shares maintenance tricks, microfauna struggles, and hints at automation and outdoor projects."
+  "description": "After four years away, Daniel tours four indoor aquariums: a Walstad guppy tank, a fry-filled 10 gallon, a cycling betta setup on a flimsy shelf, and a tiny shrimp tank. He shares maintenance tricks, microfauna struggles, and hints at automation and outdoor projects.",
+  "slug": "indoor-aquariums-tour",
+  "thumbnail": "thumbnails/20250701.jpg",
+  "transcript_file": "",
+  "summary": "Daniel showcases four indoor tanks and lessons learned."
 }

--- a/scripts/scaffold_videos.py
+++ b/scripts/scaffold_videos.py
@@ -28,6 +28,10 @@ TEMPLATE_META = {
     "keywords": [],
     "status": "draft",
     "description": "",
+    "slug": "",
+    "thumbnail": "",
+    "transcript_file": "",
+    "summary": "",
 }
 
 
@@ -73,6 +77,8 @@ def main():
             data["publish_date"] = datetime.datetime.strptime(
                 date_str, "%Y%m%d"
             ).strftime("%Y-%m-%d")
+            data["slug"] = slug
+            data["transcript_file"] = f"subtitles/{vid}.srt"
             meta_path.write_text(json.dumps(data, indent=2))
             print(f"Created {meta_path}")
 

--- a/scripts/update_transcript_links.py
+++ b/scripts/update_transcript_links.py
@@ -1,0 +1,60 @@
+import json
+import os
+import pathlib
+import urllib.request
+
+BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT_ROOT = BASE_DIR / "scripts"
+SUBS_DIR = BASE_DIR / "subtitles"
+API_KEY = os.environ.get("YOUTUBE_API_KEY", "")
+
+LIST_URL = "https://www.googleapis.com/youtube/v3/captions?part=snippet&videoId={vid}&key={key}"
+DOWNLOAD_URL = "https://www.googleapis.com/youtube/v3/captions/{cid}?tfmt=srt&key={key}"
+
+
+def fetch_transcript(video_id: str) -> pathlib.Path | None:
+    if not API_KEY:
+        return None
+    try:
+        with urllib.request.urlopen(LIST_URL.format(vid=video_id, key=API_KEY)) as resp:
+            listing = json.loads(resp.read().decode())
+        cid = None
+        for item in listing.get("items", []):
+            lang = item.get("snippet", {}).get("language", "")
+            if lang.startswith("en") and not item.get("snippet", {}).get("isDraft"):
+                cid = item.get("id")
+                break
+        if not cid:
+            return None
+        with urllib.request.urlopen(DOWNLOAD_URL.format(cid=cid, key=API_KEY)) as resp:
+            data = resp.read().decode()
+        SUBS_DIR.mkdir(exist_ok=True)
+        dest = SUBS_DIR / f"{video_id}.srt"
+        dest.write_text(data)
+        return dest
+    except Exception as exc:  # pragma: no cover - network failure
+        print(f"failed to fetch transcript for {video_id}: {exc}")
+        return None
+
+
+def main() -> None:
+    for meta_path in SCRIPT_ROOT.glob("*/metadata.json"):
+        data = json.loads(meta_path.read_text())
+        vid = data.get("youtube_id")
+        if not vid:
+            continue
+        subtitle_path = SUBS_DIR / f"{vid}.srt"
+        if not subtitle_path.exists():
+            fetched = fetch_transcript(vid)
+            if fetched:
+                subtitle_path = fetched
+        if subtitle_path.exists():
+            relative = subtitle_path.relative_to(BASE_DIR).as_posix()
+            if data.get("transcript_file") != relative:
+                data["transcript_file"] = relative
+                meta_path.write_text(json.dumps(data, indent=2) + "\n")
+                print(f"updated {meta_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -31,6 +31,8 @@ def test_e2e_pipeline(monkeypatch):
         meta_data = json.loads((vdir / "metadata.json").read_text())
         assert meta_data["youtube_id"] == vid
         assert meta_data["publish_date"] == "2024-02-02"
+        assert meta_data["slug"] == "video"
+        assert meta_data["transcript_file"] == "subtitles/XYZ123.srt"
 
         # 2. Fetch subtitles mocked
         calls = []

--- a/tests/test_fetch_subtitles.py
+++ b/tests/test_fetch_subtitles.py
@@ -30,6 +30,7 @@ def test_download_subtitles_constructs_command(monkeypatch):
     assert "--write-sub" in cmd
     assert "--write-auto-sub" not in cmd
 
+
 def test_ensure_requirements_missing(monkeypatch):
     monkeypatch.setattr(fs.shutil, "which", lambda _: None)
     with pytest.raises(SystemExit):
@@ -72,11 +73,6 @@ def test_main_handles_failure(monkeypatch, tmp_path):
 
     monkeypatch.setattr(fs, "download_subtitles", fail_download)
     fs.main()
-
-
-def test_entrypoint(monkeypatch, tmp_path):
-    monkeypatch.setattr(shutil, "which", lambda _: "yt-dlp")
-    monkeypatch.setattr(fs, "IDS_FILE", tmp_path / "ids.txt")
 
 
 def test_entrypoint(monkeypatch, tmp_path):

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -25,6 +25,8 @@ def test_scaffold_creates_files(monkeypatch):
         meta = json.loads((vid_dir / "metadata.json").read_text())
         assert meta["youtube_id"] == "ABC"
         assert meta["publish_date"] == "2024-01-02"
+        assert meta["slug"] == "test-title"
+        assert meta["transcript_file"] == "subtitles/ABC.srt"
 
 
 def test_slugify():

--- a/tests/test_update_transcript_links.py
+++ b/tests/test_update_transcript_links.py
@@ -1,0 +1,67 @@
+import json
+import scripts.update_transcript_links as utl
+
+
+def test_update_transcript_links(tmp_path, monkeypatch):
+    base = tmp_path
+    subs = base / "subtitles"
+    subs.mkdir()
+    scripts_dir = base / "scripts"
+    scripts_dir.mkdir()
+    meta = scripts_dir / "20240101_test" / "metadata.json"
+    meta.parent.mkdir()
+    meta.write_text(json.dumps({"youtube_id": "ABC", "title": "t"}))
+    (subs / "ABC.srt").write_text("hi")
+
+    monkeypatch.setattr(utl, "BASE_DIR", base)
+    monkeypatch.setattr(utl, "SCRIPT_ROOT", scripts_dir)
+    monkeypatch.setattr(utl, "SUBS_DIR", subs)
+
+    utl.main()
+
+    data = json.loads(meta.read_text())
+    assert data["transcript_file"] == "subtitles/ABC.srt"
+
+
+def test_fetch_from_api_when_missing(tmp_path, monkeypatch):
+    base = tmp_path
+    scripts_dir = base / "scripts"
+    scripts_dir.mkdir()
+    meta = scripts_dir / "20240101_test" / "metadata.json"
+    meta.parent.mkdir()
+    meta.write_text(json.dumps({"youtube_id": "ABC", "title": "t"}))
+
+    monkeypatch.setattr(utl, "BASE_DIR", base)
+    monkeypatch.setattr(utl, "SCRIPT_ROOT", scripts_dir)
+    monkeypatch.setattr(utl, "SUBS_DIR", base / "subtitles")
+    monkeypatch.setattr(utl, "API_KEY", "X")
+
+    class Resp:
+        def __init__(self, data):
+            self.data = data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def read(self):
+            return self.data
+
+    def fake_urlopen(url):
+        if "captions?" in url:
+            listing = {"items": [{"id": "1", "snippet": {"language": "en"}}]}
+            return Resp(json.dumps(listing).encode())
+        elif "captions/1" in url:
+            return Resp(b"foo")
+        raise AssertionError(url)
+
+    monkeypatch.setattr(utl.urllib.request, "urlopen", fake_urlopen)
+
+    utl.main()
+
+    out = base / "subtitles" / "ABC.srt"
+    assert out.exists()
+    data = json.loads(meta.read_text())
+    assert data["transcript_file"] == "subtitles/ABC.srt"


### PR DESCRIPTION
## Summary
- expand `update_transcript_links.py` to fetch missing transcripts via YouTube Data API
- document new environment variable usage in AGENTS and README
- refine metadata example
- test transcript download fallback

## Testing
- `make setup`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6849296c0b0c832f9801a5ba0a7b8b98