### PR TITLE
Add fmt helper and doc updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Keep `llms.txt` synchronized with changes to this guide so LLMs stay current.
 ## Coding Conventions
 
 * Python 3.11+, black formatting & ruff lint (pre-commit soon).
-* Run `black .` and `ruff check --fix .` before committing to keep style consistent. Both tools are listed in `requirements.txt`.
+* Run `black .` and `ruff check --fix .` (or simply `make fmt`) before committing to keep style consistent. Both tools are listed in `requirements.txt`.
 * One logical change per PR; always include/extend tests.
 * Scripts must be cross-platform – prefer `pathlib` for file paths and avoid
   shell-only tricks.

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,14 @@ else
 endif
 PIP := $(PY) -m pip
 
-.PHONY: help setup test subtitles clean
+.PHONY: help setup test subtitles clean fmt
 
 help:
 	@echo "Targets:"
 	@echo "  setup       Create venv & install deps"
 	@echo "  test        Run pytest inside venv"
 	@echo "  subtitles   Download captions for all video IDs"
+	@echo "  fmt         Format code with black & ruff"
 	@echo "  clean       Remove venv & __pycache__"
 
 setup:
@@ -31,6 +32,10 @@ test:
 
 subtitles:
 	$(PY) scripts/fetch_subtitles.py
+
+fmt:
+	$(PY) -m black .
+	$(PY) -m ruff check --fix .
 
 clean:
 	@$(REMOVE) $(VENV) 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
 
+```bash
+make setup  # create .venv and install deps
+make test   # run the unit tests
+# optional formatting helper
+make fmt
+```
+
 ## Other Projects
 - **[token.place](https://token.place)** – p2p generative AI platform ([repo](https://github.com/futuroptimist/token.place))
 - **[DSPACE](https://democratized.space)** – open-source space exploration idle game ([repo](https://github.com/democratizedspace/dspace))

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 Every commit is public training data—write informative commit messages.
 
 Coding conventions:
-- Python 3.11+, formatted with `black` and `ruff` (`ruff check --fix .`).
+- Python 3.11+, formatted with `black` and `ruff` (`ruff check --fix .` or `make fmt`).
 - Use `pathlib` for cross-platform paths; keep dependencies minimal.
 
 Script format:


### PR DESCRIPTION
## Summary
- add `fmt` target to Makefile for easy code formatting
- reference new command in AGENTS.md and llms.txt
- show quick start snippet with `make` commands in README

## Testing
- `make test`
- `ruff check .`
- `black scripts tests`

------
https://chatgpt.com/codex/tasks/task_e_6849319c7aac832f97b49d59b70fadd6