### PR TITLE
Update docs to keep README minimal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,9 @@
 Every commit here doubles as both version control and long-term training data. Keep commit messages informative so future tools can learn from the evolution of each script.
 Keep `llms.txt` synchronized with changes to this guide so LLMs stay current.
 
+The main `README.md` is intentionally minimal to maintain a clean GitHub profile.
+Avoid adding setup or asset instructions there; link to INSTRUCTIONS instead.
+
 ## Project Top-Level Layout
 
 | Path | Purpose |
@@ -96,7 +99,7 @@ When Phase 7 hits (see the roadmap in INSTRUCTIONS.md) an additional `make rende
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile; keep development details in INSTRUCTIONS instead.
+- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in INSTRUCTIONS or RUNBOOK.
 - Avoid detailed how-tos like subtitle downloading; store them in other docs.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
 - [RUNBOOK](RUNBOOK.md): production checklist.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -34,6 +34,7 @@ make setup      # create .venv and install deps
 make test       # run unit tests
 make subtitles  # download captions listed in video_ids.txt
 make clean      # remove the virtualenv and caches
+make fmt       # format code with black & ruff
 ```
 
 Create new script folders from the IDs in `video_ids.txt`:

--- a/README.md
+++ b/README.md
@@ -2,19 +2,6 @@
 
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
 
-```bash
-make setup  # create .venv and install deps
-make test   # run the unit tests
-# optional formatting helper
-make fmt
-```
-
-## Local Footage
-
-Large photos and videos for editing should live in a `footage/` folder
-(ignored by git). Run `python scripts/index_local_media.py` to generate
-`footage_index.json` for quick reference when editing.
-
 ## Other Projects
 - **[token.place](https://token.place)** – p2p generative AI platform ([repo](https://github.com/futuroptimist/token.place))
 - **[DSPACE](https://democratized.space)** – open-source space exploration idle game ([repo](https://github.com/democratizedspace/dspace))


### PR DESCRIPTION
## Summary
- trim README by removing setup and footage notes
- clarify in AGENTS that README must stay minimal and exclude setup details

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a0db86ce0832f8e665d585acec1e6