### PR TITLE
Improve scaffolding robustness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,10 @@ If `yt-dlp` cannot be located during tests, prefix your command with `PATH=.venv
 CI runs `pytest --cov=./scripts --cov=./tests` on every push and pull request targeting `main`. In a future phase it may also run `make subtitles` to verify caption downloads.
 Aim to keep coverage at **100%** so the Codecov badge stays green.
 
+When adding CLI entrypoint tests, stub out any network requests (e.g. patch
+`urllib.request.urlopen`) so tests remain deterministic even if external sites
+are unreachable.
+
 ## Vision & Workflow
 
 The long-term goal is to make video creation as repeatable as writing code. Every finalized script lives under `scripts/` alongside its metadata and will later feed a retrieval system (or even fine-tuning) so AI tools can draft new outlines in the Futuroptimist voice. Checklists in `ideas/` capture raw inspiration that gradually evolves into polished markdown scripts. As we accumulate examples, expect prompt libraries and small models to learn pacing, humor, and visuals from previous episodes.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -44,6 +44,8 @@ python scripts/scaffold_videos.py
 ```
 
 This fetches titles and dates to generate `scripts/YYYYMMDD_slug` directories for drafting. Format code with `black .` and `ruff check --fix .` before committing.
+If metadata can't be fetched (network issues or parsing errors) the script
+logs the failure and continues so scaffolding never blocks your workflow.
 
 Large media assets should live in a local `footage/` directory. Use `python scripts/index_local_media.py` to build `footage_index.json` so you can quickly locate clips while editing.
 

--- a/scripts/scaffold_videos.py
+++ b/scripts/scaffold_videos.py
@@ -63,7 +63,11 @@ def main():
         sys.exit("video_ids.txt not found")
 
     for vid in read_video_ids():
-        title, date_str = fetch_video_info(vid)
+        try:
+            title, date_str = fetch_video_info(vid)
+        except Exception as e:  # network or parse failure
+            print(f"Failed to fetch info for {vid}: {e}")
+            continue
         slug = slugify(title)
         folder_name = f"{date_str}_{slug}"
         vdir = VIDEO_SCRIPT_ROOT / folder_name


### PR DESCRIPTION
## Summary
- skip videos that fail metadata fetch in `scaffold_videos.py`
- test that main continues on metadata errors
- avoid network calls in entrypoint test
- document network stubbing advice in `AGENTS.md`
- mention graceful failure in `INSTRUCTIONS`

## Testing
- `pytest --cov=./scripts --cov=./tests`

------
https://chatgpt.com/codex/tasks/task_e_6853bc45f9ec832f91a08ea09c8c5b37