### PR TITLE
Fix heatmap pipeline

### DIFF
--- a/.github/workflows/contrib-heatmap.yml
+++ b/.github/workflows/contrib-heatmap.yml
@@ -19,10 +19,11 @@ jobs:
           pip install -r requirements.txt
       - name: Generate heat-map
         env:
-          GH_TOKEN: ${{ secrets.PAT_READ_ORG }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/generate_contrib_heatmap.py
       - name: Commit and push
         uses: EndBug/add-and-commit@v9
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           add: 'assets/pr_heatmap.svg'
           message: 'docs: update PR contribution heat-map [skip ci]'

--- a/README.md
+++ b/README.md
@@ -25,5 +25,6 @@ Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTub
 ## Contributions (PRs I authored in my own repos)
 
 <p align="center">
+  <!-- generated nightly via GitHub Actions -->
   <img src="assets/pr_heatmap.svg" alt="Annual PR heat-map" />
 </p>


### PR DESCRIPTION
## Summary
- wire up the PR-contribution heatmap to use `GITHUB_TOKEN`
- clarify in README that the heatmap is generated nightly
- remove stale generated SVG

## Testing
- `make setup`
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68646ffdc938832fb4b176dc1009edac