### PR TITLE
Handle GitHub API errors in heatmap script

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -37,6 +37,10 @@ make clean      # remove the virtualenv and caches
 make fmt       # format code with black & ruff
 ```
 
+Some helper scripts require a GitHub token to access the GraphQL API. Export
+`GH_TOKEN` with a personal access token that has `repo` scope when generating
+heatmaps or fetching commit stats.
+
 Create new script folders from the IDs in `video_ids.txt`:
 
 ```bash

--- a/scripts/gh_graphql.py
+++ b/scripts/gh_graphql.py
@@ -50,6 +50,10 @@ def fetch_contributions(login: str, start: str, end: str) -> List[Dict[str, Any]
         )
         resp.raise_for_status()
         data = resp.json()
+        if "errors" in data:
+            raise RuntimeError(f"GitHub GraphQL errors: {data['errors']}")
+        if "data" not in data or not data["data"].get("user"):
+            raise RuntimeError(f"Unexpected GraphQL response: {data}")
         coll = data["data"]["user"]["contributionsCollection"][
             "commitContributionsByRepository"
         ]

--- a/tests/test_generate_heatmap_svg.py
+++ b/tests/test_generate_heatmap_svg.py
@@ -1,3 +1,4 @@
+import pytest
 from scripts import gh_graphql, generate_heatmap
 
 
@@ -63,6 +64,16 @@ def test_fetch_contributions(monkeypatch):
     out = gh_graphql.fetch_contributions("me", "2024-01-01", "2024-12-31")
     assert out[0]["sha"] == "a"
     assert calls == [None, "C1"]
+
+
+def test_fetch_contributions_errors(monkeypatch):
+    def fake_post(url, json, headers, timeout):
+        return Resp({"message": "Bad credentials"})
+
+    monkeypatch.setenv("GH_TOKEN", "x")
+    monkeypatch.setattr(gh_graphql.requests, "post", fake_post)
+    with pytest.raises(RuntimeError):
+        gh_graphql.fetch_contributions("me", "2024-01-01", "2024-12-31")
 
 
 def test_generate_heatmap_writes_files(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add error checks in `gh_graphql.fetch_contributions`
- test the new error handling
- document the need for `GH_TOKEN` when generating heatmaps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647d8e2af4832f9a6e66a7678df194