### PR TITLE
Fix heatmap token reference

### DIFF
--- a/.github/workflows/contrib-heatmap.yml
+++ b/.github/workflows/contrib-heatmap.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -r requirements.txt
       - name: Generate heat-map
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: python scripts/generate_heatmap.py
       - name: Commit and push
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
## Summary
- map `GH_TOKEN` to the PAT secret in the heatmap workflow

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864c61fbb40832facc7534df3a24216