### PR TITLE
Remove pragma and ensure failure path covered

### DIFF
--- a/scripts/update_transcript_links.py
+++ b/scripts/update_transcript_links.py
@@ -32,7 +32,7 @@ def fetch_transcript(video_id: str) -> pathlib.Path | None:
         dest = SUBS_DIR / f"{video_id}.srt"
         dest.write_text(data)
         return dest
-    except Exception as exc:  # pragma: no cover - network failure
+    except Exception as exc:
         print(f"failed to fetch transcript for {video_id}: {exc}")
         return None
 

--- a/tests/test_update_transcript_links.py
+++ b/tests/test_update_transcript_links.py
@@ -117,3 +117,16 @@ def test_entrypoint(monkeypatch, tmp_path):
     (tmp_path / "scripts").mkdir()
 
     runpy.run_module("scripts.update_transcript_links", run_name="__main__")
+
+
+def test_fetch_transcript_failure(monkeypatch, capsys):
+    monkeypatch.setattr(utl, "API_KEY", "X")
+
+    def boom(url):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(utl.urllib.request, "urlopen", boom)
+
+    assert utl.fetch_transcript("XYZ") is None
+    captured = capsys.readouterr()
+    assert "failed to fetch transcript" in captured.out


### PR DESCRIPTION
## Summary
- remove `pragma: no cover` comment from `update_transcript_links.py`
- cover failure branch in new unit test

## Testing
- `make test`
- `pytest --cov=./scripts --cov=./tests`

------
https://chatgpt.com/codex/tasks/task_e_6868cd34b120832fb1f05748b4892abe