### PR TITLE
Add yearly PR data export

### DIFF
--- a/.github/workflows/yearly-contribs.yml
+++ b/.github/workflows/yearly-contribs.yml
@@ -1,0 +1,31 @@
+name: Update yearly PR counts
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  contribs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install deps
+        run: |
+          uv pip install --system -r requirements.txt
+      - name: Generate yearly chart
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: python scripts/generate_annual_contributions.py
+      - name: Commit and push
+        uses: EndBug/add-and-commit@v9
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          add: 'assets/annual_contribs.svg assets/annual_contribs.csv'
+          message: 'docs: auto-update yearly PR chart [skip ci]'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Avoid adding setup or asset instructions there; link to INSTRUCTIONS instead.
 | `/subtitles/` | Downloaded `.srt` caption files populated by `fetch_subtitles.py`. |
 | `/scripts/srt_to_markdown.py` | Convert `.srt` captions into Futuroptimist script format (handles italics and emoji) |
 | `/scripts/generate_contrib_heatmap.py` | Build an SVG calendar heatmap of PRs authored in Futuroptimist-owned repos |
+| `/scripts/generate_annual_contributions.py` | Bar chart and CSV of yearly PR counts across Futuroptimist-owned repos |
 | `/scripts/generate_heatmap.py` | Create a 3‑D lines-of-code heatmap with light/dark SVGs |
 | `/sources/` | Reference files fetched via `collect_sources.py`. |
 | `video_ids.txt` | Canonical list of YouTube IDs referenced by helper scripts. |

--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTub
   <!-- generated nightly via GitHub Actions -->
   <img src="assets/pr_heatmap.svg" alt="Pull-request activity across Futuroptimist repos" />
 </p>
+<p align="center">
+  <!-- yearly counts updated nightly -->
+  <img src="assets/annual_contribs.svg" alt="Yearly pull-request totals" />
+</p>

--- a/llms.txt
+++ b/llms.txt
@@ -49,6 +49,7 @@ Key directories:
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap
 - Tests live in `tests/` and cover schema validation and helper scripts
 - A GitHub Actions workflow runs the test suite with coverage on each push.
+- Nightly workflows update `assets/pr_heatmap.svg`, `assets/annual_contribs.svg` and `assets/annual_contribs.csv` using helper scripts.
 
 ## Data & Schemas
 - [Video metadata schema](schemas/video_metadata.schema.json)

--- a/scripts/generate_annual_contributions.py
+++ b/scripts/generate_annual_contributions.py
@@ -1,0 +1,62 @@
+"""Generate yearly contribution stats and chart."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+import sys
+
+import csv
+
+import matplotlib.pyplot as plt
+
+try:  # allow package or standalone execution
+    from .generate_contrib_heatmap import fetch_pr_dates
+except ImportError:  # pragma: no cover - direct script execution
+    sys.path.append(str(Path(__file__).resolve().parent))
+    from generate_contrib_heatmap import fetch_pr_dates  # type: ignore
+
+SVG_OUTPUT = Path("assets/annual_contribs.svg")
+CSV_OUTPUT = Path("assets/annual_contribs.csv")
+
+
+def fetch_counts(start_year: int = 2021, end_year: int | None = None) -> dict[int, int]:
+    """Return yearly PR counts from ``start_year`` to ``end_year`` inclusive."""
+    end_year = end_year or dt.date.today().year
+    counts: dict[int, int] = {}
+    for year in range(start_year, end_year + 1):
+        counts[year] = len(fetch_pr_dates(year))
+    return counts
+
+
+def generate_chart(counts: dict[int, int], output: Path = SVG_OUTPUT) -> None:
+    """Write an SVG bar chart to ``output`` summarizing ``counts``."""
+    years = sorted(counts)
+    values = [counts[y] for y in years]
+    plt.figure(figsize=(4, 2))
+    plt.bar(years, values, color="#4c9aff")
+    plt.xticks(years)
+    plt.ylabel("PRs")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    plt.tight_layout()
+    plt.savefig(output, transparent=True)
+
+
+def write_csv(counts: dict[int, int], output: Path = CSV_OUTPUT) -> None:
+    """Save ``counts`` as ``year,value`` CSV to ``output``."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["year", "count"])
+        for year in sorted(counts):
+            writer.writerow([year, counts[year]])
+
+
+def main() -> None:
+    counts = fetch_counts()
+    generate_chart(counts)
+    write_csv(counts)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/tests/test_generate_annual_contributions.py
+++ b/tests/test_generate_annual_contributions.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+import scripts.generate_annual_contributions as mod
+
+
+def test_fetch_counts(monkeypatch):
+    called = []
+
+    def fake_fetch(year):
+        called.append(year)
+        return ["d"] * year
+
+    monkeypatch.setattr(mod, "fetch_pr_dates", fake_fetch)
+    out = mod.fetch_counts(2021, 2023)
+    assert out == {2021: 2021, 2022: 2022, 2023: 2023}
+    assert called == [2021, 2022, 2023]
+
+
+def test_generate_chart(tmp_path, monkeypatch):
+    recorded = {}
+
+    class FakePlt:
+        def figure(self, figsize=None):
+            recorded["figsize"] = figsize
+            return None
+
+        def bar(self, years, values, color=None):
+            recorded["years"] = list(years)
+            recorded["values"] = list(values)
+
+        def xticks(self, years):
+            recorded["xticks"] = list(years)
+
+        def ylabel(self, label):
+            recorded["ylabel"] = label
+
+        def tight_layout(self):
+            recorded["tight"] = True
+
+        def savefig(self, path, transparent=None):
+            Path(path).write_text("svg")
+            recorded["saved"] = Path(path)
+
+    monkeypatch.setattr(mod, "plt", FakePlt())
+    out = tmp_path / "c.svg"
+    mod.generate_chart({2024: 2}, out)
+    assert out.read_text() == "svg"
+    assert recorded["years"] == [2024]
+    assert recorded["values"] == [2]
+    assert recorded["saved"] == out
+
+
+def test_main(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod, "fetch_counts", lambda: {2024: 1})
+
+    def fake_generate(counts, output=mod.SVG_OUTPUT):
+        output.parent.mkdir(parents=True, exist_ok=True)
+        Path(output).write_text("svg")
+
+    def fake_csv(counts, output=mod.CSV_OUTPUT):
+        output.parent.mkdir(parents=True, exist_ok=True)
+        Path(output).write_text("csv")
+
+    monkeypatch.setattr(mod, "generate_chart", fake_generate)
+    monkeypatch.setattr(mod, "write_csv", fake_csv)
+    mod.main()
+    assert (tmp_path / mod.SVG_OUTPUT).exists()
+    assert (tmp_path / mod.CSV_OUTPUT).exists()


### PR DESCRIPTION
## Summary
- export yearly contribution counts as CSV
- document CSV output in `AGENTS.md` and `llms.txt`
- nightly workflow commits both SVG and CSV
- update tests for new helper

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686e3134e7f4832fbf77f47b05885ae1