### PR TITLE
Fix annual contribution chart colors

### DIFF
--- a/assets/annual_contribs.svg
+++ b/assets/annual_contribs.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-07-10T04:34:42.892007</dc:date>
+    <dc:date>2025-07-10T04:50:07.687585</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -45,7 +45,7 @@ L 85.33197 116.12
 L 85.33197 116.12 
 L 49.130455 116.12 
 z
-" clip-path="url(#pa3e1902202)" style="fill: #4c9aff"/>
+" clip-path="url(#pf900831377)" style="fill: #2ecc71"/>
    </g>
    <g id="patch_4">
     <path d="M 94.382348 116.12 
@@ -53,7 +53,7 @@ L 130.583864 116.12
 L 130.583864 91.04381 
 L 94.382348 91.04381 
 z
-" clip-path="url(#pa3e1902202)" style="fill: #4c9aff"/>
+" clip-path="url(#pf900831377)" style="fill: #2ecc71"/>
    </g>
    <g id="patch_5">
     <path d="M 139.634242 116.12 
@@ -61,7 +61,7 @@ L 175.835758 116.12
 L 175.835758 65.967619 
 L 139.634242 65.967619 
 z
-" clip-path="url(#pa3e1902202)" style="fill: #4c9aff"/>
+" clip-path="url(#pf900831377)" style="fill: #2ecc71"/>
    </g>
    <g id="patch_6">
     <path d="M 184.886136 116.12 
@@ -69,7 +69,7 @@ L 221.087652 116.12
 L 221.087652 40.891429 
 L 184.886136 40.891429 
 z
-" clip-path="url(#pa3e1902202)" style="fill: #4c9aff"/>
+" clip-path="url(#pf900831377)" style="fill: #2ecc71"/>
    </g>
    <g id="patch_7">
     <path d="M 230.13803 116.12 
@@ -77,23 +77,23 @@ L 266.339545 116.12
 L 266.339545 15.815238 
 L 230.13803 15.815238 
 z
-" clip-path="url(#pa3e1902202)" style="fill: #4c9aff"/>
+" clip-path="url(#pf900831377)" style="fill: #2ecc71"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma03eea181f" d="M 0 0 
+       <path id="mf64c0298f7" d="M 0 0 
 L 0 3.5 
-" style="stroke: #000000; stroke-width: 0.8"/>
+" style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma03eea181f" x="67.231212" y="116.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf64c0298f7" x="67.231212" y="116.12" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 2021 -->
-      <g transform="translate(54.506212 130.718437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(54.506212 130.718437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -165,12 +165,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma03eea181f" x="112.483106" y="116.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf64c0298f7" x="112.483106" y="116.12" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 2022 -->
-      <g transform="translate(99.758106 130.718437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(99.758106 130.718437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -181,12 +181,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma03eea181f" x="157.735" y="116.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf64c0298f7" x="157.735" y="116.12" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 2023 -->
-      <g transform="translate(145.01 130.718437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(145.01 130.718437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -231,12 +231,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma03eea181f" x="202.986894" y="116.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf64c0298f7" x="202.986894" y="116.12" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 2024 -->
-      <g transform="translate(190.261894 130.718437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(190.261894 130.718437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -268,12 +268,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma03eea181f" x="248.238788" y="116.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf64c0298f7" x="248.238788" y="116.12" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 2025 -->
-      <g transform="translate(235.513788 130.718437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(235.513788 130.718437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -312,77 +312,102 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_6">
+      <path d="M 38.27 116.12 
+L 277.2 116.12 
+" clip-path="url(#pf900831377)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.25; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7">
       <defs>
-       <path id="m8d92567843" d="M 0 0 
+       <path id="m9ffbef7b55" d="M 0 0 
 L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
+" style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8d92567843" x="38.27" y="116.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ffbef7b55" x="38.27" y="116.12" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 0 -->
-      <g transform="translate(24.9075 119.919219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.9075 119.919219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_7">
+     <g id="line2d_8">
+      <path d="M 38.27 91.04381 
+L 277.2 91.04381 
+" clip-path="url(#pf900831377)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.25; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
       <g>
-       <use xlink:href="#m8d92567843" x="38.27" y="91.04381" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ffbef7b55" x="38.27" y="91.04381" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 1 -->
-      <g transform="translate(24.9075 94.843028) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.9075 94.843028) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_8">
+     <g id="line2d_10">
+      <path d="M 38.27 65.967619 
+L 277.2 65.967619 
+" clip-path="url(#pf900831377)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.25; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
       <g>
-       <use xlink:href="#m8d92567843" x="38.27" y="65.967619" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ffbef7b55" x="38.27" y="65.967619" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 2 -->
-      <g transform="translate(24.9075 69.766838) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.9075 69.766838) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_9">
+     <g id="line2d_12">
+      <path d="M 38.27 40.891429 
+L 277.2 40.891429 
+" clip-path="url(#pf900831377)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.25; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
       <g>
-       <use xlink:href="#m8d92567843" x="38.27" y="40.891429" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ffbef7b55" x="38.27" y="40.891429" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 3 -->
-      <g transform="translate(24.9075 44.690647) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.9075 44.690647) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_10">
+     <g id="line2d_14">
+      <path d="M 38.27 15.815238 
+L 277.2 15.815238 
+" clip-path="url(#pf900831377)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.25; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
       <g>
-       <use xlink:href="#m8d92567843" x="38.27" y="15.815238" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ffbef7b55" x="38.27" y="15.815238" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 4 -->
-      <g transform="translate(24.9075 19.614457) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.9075 19.614457) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-34"/>
       </g>
      </g>
     </g>
     <g id="text_11">
      <!-- PRs -->
-     <g transform="translate(18.827813 72.55375) rotate(-90) scale(0.1 -0.1)">
+     <g style="fill: #ffffff" transform="translate(18.827813 72.55375) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-50" d="M 1259 4147 
 L 1259 2394 
@@ -474,27 +499,27 @@ z
    <g id="patch_8">
     <path d="M 38.27 116.12 
 L 38.27 10.8 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_9">
     <path d="M 277.2 116.12 
 L 277.2 10.8 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_10">
     <path d="M 38.27 116.12 
 L 277.2 116.12 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_11">
     <path d="M 38.27 10.8 
 L 277.2 10.8 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa3e1902202">
+  <clipPath id="pf900831377">
    <rect x="38.27" y="10.8" width="238.93" height="105.32"/>
   </clipPath>
  </defs>

--- a/src/generate_annual_contributions.py
+++ b/src/generate_annual_contributions.py
@@ -33,13 +33,28 @@ def generate_chart(counts: dict[int, int], output: Path = SVG_OUTPUT) -> None:
     """Write an SVG bar chart to ``output`` summarizing ``counts``."""
     years = sorted(counts)
     values = [counts[y] for y in years]
-    plt.figure(figsize=(4, 2))
-    plt.bar(years, values, color="#4c9aff")
-    plt.xticks(years)
-    plt.ylabel("PRs")
+
+    plt.rcParams.update(
+        {
+            "text.color": "white",
+            "axes.labelcolor": "white",
+            "axes.edgecolor": "white",
+            "xtick.color": "white",
+            "ytick.color": "white",
+            "grid.color": "white",
+        }
+    )
+
+    fig, ax = plt.subplots(figsize=(4, 2))
+    ax.bar(years, values, color="#2ecc71")
+    ax.set_xticks(years)
+    ax.set_ylabel("PRs")
+    ax.grid(axis="y", linewidth=0.25, alpha=0.3)
+    for spine in ax.spines.values():
+        spine.set_color("white")
     output.parent.mkdir(parents=True, exist_ok=True)
     plt.tight_layout()
-    plt.savefig(output, transparent=True)
+    fig.savefig(output, transparent=True)
 
 
 def write_csv(counts: dict[int, int], output: Path = CSV_OUTPUT) -> None:


### PR DESCRIPTION
## Summary
- improve dark-mode styling for annual contributions
- update tests for new matplotlib calls
- regenerate annual contribution SVG

## Testing
- `ruff check --fix .`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f45ab7f14832f9fbb2e844c1ff2e6