### PR TITLE
Add gitshelves and wove to docs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -36,6 +36,7 @@ gfx
 gh
 github
 gitignored
+gitshelves
 graphql
 heatmap
 heatmaps
@@ -99,6 +100,7 @@ virtualenv
 visualise
 whitespace
 wip
+wove
 www
 xyz
 yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,8 @@ Tests under `tests/` cover folder naming (`test_folder_names.py`), schema valida
 -### Optional
 - [Contributing guide](CONTRIBUTING.md): PR etiquette and code style details.
 - For cross-project synergy, see the README's **Other Projects** links or explore
-  the [axel](https://github.com/futuroptimist/axel) repo for quest management.
+  the [axel](https://github.com/futuroptimist/axel), [gitshelves](https://github.com/futuroptimist/gitshelves),
+  and [wove](https://github.com/futuroptimist/wove) repos.
 
 ---
 *For creative context, tone, and thematic constraints refer to [`llms.txt`](llms.txt).* 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTub
 - **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – bulk-copy files from nested dirs straight to your clipboard
 - **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker for repos and next steps
 - **[sigma](https://github.com/futuroptimist/sigma)** – open-source AI pin device
+- **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turn GitHub contributions into 3D-printable block models
+- **[wove](https://github.com/futuroptimist/wove)** – open-source toolkit for knitting and robotic looms
 
 ## Contributions (issues & PRs I've opened)
 

--- a/llms.txt
+++ b/llms.txt
@@ -58,7 +58,9 @@ If `yt-dlp` isn't found during tests, prefix the command with `PATH=.venv/bin:$P
 ## Optional
 - [Ideas directory](ideas/README.md): format for idea files
 - Example idea – solar aquaponics checklist: [solar_aquaponics.md](ideas/solar_aquaponics.md)
-- For cross-repo quests, see [axel](https://github.com/futuroptimist/axel)
+- For cross-repo quests, see [axel](https://github.com/futuroptimist/axel),
+  [gitshelves](https://github.com/futuroptimist/gitshelves) and
+  [wove](https://github.com/futuroptimist/wove)
 
 ---
 LLM usage policy: No private data; operate within repo; see LICENSE (MIT).


### PR DESCRIPTION
## Summary
- highlight the gitshelves and wove projects
- mention them for cross-project synergies
- update spellcheck wordlist

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f58ff0d10832faf484b11275e7f01