### PR TITLE
Add sugarkube to repo list

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -108,3 +108,5 @@ yml
 youtube
 yt
 yyyymmdd
+sugarkube
+contributionsCollection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,9 +122,7 @@ Tests under `tests/` cover folder naming (`test_folder_names.py`), schema valida
 -### Optional
 - [Contributing guide](CONTRIBUTING.md): PR etiquette and code style details.
 - For cross-project synergy, see the README's **Other Projects** links or explore
-  the [axel](https://github.com/futuroptimist/axel), [gitshelves](https://github.com/futuroptimist/gitshelves),
-  [wove](https://github.com/futuroptimist/wove),
-  and [sugarkube](https://github.com/futuroptimist/sugarkube) repos.
+  the [axel](https://github.com/futuroptimist/axel), [gitshelves](https://github.com/futuroptimist/gitshelves), [wove](https://github.com/futuroptimist/wove), and [sugarkube](https://github.com/futuroptimist/sugarkube) repos.
 
 ---
 *For creative context, tone, and thematic constraints refer to [`llms.txt`](llms.txt).* 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,8 @@ Tests under `tests/` cover folder naming (`test_folder_names.py`), schema valida
 - [Contributing guide](CONTRIBUTING.md): PR etiquette and code style details.
 - For cross-project synergy, see the README's **Other Projects** links or explore
   the [axel](https://github.com/futuroptimist/axel), [gitshelves](https://github.com/futuroptimist/gitshelves),
-  and [wove](https://github.com/futuroptimist/wove) repos.
+  [wove](https://github.com/futuroptimist/wove),
+  and [sugarkube](https://github.com/futuroptimist/sugarkube) repos.
 
 ---
 *For creative context, tone, and thematic constraints refer to [`llms.txt`](llms.txt).* 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTub
 - **[sigma](https://github.com/futuroptimist/sigma)** – open-source AI pin device
 - **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turn GitHub contributions into 3D-printable block models
 - **[wove](https://github.com/futuroptimist/wove)** – open-source toolkit for knitting and robotic looms
+- **[sugarkube](https://github.com/futuroptimist/sugarkube)** – accessible k3s platform for off-grid Raspberry Pi clusters
 
 ## Contributions (issues & PRs I've opened)
 

--- a/llms.txt
+++ b/llms.txt
@@ -59,8 +59,9 @@ If `yt-dlp` isn't found during tests, prefix the command with `PATH=.venv/bin:$P
 - [Ideas directory](ideas/README.md): format for idea files
 - Example idea – solar aquaponics checklist: [solar_aquaponics.md](ideas/solar_aquaponics.md)
 - For cross-repo quests, see [axel](https://github.com/futuroptimist/axel),
-  [gitshelves](https://github.com/futuroptimist/gitshelves) and
-  [wove](https://github.com/futuroptimist/wove)
+  [gitshelves](https://github.com/futuroptimist/gitshelves),
+  [wove](https://github.com/futuroptimist/wove) and
+  [sugarkube](https://github.com/futuroptimist/sugarkube)
 
 ---
 LLM usage policy: No private data; operate within repo; see LICENSE (MIT).

--- a/llms.txt
+++ b/llms.txt
@@ -59,9 +59,7 @@ If `yt-dlp` isn't found during tests, prefix the command with `PATH=.venv/bin:$P
 - [Ideas directory](ideas/README.md): format for idea files
 - Example idea – solar aquaponics checklist: [solar_aquaponics.md](ideas/solar_aquaponics.md)
 - For cross-repo quests, see [axel](https://github.com/futuroptimist/axel),
-  [gitshelves](https://github.com/futuroptimist/gitshelves),
-  [wove](https://github.com/futuroptimist/wove) and
-  [sugarkube](https://github.com/futuroptimist/sugarkube)
+  [gitshelves](https://github.com/futuroptimist/gitshelves), [wove](https://github.com/futuroptimist/wove) and [sugarkube](https://github.com/futuroptimist/sugarkube)
 
 ---
 LLM usage policy: No private data; operate within repo; see LICENSE (MIT).


### PR DESCRIPTION
## Summary
- reference the new `sugarkube` project in README highlights
- include sugarkube in AGENTS and llms cross-repo links

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6875fcc9b95c832f9e1c644f51ae859e