### PR TITLE
Fix heatmap token fallback

### DIFF
--- a/src/gh_graphql.py
+++ b/src/gh_graphql.py
@@ -13,7 +13,9 @@ SEARCH_URL = "https://api.github.com/search/commits"
 
 def fetch_contributions(login: str, start: str, end: str) -> List[Dict[str, Any]]:
     """Return commits authored by *login* in the given date range."""
-    token = os.environ["GH_TOKEN"]
+    token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+    if token is None:
+        raise EnvironmentError("GH_TOKEN or GITHUB_TOKEN must be set")
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github.cloak-preview+json",

--- a/src/gh_rest.py
+++ b/src/gh_rest.py
@@ -30,7 +30,9 @@ def fetch_commit_stats(owner: str, repo: str, sha: str) -> Dict[str, int]:
     if key in cache:
         return cache[key]
 
-    token = os.environ["GH_TOKEN"]
+    token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+    if token is None:
+        raise EnvironmentError("GH_TOKEN or GITHUB_TOKEN must be set")
     headers = {"Authorization": f"Bearer {token}"}
     url = f"https://api.github.com/repos/{owner}/{repo}/commits/{sha}"
     resp = requests.get(url, headers=headers, timeout=10)

--- a/tests/test_gh_rest.py
+++ b/tests/test_gh_rest.py
@@ -1,6 +1,7 @@
 import json
 
 
+import pytest
 import src.gh_rest as gh
 
 
@@ -42,3 +43,25 @@ def test_fetch_commit_stats_fetches_and_saves(tmp_path, monkeypatch):
     assert stats == {"additions": 3, "deletions": 4}
     data = json.loads(cache.read_text())
     assert data["o/r@sha2"] == stats
+
+
+def test_fetch_commit_stats_falls_back_to_github_token(tmp_path, monkeypatch):
+    cache = tmp_path / "cache.json"
+    monkeypatch.setattr(gh, "CACHE_FILE", cache)
+
+    def fake_get(url, headers, timeout):
+        assert headers["Authorization"] == "Bearer y"
+        return Resp({"stats": {"additions": 1, "deletions": 1}})
+
+    monkeypatch.setenv("GITHUB_TOKEN", "y")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(gh.requests, "get", fake_get)
+    assert gh.fetch_commit_stats("o", "r", "sha3") == {"additions": 1, "deletions": 1}
+
+
+def test_fetch_commit_stats_missing_token(tmp_path, monkeypatch):
+    monkeypatch.setattr(gh, "CACHE_FILE", tmp_path / "cache.json")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with pytest.raises(EnvironmentError):
+        gh.fetch_commit_stats("o", "r", "sha")


### PR DESCRIPTION
## Summary
- allow heatmap generator to use `GITHUB_TOKEN` when `GH_TOKEN` isn't set

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68887b128f10832f8bd453be18bcbf8e