### PR TITLE
Abstract GitHub token lookup

### DIFF
--- a/src/gh_graphql.py
+++ b/src/gh_graphql.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import os
 from typing import Any, Dict, List
+
+from .github_auth import get_github_token
 
 import requests
 
@@ -13,7 +14,7 @@ SEARCH_URL = "https://api.github.com/search/commits"
 
 def fetch_contributions(login: str, start: str, end: str) -> List[Dict[str, Any]]:
     """Return commits authored by *login* in the given date range."""
-    token = os.environ["GH_TOKEN"]
+    token = get_github_token()
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github.cloak-preview+json",

--- a/src/gh_rest.py
+++ b/src/gh_rest.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict
 
 import requests
+from .github_auth import get_github_token
 
 CACHE_FILE = Path("assets/heatmap_data.json")
 
@@ -30,7 +30,7 @@ def fetch_commit_stats(owner: str, repo: str, sha: str) -> Dict[str, int]:
     if key in cache:
         return cache[key]
 
-    token = os.environ["GH_TOKEN"]
+    token = get_github_token()
     headers = {"Authorization": f"Bearer {token}"}
     url = f"https://api.github.com/repos/{owner}/{repo}/commits/{sha}"
     resp = requests.get(url, headers=headers, timeout=10)

--- a/src/github_auth.py
+++ b/src/github_auth.py
@@ -1,0 +1,13 @@
+"""GitHub authentication helpers."""
+
+from __future__ import annotations
+
+import os
+
+
+def get_github_token() -> str:
+    """Return an API token from ``GH_TOKEN`` or ``GITHUB_TOKEN`` env vars."""
+    token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+    if token is None:
+        raise EnvironmentError("GH_TOKEN or GITHUB_TOKEN must be set")
+    return token

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -1,0 +1,22 @@
+import pytest
+
+from src.github_auth import get_github_token
+
+
+def test_get_token_prefers_gh_token(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "a")
+    monkeypatch.setenv("GITHUB_TOKEN", "b")
+    assert get_github_token() == "a"
+
+
+def test_get_token_falls_back(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "b")
+    assert get_github_token() == "b"
+
+
+def test_get_token_missing(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with pytest.raises(EnvironmentError):
+        get_github_token()


### PR DESCRIPTION
## Summary
- share GH token fallback via `get_github_token`
- update REST and GraphQL helpers to use the new function
- add tests for the helper

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68887b128f10832f8bd453be18bcbf8e