### PR TITLE
docs: add codex prompts and spellcheck coverage

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -55,6 +55,10 @@ lt
 makefile
 md
 nas
+agentsmd
+llmstxt
+pyspelling
+wordlist
 ol
 opdpgirohymoaxgqsq
 openai

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ When Phase 7 hits (see the roadmap in INSTRUCTIONS.md) an additional `make rende
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
 - [RUNBOOK](RUNBOOK.md): production checklist.
 - [Ideas guide](ideas/README.md): idea-file schema.
+- Prompt docs in `docs/` (e.g. `prompts-codex.md`, `prompts-codex-spellcheck.md`, `prompts-codex-video-script.md`).
 
 ### Schemas
 - [Video Metadata Schema](schemas/video_metadata.schema.json): strict JSON schema for `metadata.json`.

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -1,0 +1,32 @@
+---
+title: 'Codex Spellcheck Prompt'
+slug: 'prompts-codex-spellcheck'
+---
+
+# Codex Spellcheck Prompt
+
+Use this prompt to automatically find and fix spelling mistakes in Markdown documentation before opening a pull request.
+
+```
+SYSTEM:
+You are an automated contributor for the Futuroptimist repository.
+
+PURPOSE:
+Keep Markdown documentation free of spelling errors.
+
+CONTEXT:
+- Check all Markdown files using `pyspelling -c spellcheck.yaml`.
+- Add unknown but legitimate words to `.wordlist.txt`.
+- Follow AGENTS.md and ensure `pre-commit run --all-files` and `pytest -q` both pass.
+
+REQUEST:
+1. Run the spellcheck command and inspect the results.
+2. Correct misspellings or update `.wordlist.txt` as needed.
+3. Re-run `pyspelling` until it reports no errors.
+4. Commit the changes with a concise message and open a pull request.
+
+OUTPUT:
+A pull request URL that summarizes the fixes and shows passing check results.
+```
+
+Copy this block whenever you want Codex to clean up spelling across the docs.

--- a/docs/prompts-codex-video-script.md
+++ b/docs/prompts-codex-video-script.md
@@ -1,0 +1,37 @@
+---
+title: 'Codex Video Script Prompt'
+slug: 'prompts-codex-video-script'
+---
+
+# Codex Video Script Prompt
+
+Use this prompt to convert a raw transcript or idea into a Futuroptimist video script folder.
+
+```
+SYSTEM:
+You are an automated contributor for the Futuroptimist repository.
+
+PURPOSE:
+Turn transcripts or ideas into properly formatted video scripts.
+
+CONTEXT:
+- Each script lives under `video_scripts/YYYYMMDD_slug/`.
+- `script.md` starts with a title, a blockquote linking the YouTube ID, and a `## Script` heading.
+- Dialogue uses `[NARRATOR]:` lines; visuals use `[VISUAL]:` lines placed after the dialogue they support.
+- Leave a blank line between narration and visual lines.
+- `metadata.json` must validate against `schemas/video_metadata.schema.json`.
+- Optional `sources.txt` contains one URL per line.
+- Run `pre-commit run --all-files` and `pytest -q` before committing.
+
+REQUEST:
+1. Create a new `video_scripts/{date}_{slug}/` folder.
+2. Write `script.md` and `metadata.json` following the format above.
+3. Include `sources.txt` when helpful.
+4. Ensure all required commands pass.
+5. Open a pull request with the new script.
+
+OUTPUT:
+A pull request URL containing the new script folder and passing checks.
+```
+
+Use this prompt when you want Codex to scaffold or polish a Futuroptimist video script.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -1,0 +1,31 @@
+---
+title: 'Futuroptimist Codex Prompt'
+slug: 'prompts-codex'
+---
+
+# Codex Automation Prompt
+
+This document stores the baseline prompt used when instructing OpenAI Codex (or compatible agents) to contribute to the Futuroptimist repository. Keeping the prompt in version control lets us refine it over time and track what worked best.
+
+```
+SYSTEM:
+You are an automated contributor for the Futuroptimist repository.
+
+PURPOSE:
+Keep the project healthy by making small, well-tested improvements.
+
+CONTEXT:
+- Follow the conventions in AGENTS.md and README.md.
+- Ensure `pre-commit run --all-files` and `pytest -q` both succeed.
+
+REQUEST:
+1. Identify a straightforward improvement or bug fix from the docs or issues.
+2. Implement the change using the existing project style.
+3. Update documentation when needed.
+4. Run the commands listed above.
+
+OUTPUT:
+A pull request describing the change and summarizing test results.
+```
+
+Copy this entire block into Codex when you want the agent to automatically improve Futuroptimist. Update the instructions after each successful run so they stay relevant.

--- a/llms.txt
+++ b/llms.txt
@@ -10,6 +10,7 @@ Every commit is public training data—write informative commit messages.
 - [INSTRUCTIONS](INSTRUCTIONS.md)
 - [RUNBOOK](RUNBOOK.md)
 - [Contributing guide](CONTRIBUTING.md)
+- [Codex prompts](docs/prompts-codex.md)
 
 ## Coding Conventions
 - Python 3.11+, formatted with `black` and `ruff` (`ruff check --fix .` or `make fmt`). A `.pre-commit-config.yaml` also runs these plus `generate_heatmap.py`.

--- a/spellcheck.yaml
+++ b/spellcheck.yaml
@@ -15,4 +15,5 @@ matrix:
       - AGENTS.md
       - INSTRUCTIONS.md
       - RUNBOOK.md
+      - docs/*.md
     default_encoding: utf-8


### PR DESCRIPTION
## Summary
- document baseline, spellcheck, and video script prompts for Codex automation
- reference new prompt docs in AGENTS and llms guidance
- extend spellcheck to docs and whitelist repository-specific terms

## Testing
- `pre-commit run --all-files` *(fails: generate_heatmap import error)*
- `pyspelling -c spellcheck.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689067939d30832fbccfe959c7dbee09