### PR TITLE
✨ ensure index_local_media creates output directories

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -52,7 +52,10 @@ This fetches titles and dates to generate `video_scripts/YYYYMMDD_slug` director
 If metadata can't be fetched (network issues or parsing errors) the script
 logs the failure and continues so scaffolding never blocks your workflow.
 
-Large media assets should live in a local `footage/` directory. Use `python src/index_local_media.py` to build `footage_index.json` so you can quickly locate clips while editing.
+Large media assets should live in a local `footage/` directory.
+Use `python src/index_local_media.py` to build `footage_index.json`
+so you can quickly locate clips while editing. The script creates
+the output directory if needed.
 
 ## Next Steps
 * Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).

--- a/src/index_local_media.py
+++ b/src/index_local_media.py
@@ -1,3 +1,9 @@
+"""Index local media files and write a JSON inventory.
+
+The generated index lists file paths and modification times.
+The output file's parent directories are created automatically.
+"""
+
 import argparse
 import json
 import pathlib
@@ -37,7 +43,9 @@ def main(argv=None):
     if not base.is_dir():
         parser.error(f"{base} is not a directory")
     index = scan_directory(base)
-    pathlib.Path(args.output).write_text(json.dumps(index, indent=2))
+    output_path = pathlib.Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(index, indent=2))
     print(f"Wrote {args.output}")
 
 

--- a/tests/test_index_local_media.py
+++ b/tests/test_index_local_media.py
@@ -34,6 +34,14 @@ def test_main_invalid_dir(tmp_path):
         ilm.main([str(missing)])
 
 
+def test_creates_output_parent_dirs(tmp_path):
+    f = tmp_path / "clip.mov"
+    f.write_text("x")
+    nested = tmp_path / "out" / "dir" / "index.json"
+    ilm.main([str(tmp_path), "-o", str(nested)])
+    assert nested.exists()
+
+
 def test_entrypoint(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["index_local_media.py", str(tmp_path)])
     (tmp_path).mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure `index_local_media` creates parent directories before writing
- document output directory creation
- add regression test for nested output paths

## Testing
- `SKIP=heatmap pre-commit run --all-files`
- `pytest --cov=./src --cov=./tests`


------
https://chatgpt.com/codex/tasks/task_e_6892de4cc424832f8b7acc749f8956c6