### PR TITLE
🔒 : trim GitHub token whitespace

### DIFF
--- a/src/github_auth.py
+++ b/src/github_auth.py
@@ -6,8 +6,15 @@ import os
 
 
 def get_github_token() -> str:
-    """Return an API token from ``GH_TOKEN`` or ``GITHUB_TOKEN`` env vars."""
+    """Return an API token from ``GH_TOKEN`` or ``GITHUB_TOKEN`` env vars.
+
+    Leading and trailing whitespace is stripped to avoid accidental newline
+    characters; a blank token raises ``EnvironmentError``.
+    """
     token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
     if token is None:
         raise EnvironmentError("GH_TOKEN or GITHUB_TOKEN must be set")
+    token = token.strip()
+    if not token:
+        raise EnvironmentError("GitHub token cannot be blank")
     return token

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -20,3 +20,14 @@ def test_get_token_missing(monkeypatch):
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     with pytest.raises(EnvironmentError):
         get_github_token()
+
+
+def test_get_token_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", " a\n")
+    assert get_github_token() == "a"
+
+
+def test_get_token_rejects_blank(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "  \n\t")
+    with pytest.raises(EnvironmentError):
+        get_github_token()


### PR DESCRIPTION
## Summary
- strip GH_TOKEN/GITHUB_TOKEN values and reject blanks

## Testing
- `pytest --cov=./src --cov=./tests`
- `pre-commit run --all-files` *(heatmap hook skipped: import error)*

------
https://chatgpt.com/codex/tasks/task_e_6892de4cc424832f8b7acc749f8956c6