### PR TITLE
🐛: allow heatmap scripts to run without token

### DIFF
--- a/src/generate_heatmap.py
+++ b/src/generate_heatmap.py
@@ -53,7 +53,11 @@ def draw_bars(dwg, loc_by_day, start):
 def main() -> None:
     today = dt.date.today()
     start = today - dt.timedelta(days=370)
-    contribs = fetch_contributions("futuroptimist", str(start), str(today))
+    try:
+        contribs = fetch_contributions("futuroptimist", str(start), str(today))
+    except EnvironmentError:
+        print("GH_TOKEN or GITHUB_TOKEN not set; skipping heatmap generation")
+        return
     loc_by_day = aggregate_loc(contribs)
     for theme in ("light", "dark"):
         path = Path(f"assets/heatmap_{theme}.svg")

--- a/src/gh_graphql.py
+++ b/src/gh_graphql.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from .github_auth import get_github_token
+try:  # allow imports when running as package or script
+    from .github_auth import get_github_token
+except ImportError:  # pragma: no cover - fallback for script execution
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parent))
+    from github_auth import get_github_token
 
 import requests
 

--- a/src/gh_rest.py
+++ b/src/gh_rest.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from typing import Any, Dict
 
 import requests
-from .github_auth import get_github_token
+
+try:  # allow imports when running as package or script
+    from .github_auth import get_github_token
+except ImportError:  # pragma: no cover - fallback for script execution
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parent))
+    from github_auth import get_github_token
 
 CACHE_FILE = Path("assets/heatmap_data.json")
 

--- a/tests/test_generate_heatmap_svg.py
+++ b/tests/test_generate_heatmap_svg.py
@@ -70,3 +70,15 @@ def test_generate_heatmap_writes_files(monkeypatch, tmp_path):
     generate_heatmap.main()
     assert (tmp_path / "assets/heatmap_light.svg").exists()
     assert (tmp_path / "assets/heatmap_dark.svg").exists()
+
+
+def test_generate_heatmap_skips_without_token(monkeypatch, tmp_path, capsys):
+    def fake_fetch(login, start, end):
+        raise EnvironmentError("missing token")
+
+    monkeypatch.setattr(generate_heatmap, "fetch_contributions", fake_fetch)
+    monkeypatch.chdir(tmp_path)
+    generate_heatmap.main()
+    out = capsys.readouterr().out
+    assert "GH_TOKEN" in out
+    assert not (tmp_path / "assets").exists()

--- a/tests/test_heatmap_imports.py
+++ b/tests/test_heatmap_imports.py
@@ -1,0 +1,8 @@
+import runpy
+from pathlib import Path
+
+
+def test_heatmap_modules_importable_as_scripts():
+    base = Path(__file__).resolve().parent.parent / "src"
+    runpy.run_path(base / "gh_graphql.py")
+    runpy.run_path(base / "gh_rest.py")


### PR DESCRIPTION
## Summary
- allow heatmap modules to import when executed as scripts
- skip heatmap generation if GH_TOKEN/GITHUB_TOKEN missing
- test heatmap behavior with and without token

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892de30cf68832faf085907a51cc606