### PR TITLE
⏱️ : add timeout to video metadata fetch

### DIFF
--- a/src/scaffold_videos.py
+++ b/src/scaffold_videos.py
@@ -46,9 +46,11 @@ def slugify(text: str) -> str:
 
 
 def fetch_video_info(video_id: str):
+    """Return video title and date using a 10‑second HTTP timeout."""
+
     url = f"https://r.jina.ai/https://www.youtube.com/watch?v={video_id}"
     req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-    html = urllib.request.urlopen(req).read().decode("utf-8", "ignore")
+    html = urllib.request.urlopen(req, timeout=10).read().decode("utf-8", "ignore")
     title_match = re.search(r"^Title: (.+)", html, re.MULTILINE)
     date_match = re.search(r"([A-Z][a-z]+ [0-9]{1,2}, [0-9]{4})", html)
     if not (title_match and date_match):

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -50,7 +50,7 @@ def test_fetch_video_info_parses(monkeypatch):
             return html.encode()
 
     resp = Resp()
-    monkeypatch.setattr(sv.urllib.request, "urlopen", lambda req: resp)
+    monkeypatch.setattr(sv.urllib.request, "urlopen", lambda req, timeout=10: resp)
     title, date = sv.fetch_video_info("abc")
     resp.__enter__()
     resp.__exit__(None, None, None)
@@ -70,11 +70,36 @@ def test_fetch_video_info_error(monkeypatch):
             return b"no title here"
 
     r = Resp()
-    monkeypatch.setattr(sv.urllib.request, "urlopen", lambda req: r)
+    monkeypatch.setattr(sv.urllib.request, "urlopen", lambda req, timeout=10: r)
     with pytest.raises(RuntimeError):
         sv.fetch_video_info("abc")
     r.__enter__()
     r.__exit__(None, None, None)
+
+
+def test_fetch_video_info_timeout(monkeypatch):
+    html = "Title: Example\nJan 1, 2024"
+
+    class Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def read(self):
+            return html.encode()
+
+    resp = Resp()
+
+    def fake_urlopen(req, *, timeout):
+        assert timeout == 10
+        return resp
+
+    monkeypatch.setattr(sv.urllib.request, "urlopen", fake_urlopen)
+    sv.fetch_video_info("abc")
+    resp.__enter__()
+    resp.__exit__(None, None, None)
 
 
 def test_main_exits_without_ids(monkeypatch, tmp_path):
@@ -115,7 +140,7 @@ def test_entrypoint(monkeypatch, tmp_path):
             return b"Title: Dummy\nJan 1, 2024"
 
     r = Resp()
-    monkeypatch.setattr(sv.urllib.request, "urlopen", lambda req: r)
+    monkeypatch.setattr(sv.urllib.request, "urlopen", lambda req, timeout=10: r)
     runpy.run_module("src.scaffold_videos", run_name="__main__")
     r.__enter__()
     r.__exit__(None, None, None)


### PR DESCRIPTION
## Summary
- avoid hanging HTTP requests when scaffolding video folders
- cover timeout behavior with tests

## Testing
- `SKIP=heatmap pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892de30cf68832faf085907a51cc606