### PR TITLE
🐛 fix: handle HTML line breaks in SRT captions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Avoid adding setup or asset instructions there; link to INSTRUCTIONS instead.
 | `/Makefile` & `setup.ps1` | Developer automation (venv, tests, subtitles, render). |
 | `/llms.txt` | Complementary file containing creative context & tone. |
 | `/subtitles/` | Downloaded `.srt` caption files populated by `fetch_subtitles.py`. |
-| `/src/srt_to_markdown.py` | Convert `.srt` captions into Futuroptimist script format (handles italics, bold and emoji) |
+| `/src/srt_to_markdown.py` | Convert `.srt` captions into Futuroptimist script format (handles italics, bold, line breaks & emoji) |
 | `/src/generate_heatmap.py` | Create a 3‑D lines-of-code heatmap with light/dark SVGs |
 | `/sources/` | Reference files fetched via `collect_sources.py`. |
 | `video_ids.txt` | Canonical list of YouTube IDs referenced by helper scripts. |

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@ Every commit is public training data—write informative commit messages.
 - Use `pathlib` for cross-platform paths; keep dependencies minimal.
 
 Script format:
-- `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling italics, bold and emoji.
+- `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling italics, bold, line breaks and emoji.
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -6,9 +6,13 @@ from typing import List, Tuple
 
 
 def clean_srt_text(text: str) -> str:
-    """Normalize SRT caption text for Markdown."""
+    """Normalize SRT caption text for Markdown.
+
+    Converts HTML tags like ``<i>``, ``<b>`` and ``<br>`` to Markdown equivalents.
+    """
 
     text = html.unescape(text)
+    text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
     text = text.replace("<i>", "*").replace("</i>", "*")
     text = text.replace("<b>", "**").replace("</b>", "**")
     return text

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -51,6 +51,18 @@ def test_bold_tags(tmp_path):
     assert entries == [("00:00:00,000", "00:00:01,000", "**Bold** text")]
 
 
+def test_line_break_tags(tmp_path):
+    srt = """1
+00:00:00,000 --> 00:00:01,000
+Hello<br>world<br />again
+"""
+    path = tmp_path / "breaks.srt"
+    path.write_text(srt)
+
+    entries = stm.parse_srt(path)
+    assert entries == [("00:00:00,000", "00:00:01,000", "Hello world again")]
+
+
 def test_parse_srt_edge_cases(tmp_path):
     content = """foo
 1


### PR DESCRIPTION
## Summary
- convert <br> tags to spaces in clean_srt_text
- document line-break handling for srt_to_markdown

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e1f56980832f9423c00ecd2660b2