### PR TITLE
⏱️ : store UTC modification times in footage index

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -54,8 +54,9 @@ logs the failure and continues so scaffolding never blocks your workflow.
 
 Large media assets should live in a local `footage/` directory.
 Use `python src/index_local_media.py` to build `footage_index.json`
-so you can quickly locate clips while editing. The script creates
-the output directory if needed.
+so you can quickly locate clips while editing. Modification times
+are stored in UTC. The script creates the output directory if
+needed.
 
 ## Next Steps
 * Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).

--- a/src/index_local_media.py
+++ b/src/index_local_media.py
@@ -1,13 +1,13 @@
 """Index local media files and write a JSON inventory.
 
-The generated index lists file paths and modification times.
+The generated index lists file paths and modification times in UTC.
 The output file's parent directories are created automatically.
 """
 
 import argparse
 import json
 import pathlib
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def scan_directory(base: pathlib.Path):
@@ -15,7 +15,11 @@ def scan_directory(base: pathlib.Path):
     records = []
     for path in base.rglob("*"):
         if path.is_file():
-            mtime = datetime.fromtimestamp(path.stat().st_mtime).isoformat()
+            mtime = (
+                datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
             rel_path = str(path.relative_to(base)).replace("\\", "/")
             records.append({"path": rel_path, "mtime": mtime})
     return sorted(records, key=lambda r: r["mtime"])

--- a/tests/test_index_local_media.py
+++ b/tests/test_index_local_media.py
@@ -1,7 +1,10 @@
 import json
-import pytest
-import sys
 import runpy
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
 import src.index_local_media as ilm
 
 
@@ -14,6 +17,15 @@ def test_scan_directory(tmp_path):
     result = ilm.scan_directory(tmp_path)
     names = {r["path"] for r in result}
     assert names == {"dir/a.jpg", "b.mp4"}
+
+
+def test_scan_directory_utc_mtime(tmp_path):
+    file_path = tmp_path / "clip.mp4"
+    file_path.write_text("data")
+    result = ilm.scan_directory(tmp_path)
+    ts = result[0]["mtime"].replace("Z", "+00:00")
+    mtime = datetime.fromisoformat(ts)
+    assert mtime.tzinfo == timezone.utc
 
 
 def test_main(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- ensure footage index uses UTC timestamps
- document UTC behavior and add regression test

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e1f56980832f9423c00ecd2660b2