### PR TITLE
🧪: reference video_scripts in tests and docs

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -32,7 +32,7 @@ make test    # runs `pytest -q`
 ```
 - For coverage:
 ```bash
-pytest --cov=./scripts --cov=./tests
+pytest --cov=./src --cov=./tests
 ```
 - [source_urls.txt](source_urls.txt) consumed by `collect_sources.py`
 The Makefile picks the correct Python path for Windows or Unix automatically.

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -6,7 +6,7 @@ import pytest
 SCHEMA_PATH = pathlib.Path("schemas/video_metadata.schema.json")
 SCHEMA = json.loads(SCHEMA_PATH.read_text())
 
-VIDEO_DIR = pathlib.Path("scripts")
+VIDEO_DIR = pathlib.Path("video_scripts")
 
 
 def test_metadata_files_validate():

--- a/tests/test_update_transcript_links.py
+++ b/tests/test_update_transcript_links.py
@@ -8,7 +8,7 @@ def test_update_transcript_links(tmp_path, monkeypatch):
     base = tmp_path
     subs = base / "subtitles"
     subs.mkdir()
-    scripts_dir = base / "scripts"
+    scripts_dir = base / "video_scripts"
     scripts_dir.mkdir()
     meta = scripts_dir / "20240101_test" / "metadata.json"
     meta.parent.mkdir()
@@ -27,7 +27,7 @@ def test_update_transcript_links(tmp_path, monkeypatch):
 
 def test_fetch_from_api_when_missing(tmp_path, monkeypatch):
     base = tmp_path
-    scripts_dir = base / "scripts"
+    scripts_dir = base / "video_scripts"
     scripts_dir.mkdir()
     meta = scripts_dir / "20240101_test" / "metadata.json"
     meta.parent.mkdir()
@@ -93,7 +93,7 @@ def test_fetch_transcript_no_key(monkeypatch):
 
 def test_main_skips_without_video_id(tmp_path, monkeypatch):
     base = tmp_path
-    scripts_dir = base / "scripts"
+    scripts_dir = base / "video_scripts"
     scripts_dir.mkdir()
     meta = scripts_dir / "20250101_test" / "metadata.json"
     meta.parent.mkdir()
@@ -111,10 +111,10 @@ def test_main_skips_without_video_id(tmp_path, monkeypatch):
 
 def test_entrypoint(monkeypatch, tmp_path):
     monkeypatch.setattr(utl, "BASE_DIR", tmp_path)
-    monkeypatch.setattr(utl, "SCRIPT_ROOT", tmp_path / "scripts")
+    monkeypatch.setattr(utl, "SCRIPT_ROOT", tmp_path / "video_scripts")
     monkeypatch.setattr(utl, "SUBS_DIR", tmp_path / "subtitles")
     monkeypatch.setattr(utl, "API_KEY", "")
-    (tmp_path / "scripts").mkdir()
+    (tmp_path / "video_scripts").mkdir()
 
     runpy.run_module("src.update_transcript_links", run_name="__main__")
 


### PR DESCRIPTION
what: fix outdated scripts path in tests and coverage guide
why: ensure tests validate real metadata and docs match repo layout
how to test: pre-commit run --all-files && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6893e1f56980832f9423c00ecd2660b2