### PR TITLE
🐛 : – handle uppercase caption tags in srt_to_markdown

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,8 @@ Every commit is public training data—write informative commit messages.
 - Use `pathlib` for cross-platform paths; keep dependencies minimal.
 
 Script format:
-- `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling italics, bold, line breaks and emoji.
+- `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling
+  italics, bold, line breaks, emoji, and case-insensitive HTML tags.
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -8,13 +8,14 @@ from typing import List, Tuple
 def clean_srt_text(text: str) -> str:
     """Normalize SRT caption text for Markdown.
 
-    Converts HTML tags like ``<i>``, ``<b>`` and ``<br>`` to Markdown equivalents.
+    Converts HTML tags like ``<i>``, ``<b>``, and ``<br>`` to Markdown equivalents.
+    Tag matching is case-insensitive.
     """
 
     text = html.unescape(text)
     text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
-    text = text.replace("<i>", "*").replace("</i>", "*")
-    text = text.replace("<b>", "**").replace("</b>", "**")
+    text = re.sub(r"</?i>", "*", text, flags=re.IGNORECASE)
+    text = re.sub(r"</?b>", "**", text, flags=re.IGNORECASE)
     return text
 
 

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -51,6 +51,18 @@ def test_bold_tags(tmp_path):
     assert entries == [("00:00:00,000", "00:00:01,000", "**Bold** text")]
 
 
+def test_uppercase_tags(tmp_path):
+    srt = """1
+00:00:00,000 --> 00:00:01,000
+<I>Hello</I> <B>World</B>
+"""
+    path = tmp_path / "upper.srt"
+    path.write_text(srt)
+
+    entries = stm.parse_srt(path)
+    assert entries == [("00:00:00,000", "00:00:01,000", "*Hello* **World**")]
+
+
 def test_line_break_tags(tmp_path):
     srt = """1
 00:00:00,000 --> 00:00:01,000


### PR DESCRIPTION
What: make srt_to_markdown handle <I>/<B> tags case-insensitively.
Why: subtitles using uppercase HTML tags were left unformatted.
How to test: pre-commit run --all-files && pytest -q

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689436af65b4832f8b9a1ad10b76e651