### PR TITLE
🐛 fix: ignore corrupt heatmap cache

### DIFF
--- a/DESIGN_3D_HEATMAP.md
+++ b/DESIGN_3D_HEATMAP.md
@@ -16,7 +16,8 @@ shared in chat and explains how the feature slots into this repository.
    API (`contributionsCollection`).
 2. For every commit, retrieve the `additions` and `deletions` via the REST API
    and sum them per day.
-3. Cache commit stats in `assets/heatmap_data.json` to stay inside rate limits.
+3. Cache commit stats in `assets/heatmap_data.json` to stay inside rate limits. If the file
+   becomes corrupted, it's ignored and rebuilt on the next run.
 4. Render the SVGs with `svgwrite` and commit them via the workflow.
 
 ## Implementation outline

--- a/src/gh_rest.py
+++ b/src/gh_rest.py
@@ -18,7 +18,10 @@ CACHE_FILE = Path("assets/heatmap_data.json")
 
 def _load_cache() -> Dict[str, Any]:
     if CACHE_FILE.exists():
-        return json.loads(CACHE_FILE.read_text())
+        try:
+            return json.loads(CACHE_FILE.read_text())
+        except json.JSONDecodeError:
+            return {}
     return {}
 
 


### PR DESCRIPTION
## What
- skip corrupted `heatmap_data.json` and rebuild automatically
- document cache rebuild behaviour

## Why
- prevents crashes when cache file is invalid

## How to test
- `pre-commit run --all-files`
- `pytest -q`

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_689436af65b4832f8b9a1ad10b76e651