### PR TITLE
🛡️: validate svg3d color strings

### DIFF
--- a/DESIGN_3D_HEATMAP.md
+++ b/DESIGN_3D_HEATMAP.md
@@ -26,7 +26,7 @@ Files introduced by this feature:
 src/generate_heatmap.py                 # main entrypoint
 src/gh_graphql.py                       # GraphQL helper with retries
 src/gh_rest.py                          # commit → LOC cache
-src/svg3d.py                            # draw isometric bars
+src/svg3d.py                            # draw isometric bars (expects #RRGGBB colors)
 assets/heatmap_light.svg                # auto-generated
 assets/heatmap_dark.svg                 # auto-generated
 ```

--- a/src/svg3d.py
+++ b/src/svg3d.py
@@ -16,7 +16,17 @@ def _clamp(val: int) -> int:
 
 
 def _shade(color: str, factor: float) -> str:
-    c = int(color.lstrip("#"), 16)
+    """Return ``color`` shaded by ``factor``.
+
+    ``color`` must be a hex string in ``#RRGGBB`` format. A ``ValueError`` is raised
+    if the input does not match this pattern or contains invalid hex digits.
+    """
+    if not isinstance(color, str) or not color.startswith("#") or len(color) != 7:
+        raise ValueError("color must be in format '#RRGGBB'")
+    try:
+        c = int(color[1:], 16)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError("color must be in format '#RRGGBB'") from exc
     r = (c >> 16) & 0xFF
     g = (c >> 8) & 0xFF
     b = c & 0xFF

--- a/tests/test_svg3d.py
+++ b/tests/test_svg3d.py
@@ -1,3 +1,4 @@
+import pytest
 import svgwrite
 from src import svg3d
 
@@ -19,3 +20,10 @@ def test_draw_bar_adds_polygons():
     polys = [e for e in dwg.elements if isinstance(e, svgwrite.shapes.Polygon)]
     assert len(polys) == 3
     assert polys[0].points == [(0, 5), (12, 5), (16, 1), (4, 1)]
+
+
+def test_shade_invalid_color():
+    with pytest.raises(ValueError):
+        svg3d._shade("123456", 1)
+    with pytest.raises(ValueError):
+        svg3d._shade("#zzzzzz", 1)


### PR DESCRIPTION
## Summary
- enforce `#RRGGBB` hex validation in `svg3d._shade`
- document color requirement in heatmap design guide
- test invalid color paths

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689436af65b4832f8b9a1ad10b76e651