### PR TITLE
✨ feat: include file sizes in media index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,10 @@ instead of collecting them at the end.
 - Each script folder must include a `metadata.json` file conforming to `schemas/video_metadata.schema.json`. Optional fields like `slug`, `thumbnail`, `transcript_file`, and `summary` enrich automation but aren't required.
 - Each script folder may include a `sources.txt` file with one URL per line. Any downloaded articles or clips are for reference only—check usage rights and cite sources in **APA style** rather than redistributing content.
 - Each script folder may also contain a `footage.md` checklist to track B-roll or CGI shots to gather. Note existing archive vs new footage, and flag generative AI segments so they don't look like "AI slop".
-- Large photos or video files belong in a local `footage/` folder (ignored by git). Run `python src/index_local_media.py` whenever assets change to rebuild `footage_index.json` for quick lookup during editing.
+- Large photos or video files belong in a local `footage/` folder (ignored by git).
+  Run `python src/index_local_media.py` whenever assets change to rebuild
+  `footage_index.json` for quick lookup during editing. Each entry records the
+  file path, modification time, and size in bytes.
 - Run `python src/update_transcript_links.py` to sync `transcript_file` paths; with `YOUTUBE_API_KEY` set it also fetches missing captions via YouTube Data API.
 
 ## Testing & CI

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -54,9 +54,9 @@ logs the failure and continues so scaffolding never blocks your workflow.
 
 Large media assets should live in a local `footage/` directory.
 Use `python src/index_local_media.py` to build `footage_index.json`
-so you can quickly locate clips while editing. Modification times
-are stored in UTC. The script creates the output directory if
-needed.
+so you can quickly locate clips while editing. Each entry includes
+the file path, modification time in UTC, and size in bytes. The
+script creates the output directory if needed.
 
 ## Next Steps
 * Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).

--- a/llms.txt
+++ b/llms.txt
@@ -25,6 +25,9 @@ Script format:
 - Each script folder includes a `metadata.json` validated against `schemas/video_metadata.schema.json`.
 - Each script folder may also contain a `sources.txt` file with one URL per line. Downloaded articles or clips are for citation/reference only—check usage rights and cite in **APA style** rather than redistributing.
 - Each script folder may also have a `footage.md` file listing required shots (archive vs new, CGI or generative). Mark generative items to avoid obvious "AI slop".
+- Run `python src/index_local_media.py` to rebuild `footage_index.json`, which lists
+  file paths, UTC modification times, and file sizes for assets stored in the
+  local `footage/` directory.
 
 Run tests with:
 ```bash

--- a/tests/test_index_local_media.py
+++ b/tests/test_index_local_media.py
@@ -17,6 +17,8 @@ def test_scan_directory(tmp_path):
     result = ilm.scan_directory(tmp_path)
     names = {r["path"] for r in result}
     assert names == {"dir/a.jpg", "b.mp4"}
+    sizes = {r["size"] for r in result}
+    assert sizes == {1}
 
 
 def test_scan_directory_utc_mtime(tmp_path):
@@ -37,6 +39,7 @@ def test_main(tmp_path, capsys):
     assert out_file.exists()
     data = json.loads(out_file.read_text())
     assert data[0]["path"] == "x.txt"
+    assert data[0]["size"] == 2
     assert "Wrote" in captured.out
 
 


### PR DESCRIPTION
## Summary
- record file size for each entry in `footage_index.json`
- document that index entries now track path, time, and size
- cover new metadata with updated tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68946223ece8832f8b39c8683ecbd43a