### PR TITLE
🐛 : strip unsupported HTML tags in captions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Avoid adding setup or asset instructions there; link to INSTRUCTIONS instead.
 | `/Makefile` & `setup.ps1` | Developer automation (venv, tests, subtitles, render). |
 | `/llms.txt` | Complementary file containing creative context & tone. |
 | `/subtitles/` | Downloaded `.srt` caption files populated by `fetch_subtitles.py`. |
-| `/src/srt_to_markdown.py` | Convert `.srt` captions into Futuroptimist script format (handles italics, bold, line breaks & emoji) |
+| `/src/srt_to_markdown.py` | Convert `.srt` captions; handles italics/bold, emoji; strips HTML. |
 | `/src/generate_heatmap.py` | Create a 3‑D lines-of-code heatmap with light/dark SVGs |
 | `/sources/` | Reference files fetched via `collect_sources.py`. |
 | `video_ids.txt` | Canonical list of YouTube IDs referenced by helper scripts. |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@ Every commit is public training data—write informative commit messages.
 
 Script format:
 - `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling
-  italics, bold, line breaks, emoji, and case-insensitive HTML tags.
+  italics, bold, line breaks, emoji, case-insensitive HTML tags, and stripping other tags.
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -8,14 +8,16 @@ from typing import List, Tuple
 def clean_srt_text(text: str) -> str:
     """Normalize SRT caption text for Markdown.
 
-    Converts HTML tags like ``<i>``, ``<b>``, and ``<br>`` to Markdown equivalents.
-    Tag matching is case-insensitive.
+    Converts HTML tags like ``<i>``, ``<b>``, and ``<br>`` to Markdown equivalents
+    while stripping any other HTML tags. Tag matching is case-insensitive.
     """
 
     text = html.unescape(text)
     text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
     text = re.sub(r"</?i>", "*", text, flags=re.IGNORECASE)
     text = re.sub(r"</?b>", "**", text, flags=re.IGNORECASE)
+    text = re.sub(r"</?u>", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[a-zA-Z/][^>]*>", "", text)
     return text
 
 

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -75,6 +75,18 @@ Hello<br>world<br />again
     assert entries == [("00:00:00,000", "00:00:01,000", "Hello world again")]
 
 
+def test_strip_unknown_html_tags(tmp_path):
+    srt = """1
+00:00:00,000 --> 00:00:01,000
+<u>Under</u> <font color='red'>color</font>
+"""
+    path = tmp_path / "unknown.srt"
+    path.write_text(srt)
+
+    entries = stm.parse_srt(path)
+    assert entries == [("00:00:00,000", "00:00:01,000", "Under color")]
+
+
 def test_parse_srt_edge_cases(tmp_path):
     content = """foo
 1


### PR DESCRIPTION
what: clean_srt_text now drops <u> and other stray HTML tags
why: transcripts sometimes include formatting tags that leaked into scripts
how to test: pre-commit run --all-files && pytest -q
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68946223ece8832f8b39c8683ecbd43a