### PR TITLE
✨ feat: show repo CI status in README

### DIFF
--- a/.github/workflows/update-repo-status.yml
+++ b/.github/workflows/update-repo-status.yml
@@ -1,0 +1,29 @@
+name: Update Repo Statuses
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install deps
+        run: uv pip install --system -r requirements.txt
+      - name: Update README
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python src/repo_status.py
+      - name: Commit changes
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add README.md
+          git commit -m 'docs: update repo statuses' || exit 0
+          git push

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md). The automated tests run via GitHub Actions on each push and pull request and currently reach **100%** coverage.
 
 ## Related Projects
-- **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
-- **[DSPACE](https://democratized.space)** – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace))
-- **[flywheel](https://github.com/futuroptimist/flywheel)** – opinionated boilerplate for reproducible CI and releases
-- **[gabriel](https://github.com/futuroptimist/gabriel)** – guardian-angel LLM that nudges safer digital hygiene
-- **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – bulk-copy files from nested dirs straight to your clipboard
-- **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker for repos and next steps
-- **[sigma](https://github.com/futuroptimist/sigma)** – open-source AI pin device
-- **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turn GitHub contributions into 3D-printable block models
-- **[wove](https://github.com/futuroptimist/wove)** – open-source toolkit for knitting and robotic looms
-- **[sugarkube](https://github.com/futuroptimist/sugarkube)** – accessible k3s platform for off-grid Raspberry Pi clusters
+- ❌ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
+- ❌ **[DSPACE](https://democratized.space)** – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace))
+- ✅ **[flywheel](https://github.com/futuroptimist/flywheel)** – opinionated boilerplate for reproducible CI and releases
+- ✅ **[gabriel](https://github.com/futuroptimist/gabriel)** – guardian-angel LLM that nudges safer digital hygiene
+- ❌ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – bulk-copy files from nested dirs straight to your clipboard
+- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker for repos and next steps
+- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source AI pin device
+- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turn GitHub contributions into 3D-printable block models
+- ✅ **[wove](https://github.com/futuroptimist/wove)** – open-source toolkit for knitting and robotic looms
+- ✅ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – accessible k3s platform for off-grid Raspberry Pi clusters
 
 ## Values
 

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -1,0 +1,68 @@
+"""Update README with repo status emojis.
+
+Fetches the latest GitHub Actions run for each repo listed in the README's
+"Related Projects" section and prepends a green check or red cross depending on
+whether the most recent workflow run on the default branch succeeded.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import requests
+
+GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)")
+
+
+def status_to_emoji(conclusion: str | None) -> str:
+    """Return an emoji representing the run conclusion.
+
+    Parameters
+    ----------
+    conclusion:
+        The `conclusion` field from a workflow run, e.g. ``"success"`` or
+        ``"failure"``. ``None`` indicates no runs or an in-progress run.
+    """
+
+    return "✅" if conclusion == "success" else "❌"
+
+
+def fetch_repo_status(repo: str, token: str | None = None) -> str:
+    """Fetch the latest workflow run conclusion for ``repo`` and return an emoji."""
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=1"
+    resp = requests.get(url, headers=headers, timeout=10)
+    resp.raise_for_status()
+    runs = resp.json().get("workflow_runs", [])
+    conclusion = runs[0].get("conclusion") if runs else None
+    return status_to_emoji(conclusion)
+
+
+def update_readme(readme_path: Path, token: str | None = None) -> None:
+    """Update README with status emojis for related project repos."""
+    lines = readme_path.read_text().splitlines()
+    in_section = False
+    for i, line in enumerate(lines):
+        if line.strip() == "## Related Projects":
+            in_section = True
+            continue
+        if in_section and line.startswith("## "):
+            break
+        if in_section and line.startswith("- "):
+            match = GITHUB_RE.search(line)
+            if match:
+                repo = f"{match.group(1)}/{match.group(2)}"
+                emoji = fetch_repo_status(repo, token)
+                # remove existing emoji
+                lines[i] = re.sub(r"^(-\s*)(?:✅|❌)?\s*", r"\1", line)
+                lines[i] = f"- {emoji} {lines[i][2:].lstrip()}"
+    readme_path.write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    token = os.environ.get("GITHUB_TOKEN")
+    update_readme(Path(__file__).resolve().parent.parent / "README.md", token)

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+from src import repo_status
+from src.repo_status import status_to_emoji
+
+
+def test_status_to_emoji() -> None:
+    assert status_to_emoji("success") == "✅"
+    assert status_to_emoji("failure") == "❌"
+    assert status_to_emoji(None) == "❌"
+
+
+class DummyResp:
+    def __init__(self, data: dict):
+        self._data = data
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no error path
+        pass
+
+    def json(self) -> dict:
+        return self._data
+
+
+def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        assert "Authorization" in headers
+        return DummyResp({"workflow_runs": [{"conclusion": "success"}]})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo", token="abc") == "✅"
+
+
+def test_fetch_repo_status_no_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        return DummyResp({"workflow_runs": []})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "❌"
+
+
+def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    content = (
+        "intro\n\n## Related Projects\n"
+        "- https://github.com/user/repo\n"
+        "- ❌ https://github.com/other/repo\n\n## Footer\n"
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(content)
+
+    def fake_status(repo: str, token: str | None = None) -> str:
+        return {"user/repo": "✅", "other/repo": "❌"}[repo]
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    repo_status.update_readme(readme)
+
+    lines = readme.read_text().splitlines()
+    assert lines[3] == "- ✅ https://github.com/user/repo"
+    assert lines[4] == "- ❌ https://github.com/other/repo"
+    assert lines[6] == "## Footer"


### PR DESCRIPTION
## Summary
- script to fetch latest workflow run and decorate README with emoji status
- scheduled action updates statuses every hour
- add tests for repo_status and exclude CLI entrypoint from coverage

## Testing
- `python -m black .`
- `ruff check --fix .`
- `pytest --cov=./src --cov=./tests`


------
https://chatgpt.com/codex/tasks/task_e_6895a1d4a868832f93c6790b3f15c2d2