### PR TITLE
🛠️ : handle branch-specific repo statuses in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md). The automated tests run via GitHub Actions on each push and pull request and currently reach **100%** coverage.
 
 ## Related Projects
-- ❌ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
-- ✅ **[DSPACE](https://democratized.space)** – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace))
+- ✅ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
+- ❌ **[DSPACE](https://democratized.space)** @v3 – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace/tree/v3))
 - ✅ **[flywheel](https://github.com/futuroptimist/flywheel)** – opinionated boilerplate for reproducible CI and releases
 - ✅ **[gabriel](https://github.com/futuroptimist/gabriel)** – guardian-angel LLM that nudges safer digital hygiene
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – bulk-copy files from nested dirs straight to your clipboard
+- ❌ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – bulk-copy files from nested dirs straight to your clipboard
 - ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker for repos and next steps
 - ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source AI pin device
 - ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turn GitHub contributions into 3D-printable block models
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – open-source toolkit for knitting and robotic looms
+- ❌ **[wove](https://github.com/futuroptimist/wove)** – open-source toolkit for knitting and robotic looms
 - ✅ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – accessible k3s platform for off-grid Raspberry Pi clusters
 
 ## Values

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -44,12 +44,17 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     content = (
         "intro\n\n## Related Projects\n"
         "- https://github.com/user/repo\n"
-        "- ❌ https://github.com/other/repo\n\n## Footer\n"
+        "- ❌ https://github.com/other/repo/tree/dev\n\n## Footer\n"
     )
     readme = tmp_path / "README.md"
     readme.write_text(content)
 
-    def fake_status(repo: str, token: str | None = None) -> str:
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_status(
+        repo: str, token: str | None = None, branch: str | None = None
+    ) -> str:
+        calls.append((repo, branch))
         return {"user/repo": "✅", "other/repo": "❌"}[repo]
 
     monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
@@ -57,5 +62,6 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "- ✅ https://github.com/user/repo"
-    assert lines[4] == "- ❌ https://github.com/other/repo"
+    assert lines[4] == "- ❌ https://github.com/other/repo/tree/dev"
     assert lines[6] == "## Footer"
+    assert calls == [("user/repo", None), ("other/repo", "dev")]


### PR DESCRIPTION
what: add optional branch query to repo_status, correct project badges
why: DSPACE tracks v3 and several badge colors were wrong
how to test: pre-commit run --files README.md src/repo_status.py
  tests/test_repo_status.py && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6895a6d42d94832f977aeb2e9e5e1d05