### PR TITLE
🐛 : ignore in-progress workflow runs for repo status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md). The automated tests run via GitHub Actions on each push and pull request and currently reach **100%** coverage.
 
 ## Related Projects
-- ❌ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
+- ✅ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
 - ❌ **[DSPACE](https://democratized.space)** @v3 – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace/tree/v3))
 - ✅ **[flywheel](https://github.com/futuroptimist/flywheel)** – opinionated boilerplate for reproducible CI and releases
 - ✅ **[gabriel](https://github.com/futuroptimist/gabriel)** – guardian-angel LLM that nudges safer digital hygiene
@@ -19,7 +19,7 @@ Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTub
 - ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker for repos and next steps
 - ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source AI pin device
 - ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turn GitHub contributions into 3D-printable block models
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – open-source toolkit for knitting and robotic looms
+- ❌ **[wove](https://github.com/futuroptimist/wove)** – open-source toolkit for knitting and robotic looms
 - ✅ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – accessible k3s platform for off-grid Raspberry Pi clusters
 
 ## Values

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -36,9 +36,13 @@ def fetch_repo_status(
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=1"
+
+    url = "https://api.github.com/repos/{repo}/actions/runs?per_page=1&status=completed".format(
+        repo=repo
+    )
     if branch:
         url += f"&branch={branch}"
+
     resp = requests.get(url, headers=headers, timeout=10)
     resp.raise_for_status()
     runs = resp.json().get("workflow_runs", [])

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -25,6 +25,9 @@ class DummyResp:
 
 def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed"
+        )
         assert "Authorization" in headers
         return DummyResp({"workflow_runs": [{"conclusion": "success"}]})
 
@@ -34,6 +37,9 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_fetch_repo_status_no_runs(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed"
+        )
         return DummyResp({"workflow_runs": []})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
@@ -41,12 +47,20 @@ def test_fetch_repo_status_no_runs(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
     def fake_get(url: str, headers: dict, timeout: int):
-        assert url.endswith("&branch=dev")
+        calls.append(url)
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev"
+        )
         return DummyResp({"workflow_runs": [{"conclusion": "success"}]})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
+    assert calls == [
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev"
+    ]
 
 
 def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
what: query only completed workflow runs when updating repo status emojis
why: avoid red/green misreports when a run is still in progress
how: npm run lint (fails: missing package.json); npm run test:ci (fails: missing package.json); ruff check .; black --check .; pytest --cov=./src --cov=./tests; git diff --cached | ./scripts/scan-secrets.py (fails: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_6895ac95c178832f95d35dcfc76d692c