### PR TITLE
🔐 support token file for GitHub auth

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -40,7 +40,9 @@ pre-commit install  # optional: run hooks (formatters + heatmap check) on commit
 
 Some helper scripts require a GitHub token to access the GraphQL API. Export
 `GH_TOKEN` (or `GITHUB_TOKEN`) with a personal access token that includes `repo`
-and `read:org` scopes when generating heatmaps or fetching commit stats.
+and `read:org` scopes when generating heatmaps or fetching commit stats. You may
+also set `GH_TOKEN_FILE` or `GITHUB_TOKEN_FILE` to point at a file containing
+the token.
 
 Create new script folders from the IDs in `video_ids.txt`:
 

--- a/src/github_auth.py
+++ b/src/github_auth.py
@@ -3,17 +3,33 @@
 from __future__ import annotations
 
 import os
+import pathlib
+
+
+def _read_token_file(var: str) -> str | None:
+    path = os.getenv(var)
+    if not path:
+        return None
+    try:
+        return pathlib.Path(path).read_text()
+    except OSError:
+        return None
 
 
 def get_github_token() -> str:
-    """Return an API token from ``GH_TOKEN`` or ``GITHUB_TOKEN`` env vars.
+    """Return an API token from env vars or file paths.
 
-    Leading and trailing whitespace is stripped to avoid accidental newline
-    characters; a blank token raises ``EnvironmentError``.
+    ``GH_TOKEN`` takes precedence, followed by ``GH_TOKEN_FILE``,
+    ``GITHUB_TOKEN`` and ``GITHUB_TOKEN_FILE``. Leading/trailing whitespace is
+    stripped and a blank token raises ``EnvironmentError``.
     """
-    token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+
+    token = os.getenv("GH_TOKEN") or _read_token_file("GH_TOKEN_FILE")
+    token = token or os.getenv("GITHUB_TOKEN") or _read_token_file("GITHUB_TOKEN_FILE")
     if token is None:
-        raise EnvironmentError("GH_TOKEN or GITHUB_TOKEN must be set")
+        raise EnvironmentError(
+            "GH_TOKEN/GH_TOKEN_FILE or GITHUB_TOKEN/GITHUB_TOKEN_FILE must be set"
+        )
     token = token.strip()
     if not token:
         raise EnvironmentError("GitHub token cannot be blank")

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -3,6 +3,12 @@ import pytest
 from src.github_auth import get_github_token
 
 
+@pytest.fixture(autouse=True)
+def clear_token_file_env(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN_FILE", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN_FILE", raising=False)
+
+
 def test_get_token_prefers_gh_token(monkeypatch):
     monkeypatch.setenv("GH_TOKEN", "a")
     monkeypatch.setenv("GITHUB_TOKEN", "b")
@@ -31,3 +37,31 @@ def test_get_token_rejects_blank(monkeypatch):
     monkeypatch.setenv("GH_TOKEN", "  \n\t")
     with pytest.raises(EnvironmentError):
         get_github_token()
+
+
+def test_get_token_from_file(monkeypatch, tmp_path):
+    token_file = tmp_path / "token.txt"
+    token_file.write_text("filetoken\n")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN_FILE", str(token_file))
+    assert get_github_token() == "filetoken"
+
+
+def test_file_precedence_over_github_token(monkeypatch, tmp_path):
+    token_file = tmp_path / "token.txt"
+    token_file.write_text("filetoken")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("GITHUB_TOKEN", "envtoken")
+    assert get_github_token() == "filetoken"
+
+
+def test_github_token_file_fallback(monkeypatch, tmp_path):
+    token_file = tmp_path / "token.txt"
+    token_file.write_text("filetoken")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN_FILE", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN_FILE", str(token_file))
+    assert get_github_token() == "filetoken"


### PR DESCRIPTION
## Summary
- allow `get_github_token` to read from `GH_TOKEN_FILE` or `GITHUB_TOKEN_FILE`
- document token file env vars in instructions
- test token file fallback and precedence

## Testing
- `pre-commit run --all-files`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896cd7d3934832fa0f772cda24aa768