### PR TITLE
🐛 : normalize non-breaking spaces in captions

### DIFF
--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -10,9 +10,10 @@ def clean_srt_text(text: str) -> str:
 
     Converts HTML tags like ``<i>``, ``<b>``, and ``<br>`` to Markdown equivalents
     while stripping any other HTML tags. Tag matching is case-insensitive.
+    Non-breaking spaces (``&nbsp;``) are converted to regular spaces.
     """
 
-    text = html.unescape(text)
+    text = html.unescape(text).replace("\xa0", " ")
     text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
     text = re.sub(r"</?i>", "*", text, flags=re.IGNORECASE)
     text = re.sub(r"</?b>", "**", text, flags=re.IGNORECASE)

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -75,6 +75,18 @@ Hello<br>world<br />again
     assert entries == [("00:00:00,000", "00:00:01,000", "Hello world again")]
 
 
+def test_nbsp_entities(tmp_path):
+    srt = """1
+00:00:00,000 --> 00:00:01,000
+Hello&nbsp;world
+"""
+    path = tmp_path / "nbsp.srt"
+    path.write_text(srt)
+
+    entries = stm.parse_srt(path)
+    assert entries == [("00:00:00,000", "00:00:01,000", "Hello world")]
+
+
 def test_strip_unknown_html_tags(tmp_path):
     srt = """1
 00:00:00,000 --> 00:00:01,000


### PR DESCRIPTION
## Summary
- replace non-breaking spaces when cleaning SRT captions
- cover &nbsp; entities with a regression test

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896cd7d3934832fa0f772cda24aa768