### PR TITLE
🧪 : – cover missing token file

### DIFF
--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -65,3 +65,11 @@ def test_github_token_file_fallback(monkeypatch, tmp_path):
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("GITHUB_TOKEN_FILE", str(token_file))
     assert get_github_token() == "filetoken"
+
+
+def test_missing_token_file_uses_env(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.txt"
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN_FILE", str(missing))
+    monkeypatch.setenv("GITHUB_TOKEN", "b")
+    assert get_github_token() == "b"


### PR DESCRIPTION
Add test for missing GH_TOKEN_FILE to trigger OSError branch.
Ensures fallback to GITHUB_TOKEN.
Test: pytest --cov=./src --cov=./tests
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896e2791f50832f8649b90744157d9a