### PR TITLE
✨ Support attributes in SRT bold and italic tags

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,8 @@ Every commit is public training data—write informative commit messages.
 
 Script format:
 - `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling
-  italics, bold, line breaks, emoji, case-insensitive HTML tags, and stripping other tags.
+  italics and bold (even when tags include attributes), line breaks, emoji,
+  case-insensitive HTML tags, and stripping other tags.
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -8,16 +8,17 @@ from typing import List, Tuple
 def clean_srt_text(text: str) -> str:
     """Normalize SRT caption text for Markdown.
 
-    Converts HTML tags like ``<i>``, ``<b>``, and ``<br>`` to Markdown equivalents
-    while stripping any other HTML tags. Tag matching is case-insensitive.
+    Converts HTML tags like ``<i>``, ``<b>`` (with optional attributes), and ``<br>``
+    to Markdown equivalents while stripping any other HTML tags. Tag matching is
+    case-insensitive.
     Non-breaking spaces (``&nbsp;``) are converted to regular spaces.
     """
 
     text = html.unescape(text).replace("\xa0", " ")
     text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
-    text = re.sub(r"</?i>", "*", text, flags=re.IGNORECASE)
-    text = re.sub(r"</?b>", "**", text, flags=re.IGNORECASE)
-    text = re.sub(r"</?u>", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"</?i\b[^>]*>", "*", text, flags=re.IGNORECASE)
+    text = re.sub(r"</?b\b[^>]*>", "**", text, flags=re.IGNORECASE)
+    text = re.sub(r"</?u\b[^>]*>", "", text, flags=re.IGNORECASE)
     text = re.sub(r"<[a-zA-Z/][^>]*>", "", text)
     return text
 

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -99,6 +99,18 @@ def test_strip_unknown_html_tags(tmp_path):
     assert entries == [("00:00:00,000", "00:00:01,000", "Under color")]
 
 
+def test_tags_with_attributes(tmp_path):
+    srt = """1
+00:00:00,000 --> 00:00:01,000
+<i class='x'>Hi</i> <b style="color:red">there</b>
+"""
+    path = tmp_path / "attr.srt"
+    path.write_text(srt)
+
+    entries = stm.parse_srt(path)
+    assert entries == [("00:00:00,000", "00:00:01,000", "*Hi* **there**")]
+
+
 def test_parse_srt_edge_cases(tmp_path):
     content = """foo
 1


### PR DESCRIPTION
## Summary
- handle <i>/<b> tags with attributes in srt_to_markdown
- test conversion of attribute-rich tags
- document attribute support for caption tags

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896eab31b58832fb11e19b1e1c85e58