### PR TITLE
🐛 : distinguish missing GitHub run from failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ). If you're looking for the full project details, see [INSTRUCTIONS.md](INSTRUCTIONS.md). Guidelines for AI tools live in [AGENTS.md](AGENTS.md). The automated tests run via GitHub Actions on each push and pull request and currently reach **100%** coverage.
 
 ## Related Projects
+Status icons: ✅ latest run succeeded, ❌ failed, ❓ no completed runs.
 - ❌ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
 - ❌ **[DSPACE](https://democratized.space)** @v3 – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace/tree/v3))
 - ✅ **[flywheel](https://github.com/futuroptimist/flywheel)** – opinionated boilerplate for reproducible CI and releases

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -1,8 +1,9 @@
 """Update README with repo status emojis.
 
 Fetches the latest GitHub Actions run for each repo listed in the README's
-"Related Projects" section and prepends a green check or red cross depending on
-whether the most recent workflow run on the default branch succeeded.
+"Related Projects" section and prepends a green check, red cross, or question
+mark depending on whether the most recent workflow run on the default branch
+completed successfully, failed, or hasn't completed.
 """
 
 from __future__ import annotations
@@ -23,10 +24,13 @@ def status_to_emoji(conclusion: str | None) -> str:
     ----------
     conclusion:
         The `conclusion` field from a workflow run, e.g. ``"success"`` or
-        ``"failure"``. ``None`` indicates no runs or an in-progress run.
+        ``"failure"``. ``None`` indicates no completed runs.
     """
-
-    return "✅" if conclusion == "success" else "❌"
+    if conclusion == "success":
+        return "✅"
+    if conclusion is None:
+        return "❓"
+    return "❌"
 
 
 def fetch_repo_status(

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -9,7 +9,7 @@ from src.repo_status import status_to_emoji
 def test_status_to_emoji() -> None:
     assert status_to_emoji("success") == "✅"
     assert status_to_emoji("failure") == "❌"
-    assert status_to_emoji(None) == "❌"
+    assert status_to_emoji(None) == "❓"
 
 
 class DummyResp:
@@ -43,7 +43,7 @@ def test_fetch_repo_status_no_runs(monkeypatch: pytest.MonkeyPatch) -> None:
         return DummyResp({"workflow_runs": []})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
-    assert repo_status.fetch_repo_status("user/repo") == "❌"
+    assert repo_status.fetch_repo_status("user/repo") == "❓"
 
 
 def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- show ❓ when repo has no completed workflows
- document status icon meanings in README
- test repo status handling for empty workflow runs

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896eab31b58832fb11e19b1e1c85e58