### PR TITLE
🛠️ : add repo status check for self and harden script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my [YouTub
 
 ## Related Projects
 Status icons: ✅ latest run succeeded, ❌ failed, ❓ no completed runs.
+- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – scripts and metadata for the channel
 - ❌ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
 - ❌ **[DSPACE](https://democratized.space)** @v3 – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace/tree/v3))
 - ✅ **[flywheel](https://github.com/futuroptimist/flywheel)** – opinionated boilerplate for reproducible CI and releases


### PR DESCRIPTION
## Summary
- link this repository in README related projects so CI status emoji shows
- verify workflow status deterministically and scrub existing emojis when updating README
- test status fetching retries and failure on non-determinism

## Testing
- `python -m black src tests`
- `python -m ruff check --fix src tests`
- `detect-secrets scan /tmp/diff.patch`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990f8015d8832fa1f85f010fd8d661