### PR TITLE
✨ support <em>/<strong> in srt_to_markdown

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -18,8 +18,8 @@ Every commit is public training data—write informative commit messages.
 
 Script format:
 - `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling
-  italics and bold (even when tags include attributes), line breaks, emoji,
-  case-insensitive HTML tags, and stripping other tags.
+  italics and bold tags (`<i>/<em>` and `<b>/<strong>`, even with attributes), line breaks,
+  emoji, case-insensitive HTML tags, and stripping other tags.
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -8,16 +8,16 @@ from typing import List, Tuple
 def clean_srt_text(text: str) -> str:
     """Normalize SRT caption text for Markdown.
 
-    Converts HTML tags like ``<i>``, ``<b>`` (with optional attributes), and ``<br>``
-    to Markdown equivalents while stripping any other HTML tags. Tag matching is
-    case-insensitive.
+    Converts HTML tags like ``<i>``, ``<em>``, ``<b>``, ``<strong>`` (with optional
+    attributes), and ``<br>`` to Markdown equivalents while stripping any other HTML
+    tags. Tag matching is case-insensitive.
     Non-breaking spaces (``&nbsp;``) are converted to regular spaces.
     """
 
     text = html.unescape(text).replace("\xa0", " ")
     text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
-    text = re.sub(r"</?i\b[^>]*>", "*", text, flags=re.IGNORECASE)
-    text = re.sub(r"</?b\b[^>]*>", "**", text, flags=re.IGNORECASE)
+    text = re.sub(r"</?(i|em)\b[^>]*>", "*", text, flags=re.IGNORECASE)
+    text = re.sub(r"</?(b|strong)\b[^>]*>", "**", text, flags=re.IGNORECASE)
     text = re.sub(r"</?u\b[^>]*>", "", text, flags=re.IGNORECASE)
     text = re.sub(r"<[a-zA-Z/][^>]*>", "", text)
     return text

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -63,6 +63,18 @@ def test_uppercase_tags(tmp_path):
     assert entries == [("00:00:00,000", "00:00:01,000", "*Hello* **World**")]
 
 
+def test_em_and_strong_tags(tmp_path):
+    srt = """1
+00:00:00,000 --> 00:00:01,000
+<em>Hello</em> <strong>World</strong>
+"""
+    path = tmp_path / "emstrong.srt"
+    path.write_text(srt)
+
+    entries = stm.parse_srt(path)
+    assert entries == [("00:00:00,000", "00:00:01,000", "*Hello* **World**")]
+
+
 def test_line_break_tags(tmp_path):
     srt = """1
 00:00:00,000 --> 00:00:01,000


### PR DESCRIPTION
## Summary
- handle `<em>` and `<strong>` tags when converting captions to Markdown
- document the new HTML support for contributors

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68991688fa3c832f8db4767fed32ae6c