### PR TITLE
📝 : add draft script support and update prompt

### DIFF
--- a/docs/prompts-codex-video-script.md
+++ b/docs/prompts-codex-video-script.md
@@ -15,7 +15,8 @@ PURPOSE:
 Turn transcripts or ideas into properly formatted video scripts.
 
 CONTEXT:
-- Each script lives under `video_scripts/YYYYMMDD_slug/`.
+- Early drafts live under `video_scripts/drafts/slug/` to avoid implying a release date.
+- Finalized scripts move to `video_scripts/YYYYMMDD_slug/`.
 - `script.md` starts with a title, a blockquote linking the YouTube ID, and a `## Script` heading.
 - Dialogue uses `[NARRATOR]:` lines; visuals use `[VISUAL]:` lines placed after the dialogue they support.
 - Leave a blank line between narration and visual lines.
@@ -24,7 +25,7 @@ CONTEXT:
 - Run `pre-commit run --all-files` and `pytest -q` before committing.
 
 REQUEST:
-1. Create a new `video_scripts/{date}_{slug}/` folder.
+1. Create a new `video_scripts/drafts/{slug}/` folder for the draft.
 2. Write `script.md` and `metadata.json` following the format above.
 3. Include `sources.txt` when helpful.
 4. Ensure all required commands pass.

--- a/tests/test_folder_names.py
+++ b/tests/test_folder_names.py
@@ -3,9 +3,17 @@ import re
 
 
 def test_script_folder_naming():
-    pattern = re.compile(r"^\d{8}_[a-z0-9\-]+$")
+    final_pattern = re.compile(r"^\d{8}_[a-z0-9\-]+$")
+    draft_pattern = re.compile(r"^[a-z0-9\-]+$")
     for p in pathlib.Path("video_scripts").iterdir():
         if p.is_dir() and p.name != "__pycache__":
-            assert pattern.match(
-                p.name
-            ), f"Folder {p.name} does not match YYYYMMDD_slug convention"
+            if p.name == "drafts":
+                for d in p.iterdir():
+                    if d.is_dir():
+                        assert draft_pattern.match(
+                            d.name
+                        ), f"Draft folder {d.name} should be slug-only"
+            else:
+                assert final_pattern.match(
+                    p.name
+                ), f"Folder {p.name} does not match YYYYMMDD_slug convention"

--- a/video_scripts/drafts/solarpunk-weather-station/metadata.json
+++ b/video_scripts/drafts/solarpunk-weather-station/metadata.json
@@ -1,0 +1,6 @@
+{
+  "youtube_id": "draft",
+  "title": "Solarpunk Weather Station (Draft)",
+  "status": "draft",
+  "keywords": ["solarpunk", "weather", "sensor"]
+}

--- a/video_scripts/drafts/solarpunk-weather-station/script.md
+++ b/video_scripts/drafts/solarpunk-weather-station/script.md
@@ -1,0 +1,12 @@
+# Solarpunk Weather Station (Draft)
+> YouTube ID: draft
+
+## Script
+
+[NARRATOR]: Imagine checking your garden's weather with a sensor you built yourself.
+
+[VISUAL]: A small 3D-printed station sits among thriving plants.
+
+[NARRATOR]: Powered entirely by the sun, it keeps logging data even off-grid.
+
+[VISUAL]: Solar panel charges a tiny battery while graphs animate on screen.

--- a/video_scripts/drafts/solarpunk-weather-station/sources.txt
+++ b/video_scripts/drafts/solarpunk-weather-station/sources.txt
@@ -1,0 +1,1 @@
+https://maker.pro/arduino/tutorial/how-to-build-a-solar-powered-weather-station


### PR DESCRIPTION
## Summary
- allow storing early video scripts under video_scripts/drafts
- add initial "Solarpunk Weather Station" draft with metadata and sources
- steer script prompt toward draft naming

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689916f7f504832fad77cf8d7b281472