### PR TITLE
🛠️: fix Codecov badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/futuroptimist/actions/workflows/01-lint-format.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/futuroptimist/actions/workflows/02-tests.yml)
-[![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/futuroptimist)
+[![Coverage](https://codecov.io/github/futuroptimist/futuroptimist/coverage.svg?branch=main)](https://app.codecov.io/github/futuroptimist/futuroptimist?branch=main)
 [![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
 [![License](https://img.shields.io/github/license/futuroptimist/futuroptimist)](LICENSE)
 


### PR DESCRIPTION
what: switch README's coverage badge to Codecov's new endpoint.
why: previous badge rendered "unknown" despite valid coverage.
how to test: view README and confirm coverage badge shows percentage.


------
https://chatgpt.com/codex/tasks/task_e_68998403b784832f9e457401db6ece01