### PR TITLE
📝 : fix Codecov badge path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/futuroptimist/actions/workflows/01-lint-format.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/futuroptimist/actions/workflows/02-tests.yml)
-[![Coverage](https://codecov.io/github/futuroptimist/futuroptimist/coverage.svg?branch=main)](https://app.codecov.io/github/futuroptimist/futuroptimist?branch=main)
+[![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://app.codecov.io/gh/futuroptimist/futuroptimist/branch/main)
 [![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
 [![License](https://img.shields.io/github/license/futuroptimist/futuroptimist)](LICENSE)
 


### PR DESCRIPTION
what: update README badge to new Codecov URL so coverage displays
why: old coverage.svg path returned unknown coverage
how to test:
- pre-commit run black --files README.md
- pre-commit run ruff --files README.md
- pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689a9cf3d074832f860eb485457920b8