### PR TITLE
Add URL scheme checks and security scanners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,26 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      matrix:
+        language: [python]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 [![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://app.codecov.io/gh/futuroptimist/futuroptimist/branch/main)
 [![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
 [![License](https://img.shields.io/github/license/futuroptimist/futuroptimist)](LICENSE)
+[![Dependabot](https://img.shields.io/badge/Dependabot-enabled-brightgreen?logo=dependabot)](https://github.com/futuroptimist/futuroptimist/security/dependabot)
+[![CodeQL](https://github.com/futuroptimist/futuroptimist/actions/workflows/codeql.yml/badge.svg)](https://github.com/futuroptimist/futuroptimist/actions/workflows/codeql.yml)
+[![Secret Scanning](https://img.shields.io/badge/secret%20scanning-enabled-brightgreen?logo=github)](https://docs.github.com/en/code-security/secret-scanning)
 
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my
 [YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ).

--- a/src/collect_sources.py
+++ b/src/collect_sources.py
@@ -15,7 +15,10 @@ def download_url(url: str, dest: pathlib.Path) -> bool:
     Returns ``True`` on success and ``False`` if the request fails.
     """
     try:
-        with urllib.request.urlopen(url) as resp:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError(f"unsupported URL scheme: {parsed.scheme}")
+        with urllib.request.urlopen(url) as resp:  # noqa: S310  # nosec B310
             dest.write_bytes(resp.read())
         return True
     except urllib.error.URLError as exc:

--- a/src/scaffold_videos.py
+++ b/src/scaffold_videos.py
@@ -2,6 +2,7 @@ import json
 import pathlib
 import sys
 import urllib.request
+import urllib.parse
 import re
 import datetime
 
@@ -48,7 +49,11 @@ def slugify(text: str) -> str:
 def fetch_video_info(video_id: str):
     url = f"https://r.jina.ai/https://www.youtube.com/watch?v={video_id}"
     req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-    html = urllib.request.urlopen(req).read().decode("utf-8", "ignore")
+    parsed = urllib.parse.urlparse(req.full_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("unsupported URL scheme")
+    response = urllib.request.urlopen(req)  # noqa: S310  # nosec B310
+    html = response.read().decode("utf-8", "ignore")
     title_match = re.search(r"^Title: (.+)", html, re.MULTILINE)
     date_match = re.search(r"([A-Z][a-z]+ [0-9]{1,2}, [0-9]{4})", html)
     if not (title_match and date_match):

--- a/tests/test_collect_sources.py
+++ b/tests/test_collect_sources.py
@@ -1,5 +1,6 @@
 import json
 import urllib.request
+import pytest
 import src.collect_sources as cs
 
 
@@ -33,6 +34,11 @@ def test_download_url_success(monkeypatch, tmp_path):
     result = cs.download_url("http://example.com/out.txt", dest)
     assert result is True
     assert dest.read_bytes() == b"hi"
+
+
+def test_download_url_rejects_bad_scheme(tmp_path):
+    with pytest.raises(ValueError):
+        cs.download_url("file:///etc/passwd", tmp_path / "out.txt")
 
 
 def test_process_video_dir_and_main(monkeypatch, tmp_path):

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -58,6 +58,17 @@ def test_fetch_video_info_parses(monkeypatch):
     assert date == "20240102"
 
 
+def test_fetch_video_info_rejects_bad_scheme(monkeypatch):
+    class DummyReq:
+        full_url = "file://bad"
+
+    monkeypatch.setattr(
+        sv.urllib.request, "Request", lambda url, headers=None: DummyReq
+    )
+    with pytest.raises(ValueError):
+        sv.fetch_video_info("abc")
+
+
 def test_fetch_video_info_error(monkeypatch):
     class Resp:
         def __enter__(self):

--- a/tests/test_update_transcript_links.py
+++ b/tests/test_update_transcript_links.py
@@ -130,3 +130,11 @@ def test_fetch_transcript_failure(monkeypatch, capsys):
     assert utl.fetch_transcript("XYZ") is None
     captured = capsys.readouterr()
     assert "failed to fetch transcript" in captured.out
+
+
+def test_fetch_transcript_rejects_bad_scheme(monkeypatch, capsys):
+    monkeypatch.setattr(utl, "API_KEY", "X")
+    monkeypatch.setattr(utl, "LIST_URL", "file://{vid}?key={key}")
+    assert utl.fetch_transcript("XYZ") is None
+    captured = capsys.readouterr()
+    assert "unsupported URL scheme" in captured.out


### PR DESCRIPTION
## Summary
- validate URL schemes before urllib requests
- add CodeQL and Dependabot config with badges

## Testing
- `pytest -q`
- `bandit -r tokenplace -lll`
- `bandit -r src -ll`


------
https://chatgpt.com/codex/tasks/task_e_689c24f85f74832fab7c01622a9ffa04