### PR TITLE
Handle neutral workflow statuses gracefully

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -20,17 +20,15 @@ GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+
 def status_to_emoji(conclusion: str | None) -> str:
     """Return an emoji representing the run conclusion.
 
-    Parameters
-    ----------
-    conclusion:
-        The `conclusion` field from a workflow run, e.g. ``"success"`` or
-        ``"failure"``. ``None`` indicates no completed runs.
+    - ``"success"`` → ✅
+    - ``"failure"`` → ❌
+    - anything else (including ``None``) → ❓
     """
     if conclusion == "success":
         return "✅"
-    if conclusion is None:
-        return "❓"
-    return "❌"
+    if conclusion == "failure":
+        return "❌"
+    return "❓"
 
 
 def fetch_repo_status(

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -10,6 +10,7 @@ def test_status_to_emoji() -> None:
     assert status_to_emoji("success") == "✅"
     assert status_to_emoji("failure") == "❌"
     assert status_to_emoji(None) == "❓"
+    assert status_to_emoji("neutral") == "❓"
 
 
 class DummyResp:


### PR DESCRIPTION
## Summary
- treat unknown GitHub workflow conclusions as neutral
- document status-to-emoji mapping

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c24f419e0832fbb72afb7cc7d84fd