### PR TITLE
🐛 : ensure sources.json ends with newline

### DIFF
--- a/src/collect_sources.py
+++ b/src/collect_sources.py
@@ -43,7 +43,7 @@ def process_video_dir(video_dir: pathlib.Path) -> None:
         if dest.exists() or download_url(url, dest):
             mapping[url] = dest.name
 
-    (video_dir / "sources.json").write_text(json.dumps(mapping, indent=2))
+    (video_dir / "sources.json").write_text(json.dumps(mapping, indent=2) + "\n")
 
 
 def main() -> None:

--- a/tests/test_collect_sources.py
+++ b/tests/test_collect_sources.py
@@ -84,3 +84,19 @@ def test_cli_entrypoint(monkeypatch, tmp_path):
     fake_process(d)  # ensure line coverage
     runpy.run_module("src.collect_sources", run_name="__main__")
     assert called
+
+
+def test_sources_json_has_trailing_newline(monkeypatch, tmp_path):
+    vid_dir = tmp_path / "20250101_newline"
+    vid_dir.mkdir()
+    (vid_dir / "sources.txt").write_text("http://example.com/a.txt\n")
+
+    def fake_download(url, dest):
+        dest.write_text("data")
+        return True
+
+    monkeypatch.setattr(cs, "download_url", fake_download)
+    cs.process_video_dir(vid_dir)
+
+    content = (vid_dir / "sources.json").read_text()
+    assert content.endswith("\n")


### PR DESCRIPTION
what: write trailing newline to sources.json for POSIX compliance
why: avoid noisy diffs and honour repo style guide
how to test:
- pre-commit run --all-files
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_689c24f419e0832fbb72afb7cc7d84fd