### PR TITLE
Add user agent to collect_sources downloads

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -79,7 +79,7 @@ The goal: turn this repo into a self-reinforcing engine that **accelerates Futur
 | 6️⃣  Community | • GitHub Discussions integration for crowdsourced fact-checks.<br>• Scheduled newsletter builder that stitches new scripts + links. | Audience feedback loop |
 | 7️⃣  Production Pipeline | • Adopt OpenTimelineIO as canonical timeline format.<br>• Asset manifest (audio, b-roll, gfx) auto-generated from `videos/<id>` folders.<br>• FFmpeg rendering scripts for rough-cut assembly and caption burn-in.<br>• CLI wrapper `make render VIDEO=xyz` → `dist/xyz.mp4`. | End-to-end reproducible builds |
 | 8️⃣  Publish Orchestration | • YouTube Data API V3 upload endpoint (draft/private).<br>• Automatic thumbnail + metadata attach from repo files.<br>• Post-publish annotation back into metadata.json (video url, processing times). | One-command release |
-| 9️⃣  Source Archival | • `collect_sources.py` downloads HTML/mp4 references from `sources.txt` into `sources/` subfolders.<br>• `sources.json` maps URLs to filenames for easy citation. | Reliable citation & reproducibility |
+| 9️⃣  Source Archival | • `collect_sources.py` downloads HTML/mp4 references from `sources.txt` into `sources/` subfolders with a friendly `User-Agent`.<br>• `sources.json` maps URLs to filenames for easy citation. | Reliable citation & reproducibility |
 
 *(Tick items as we progress!)*
 

--- a/src/collect_sources.py
+++ b/src/collect_sources.py
@@ -7,6 +7,7 @@ import sys
 
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 VIDEO_ROOT = BASE_DIR / "video_scripts"
+USER_AGENT = "futuroptimist-bot/1.0"
 
 
 def download_url(url: str, dest: pathlib.Path) -> bool:
@@ -15,7 +16,8 @@ def download_url(url: str, dest: pathlib.Path) -> bool:
     Returns ``True`` on success and ``False`` if the request fails.
     """
     try:
-        with urllib.request.urlopen(url) as resp:
+        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        with urllib.request.urlopen(req) as resp:
             dest.write_bytes(resp.read())
         return True
     except urllib.error.URLError as exc:


### PR DESCRIPTION
## Summary
- send a friendly User-Agent when collecting sources to avoid blocked downloads
- note the User-Agent behavior in instructions

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c24f419e0832fbb72afb7cc7d84fd