### PR TITLE
🔄 : rebase before pushing repo status updates

### DIFF
--- a/.github/workflows/update-repo-status.yml
+++ b/.github/workflows/update-repo-status.yml
@@ -26,4 +26,5 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add README.md
           git commit -m 'docs: update repo statuses' || exit 0
+          git pull --rebase origin main
           git push


### PR DESCRIPTION
what: rebase main before pushing README changes
why: avoid push rejects when main advances
how to test: pytest --cov=./src --cov=./tests --cov-report=xml
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d58a3a190832f8e8342af4336c4e6