### PR TITLE
✅ : ensure repo status uses default branch

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -48,9 +48,16 @@ def fetch_repo_status(
     if token:
         headers["Authorization"] = f"Bearer {token}"
 
-    url = "https://api.github.com/repos/{repo}/actions/runs?per_page=1&status=completed".format(
-        repo=repo
-    )
+    if branch is None:
+        repo_resp = requests.get(
+            f"https://api.github.com/repos/{repo}", headers=headers, timeout=10
+        )
+        repo_resp.raise_for_status()
+        branch = repo_resp.json().get("default_branch")
+
+    url = (
+        "https://api.github.com/repos/{repo}/actions/runs?per_page=1&status=completed&event=push"
+    ).format(repo=repo)
     if branch:
         url += f"&branch={branch}"
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -29,8 +29,10 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
         assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed"
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push&branch=main"
         )
         assert "Authorization" in headers
         return DummyResp({"workflow_runs": [{"conclusion": "success"}]})
@@ -38,8 +40,9 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", token="abc") == "✅"
     assert calls == [
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
+        "https://api.github.com/repos/user/repo",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push&branch=main",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push&branch=main",
     ]
 
 
@@ -48,16 +51,19 @@ def test_fetch_repo_status_no_runs(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
         assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed"
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push&branch=main"
         )
         return DummyResp({"workflow_runs": []})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "❓"
     assert calls == [
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
+        "https://api.github.com/repos/user/repo",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push&branch=main",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push&branch=main",
     ]
 
 
@@ -67,26 +73,27 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
         assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev"
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push&branch=dev"
         )
         return DummyResp({"workflow_runs": [{"conclusion": "success"}]})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push&branch=dev",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push&branch=dev",
     ]
 
 
 def test_fetch_repo_status_nondeterministic(monkeypatch: pytest.MonkeyPatch) -> None:
     responses = [
-        {"workflow_runs": [{"conclusion": "success"}]},
-        {"workflow_runs": [{"conclusion": "failure"}]},
+        DummyResp({"default_branch": "main"}),
+        DummyResp({"workflow_runs": [{"conclusion": "success"}]}),
+        DummyResp({"workflow_runs": [{"conclusion": "failure"}]}),
     ]
 
     def fake_get(url: str, headers: dict, timeout: int):
-        return DummyResp(responses.pop(0))
+        return responses.pop(0)
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
## What
- query repo default branch and restrict to push events
- cover branch and default branch cases in repo status tests

## Why
- status badges misread failing PR runs as branch failures

## How to Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d9b867b3c832f829ec1a4dc85e68c