### PR TITLE
fix: ignore non-CI runs in repo status updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ run via GitHub Actions on each push and pull request and currently reach
 ## Related Projects
 Status icons: ✅ latest run succeeded, ❌ failed, ❓ no completed runs.
 - ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – scripts and metadata for the channel
-- ❓ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
-- ❌ **[DSPACE](https://democratized.space)** @v3 – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ✅ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
+- ✅ **[DSPACE](https://democratized.space)** @v3 – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace/tree/v3))
 - ✅ **[flywheel](https://github.com/futuroptimist/flywheel)** – opinionated boilerplate for reproducible CI and releases
 - ✅ **[gabriel](https://github.com/futuroptimist/gabriel)** – guardian-angel LLM that nudges safer digital hygiene
 - ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – bulk-copy files from nested dirs straight to your clipboard

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -30,7 +30,7 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
         assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed"
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=10&status=completed"
         )
         assert "Authorization" in headers
         return DummyResp({"workflow_runs": [{"conclusion": "success"}]})
@@ -38,8 +38,8 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", token="abc") == "✅"
     assert calls == [
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=10&status=completed",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=10&status=completed",
     ]
 
 
@@ -49,15 +49,15 @@ def test_fetch_repo_status_no_runs(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
         assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed"
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=10&status=completed"
         )
         return DummyResp({"workflow_runs": []})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "❓"
     assert calls == [
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=10&status=completed",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=10&status=completed",
     ]
 
 
@@ -67,15 +67,15 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
         assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev"
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=10&status=completed&branch=dev"
         )
         return DummyResp({"workflow_runs": [{"conclusion": "success"}]})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=10&status=completed&branch=dev",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=10&status=completed&branch=dev",
     ]
 
 
@@ -91,6 +91,21 @@ def test_fetch_repo_status_nondeterministic(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     with pytest.raises(RuntimeError):
         repo_status.fetch_repo_status("user/repo")
+
+
+def test_fetch_repo_status_ignores_non_ci_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "skipped", "event": "issue_comment"},
+                    {"conclusion": "success", "event": "push"},
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "✅"
 
 
 def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- ignore non-CI workflow runs when fetching repo status
- test repo_status logic for skipped events
- correct token.place and DSPACE status in README

## Testing
- `ruff check --fix src/repo_status.py tests/test_repo_status.py`
- `black src/repo_status.py tests/test_repo_status.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9b867b3c832f829ec1a4dc85e68c