### PR TITLE
🐛 : filter repo status by push event

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ run via GitHub Actions on each push and pull request and currently reach
 ## Related Projects
 Status icons: ✅ latest run succeeded, ❌ failed, ❓ no completed runs.
 - ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – scripts and metadata for the channel
-- ❓ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
-- ❌ **[DSPACE](https://democratized.space)** @v3 – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ✅ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
+- ✅ **[DSPACE](https://democratized.space)** @v3 – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace/tree/v3))
 - ✅ **[flywheel](https://github.com/futuroptimist/flywheel)** – opinionated boilerplate for reproducible CI and releases
 - ✅ **[gabriel](https://github.com/futuroptimist/gabriel)** – guardian-angel LLM that nudges safer digital hygiene
 - ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – bulk-copy files from nested dirs straight to your clipboard

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -35,10 +35,12 @@ def fetch_repo_status(
     repo: str,
     token: str | None = None,
     branch: str | None = None,
+    event: str | None = "push",
     attempts: int = 2,
 ) -> str:
     """Fetch the latest workflow run conclusion for ``repo`` and return an emoji.
 
+    Only considers runs triggered by the given ``event`` (default ``"push"``).
     The GitHub API occasionally returns inconsistent data if a workflow is
     updating while we query it. To catch this non-determinism we fetch the
     status multiple times and ensure all results match. If they differ we raise
@@ -53,6 +55,8 @@ def fetch_repo_status(
     )
     if branch:
         url += f"&branch={branch}"
+    if event:
+        url += f"&event={event}"
 
     def _fetch() -> str | None:
         resp = requests.get(url, headers=headers, timeout=10)

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -30,7 +30,7 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
         assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed"
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push"
         )
         assert "Authorization" in headers
         return DummyResp({"workflow_runs": [{"conclusion": "success"}]})
@@ -38,8 +38,8 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", token="abc") == "✅"
     assert calls == [
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push",
     ]
 
 
@@ -49,15 +49,15 @@ def test_fetch_repo_status_no_runs(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
         assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed"
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push"
         )
         return DummyResp({"workflow_runs": []})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "❓"
     assert calls == [
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&event=push",
     ]
 
 
@@ -67,15 +67,15 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
         assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev"
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev&event=push"
         )
         return DummyResp({"workflow_runs": [{"conclusion": "success"}]})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev&event=push",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=1&status=completed&branch=dev&event=push",
     ]
 
 


### PR DESCRIPTION
what: restrict status checks to push-triggered runs and update badges
why: non-test workflows skewed repo health indicators
how to test: pre-commit run --files README.md src/repo_status.py tests/test_repo_status.py && pytest
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d9b867b3c832f829ec1a4dc85e68c