### PR TITLE
docs: use YouTube handle and clean wordlist

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -60,7 +60,6 @@ llmstxt
 pyspelling
 wordlist
 ol
-opdpgirohymoaxgqsq
 openai
 opentimelineio
 optimised

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/github/license/futuroptimist/futuroptimist)](LICENSE)
 
 Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my
-[YouTube channel](https://www.youtube.com/channel/UCA-J-opDpgiRoHYmOAxGQSQ).
+[YouTube channel](https://www.youtube.com/@futuroptimist).
 If you're looking for the full project details, see
 [INSTRUCTIONS.md](INSTRUCTIONS.md). We manage Python dependencies with
 [uv](https://docs.astral.sh/uv/); check the instructions for setup steps.


### PR DESCRIPTION
## Summary
- switch README YouTube link to @futuroptimist handle
- drop unused channel ID from `.wordlist.txt`

## Testing
- `pyspelling -c spellcheck.yaml`
- `pre-commit run --all-files`
- `pytest -q`

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_689eb59dc90c832fa16bee1e717b7edc