### PR TITLE
Add timeout to collect_sources downloads

### DIFF
--- a/src/collect_sources.py
+++ b/src/collect_sources.py
@@ -8,16 +8,18 @@ import sys
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 VIDEO_ROOT = BASE_DIR / "video_scripts"
 USER_AGENT = "futuroptimist-bot/1.0"
+URL_TIMEOUT = 10
 
 
 def download_url(url: str, dest: pathlib.Path) -> bool:
     """Download a single URL to ``dest``.
 
-    Returns ``True`` on success and ``False`` if the request fails.
+    Uses a ``10s`` timeout and returns ``True`` on success, ``False`` on any
+    ``URLError``.
     """
     try:
         req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-        with urllib.request.urlopen(req) as resp:
+        with urllib.request.urlopen(req, timeout=URL_TIMEOUT) as resp:
             dest.write_bytes(resp.read())
         return True
     except urllib.error.URLError as exc:

--- a/tests/test_collect_sources.py
+++ b/tests/test_collect_sources.py
@@ -6,8 +6,9 @@ import src.collect_sources as cs
 def test_download_url_handles_error(monkeypatch, tmp_path):
     seen = {}
 
-    def fake_urlopen(req):
+    def fake_urlopen(req, *, timeout=None):
         seen["ua"] = req.get_header("User-agent")
+        seen["timeout"] = timeout
         raise urllib.error.URLError("boom")
 
     monkeypatch.setattr(cs.urllib.request, "urlopen", fake_urlopen)
@@ -16,6 +17,7 @@ def test_download_url_handles_error(monkeypatch, tmp_path):
     assert result is False
     assert not dest.exists()
     assert seen["ua"] == cs.USER_AGENT
+    assert seen["timeout"] == cs.URL_TIMEOUT
 
 
 def test_download_url_success(monkeypatch, tmp_path):
@@ -32,7 +34,8 @@ def test_download_url_success(monkeypatch, tmp_path):
         def read(self):
             return self.data
 
-    def fake_urlopen(req):
+    def fake_urlopen(req, *, timeout=None):
+        assert timeout == cs.URL_TIMEOUT
         assert req.get_header("User-agent") == cs.USER_AGENT
         return DummyResponse()
 


### PR DESCRIPTION
## Summary
- avoid hanging downloads by adding 10s timeout to `collect_sources`
- assert timeout usage in tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689eb5a48a58832f8d8ef1485e2b3bdc