### PR TITLE
🔐 Expand token file path in GitHub auth

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -42,7 +42,8 @@ Some helper scripts require a GitHub token to access the GraphQL API. Export
 `GH_TOKEN` (or `GITHUB_TOKEN`) with a personal access token that includes `repo`
 and `read:org` scopes when generating heatmaps or fetching commit stats. You may
 also set `GH_TOKEN_FILE` or `GITHUB_TOKEN_FILE` to point at a file containing
-the token.
+the token. Paths in these variables may include `~` or environment variables and
+will be expanded.
 
 Create new script folders from the IDs in `video_ids.txt`:
 

--- a/src/github_auth.py
+++ b/src/github_auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import os.path
 
 
 def _read_token_file(var: str) -> str | None:
@@ -11,7 +12,8 @@ def _read_token_file(var: str) -> str | None:
     if not path:
         return None
     try:
-        return pathlib.Path(path).read_text()
+        expanded = os.path.expanduser(os.path.expandvars(path))
+        return pathlib.Path(expanded).read_text()
     except OSError:
         return None
 

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -73,3 +73,27 @@ def test_missing_token_file_uses_env(monkeypatch, tmp_path):
     monkeypatch.setenv("GH_TOKEN_FILE", str(missing))
     monkeypatch.setenv("GITHUB_TOKEN", "b")
     assert get_github_token() == "b"
+
+
+def test_token_file_path_expands_user(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    token_file = home / "token.txt"
+    token_file.write_text("filetoken")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN_FILE", "~/token.txt")
+    assert get_github_token() == "filetoken"
+
+
+def test_token_file_path_expands_env_var(monkeypatch, tmp_path):
+    token_dir = tmp_path / "dir"
+    token_dir.mkdir()
+    token_file = token_dir / "token.txt"
+    token_file.write_text("filetoken")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("TOKEN_DIR", str(token_dir))
+    monkeypatch.setenv("GH_TOKEN_FILE", "$TOKEN_DIR/token.txt")
+    assert get_github_token() == "filetoken"


### PR DESCRIPTION
## Summary
- expand `GH_TOKEN_FILE`/`GITHUB_TOKEN_FILE` to resolve `~` and env vars
- document token file path expansion in INSTRUCTIONS

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb5a48a58832f8d8ef1485e2b3bdc