### PR TITLE
🔒 Add secret scan script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Avoid adding setup or asset instructions there; link to INSTRUCTIONS instead.
 * Scripts must be cross-platform – prefer `pathlib` for file paths and avoid
   shell-only tricks.
 * Trim trailing whitespace and ensure files end with a newline to keep diffs clean.
+* Scan staged changes for secrets using `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 ## Script Format
 

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Detect potential secrets in staged diffs.
+
+Reads diff content from ``stdin`` and exits with status ``1`` if any
+secret-like patterns are found. The scan is intentionally lightweight and
+should be supplemented with dedicated tools for thorough auditing.
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+PATTERNS = [
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----"),
+    re.compile(r"(?i)(api_key|apikey|password|secret)[\s:=]+[^\n]+"),
+]
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    lines = []
+    for line in raw.splitlines():
+        if "allowlist secret" in line:
+            continue
+        if line.startswith("+"):
+            line = line[1:]
+        lines.append(line)
+    content = "\n".join(lines)
+
+    matches: list[str] = []
+    for pattern in PATTERNS:
+        matches.extend(m.group(0) for m in pattern.finditer(content))
+    if matches:
+        sys.stderr.write("Possible secrets detected:\n")
+        for m in matches:
+            sys.stderr.write(f"{m}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_scan_secrets.py
+++ b/tests/test_scan_secrets.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_scan(content: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(Path("scripts/scan-secrets.py"))],
+        input=content.encode(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_no_secrets(tmp_path):
+    proc = run_scan("hello world")
+    assert proc.returncode == 0
+    assert proc.stderr == b""
+
+
+def test_detects_secret(tmp_path):
+    proc = run_scan("api_key=12345")  # pragma: allowlist secret
+    assert proc.returncode == 1
+    assert b"api_key" in proc.stderr


### PR DESCRIPTION
## Summary
- add lightweight diff scanner to catch API keys and private keys
- document secret scanning in AGENTS guidance

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb5a48a58832f8d8ef1485e2b3bdc