### PR TITLE
🛠️ fix: silence run_module warnings in CLI tests

### DIFF
--- a/tests/test_collect_sources.py
+++ b/tests/test_collect_sources.py
@@ -90,10 +90,17 @@ def test_cli_entrypoint(monkeypatch, tmp_path):
 
     import runpy
     import sys
+    import warnings
 
     monkeypatch.setitem(sys.modules, "src.collect_sources", cs)
     fake_process(d)  # ensure line coverage
-    runpy.run_module("src.collect_sources", run_name="__main__")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*found in sys.modules.*",
+            category=RuntimeWarning,
+        )
+        runpy.run_module("src.collect_sources", run_name="__main__")
     assert called
 
 

--- a/tests/test_fetch_subtitles.py
+++ b/tests/test_fetch_subtitles.py
@@ -82,5 +82,12 @@ def test_entrypoint(monkeypatch, tmp_path):
     monkeypatch.setattr(fs, "read_video_ids", lambda: [])
     monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
     import runpy
+    import warnings
 
-    runpy.run_module("src.fetch_subtitles", run_name="__main__")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*found in sys.modules.*",
+            category=RuntimeWarning,
+        )
+        runpy.run_module("src.fetch_subtitles", run_name="__main__")

--- a/tests/test_index_local_media.py
+++ b/tests/test_index_local_media.py
@@ -4,6 +4,7 @@ import sys
 from datetime import datetime, timezone
 import os
 import pathlib
+import warnings
 
 import pytest
 
@@ -78,5 +79,10 @@ def test_scan_directory_deterministic_order(tmp_path, monkeypatch):
 def test_entrypoint(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["index_local_media.py", str(tmp_path)])
     (tmp_path).mkdir(exist_ok=True)
-
-    runpy.run_module("src.index_local_media", run_name="__main__")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*found in sys.modules.*",
+            category=RuntimeWarning,
+        )
+        runpy.run_module("src.index_local_media", run_name="__main__")

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -3,6 +3,7 @@ import pathlib
 import json
 import runpy
 import sys
+import warnings
 import src.scaffold_videos as sv
 import pytest
 
@@ -123,6 +124,12 @@ def test_entrypoint(monkeypatch, tmp_path):
 
     r = Resp()
     monkeypatch.setattr(sv.urllib.request, "urlopen", lambda req: r)
-    runpy.run_module("src.scaffold_videos", run_name="__main__")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*found in sys.modules.*",
+            category=RuntimeWarning,
+        )
+        runpy.run_module("src.scaffold_videos", run_name="__main__")
     r.__enter__()
     r.__exit__(None, None, None)

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -1,5 +1,6 @@
 import sys
 import runpy
+import warnings
 import src.srt_to_markdown as stm
 
 
@@ -147,11 +148,23 @@ def test_entrypoint(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(
         sys, "argv", ["srt_to_markdown.py", str(srt_path), "-o", str(out)]
     )
-    runpy.run_module("src.srt_to_markdown", run_name="__main__")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*found in sys.modules.*",
+            category=RuntimeWarning,
+        )
+        runpy.run_module("src.srt_to_markdown", run_name="__main__")
     assert out.exists()
 
     sys.modules.pop("__main__", None)
     monkeypatch.setattr(sys, "argv", ["srt_to_markdown.py", str(srt_path)])
-    runpy.run_module("src.srt_to_markdown", run_name="__main__")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*found in sys.modules.*",
+            category=RuntimeWarning,
+        )
+        runpy.run_module("src.srt_to_markdown", run_name="__main__")
     captured = capsys.readouterr()
     assert "[NARRATOR]: Hi" in captured.out

--- a/tests/test_update_transcript_links.py
+++ b/tests/test_update_transcript_links.py
@@ -1,6 +1,7 @@
 import json
 import runpy
 import pytest
+import warnings
 import src.update_transcript_links as utl
 
 
@@ -116,7 +117,13 @@ def test_entrypoint(monkeypatch, tmp_path):
     monkeypatch.setattr(utl, "API_KEY", "")
     (tmp_path / "scripts").mkdir()
 
-    runpy.run_module("src.update_transcript_links", run_name="__main__")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*found in sys.modules.*",
+            category=RuntimeWarning,
+        )
+        runpy.run_module("src.update_transcript_links", run_name="__main__")
 
 
 def test_fetch_transcript_failure(monkeypatch, capsys):


### PR DESCRIPTION
## What
- filter RuntimeWarnings in CLI entrypoint tests

## Why
- keep pytest output clean

## How to Test
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f89cfb5ac832f9857616f2548d504