### PR TITLE
🐛 Strip speaker prefixes in SRT converter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Avoid adding setup or asset instructions there; link to INSTRUCTIONS instead.
 | `/Makefile` & `setup.ps1` | Developer automation (venv, tests, subtitles, render). |
 | `/llms.txt` | Complementary file containing creative context & tone. |
 | `/subtitles/` | Downloaded `.srt` caption files populated by `fetch_subtitles.py`. |
-| `/src/srt_to_markdown.py` | Convert `.srt` captions; handles italics/bold, emoji; strips HTML. |
+| `/src/srt_to_markdown.py` | Convert `.srt` captions; handles italics/bold, emoji; strips HTML and speaker prefixes. |
 | `/src/generate_heatmap.py` | Create a 3‑D lines-of-code heatmap with light/dark SVGs |
 | `/sources/` | Reference files fetched via `collect_sources.py`. |
 | `video_ids.txt` | Canonical list of YouTube IDs referenced by helper scripts; lines starting with `#` are comments. |

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@ Every commit is public training data—write informative commit messages.
 Script format:
 - `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling
   italics and bold tags (`<i>/<em>` and `<b>/<strong>`, even with attributes), line breaks,
-  emoji, case-insensitive HTML tags, and stripping other tags.
+  emoji, case-insensitive HTML tags, removing speaker prefixes, and stripping other tags.
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -12,9 +12,11 @@ def clean_srt_text(text: str) -> str:
     attributes), and ``<br>`` to Markdown equivalents while stripping any other HTML
     tags. Tag matching is case-insensitive.
     Non-breaking spaces (``&nbsp;``) are converted to regular spaces.
+    Speaker prefixes such as ``- [Narrator]`` are removed.
     """
 
     text = html.unescape(text).replace("\xa0", " ")
+    text = re.sub(r"^-?\s*\[[^\]]+\]\s*:?\s*", "", text)
     text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
     text = re.sub(r"</?(i|em)\b[^>]*>", "*", text, flags=re.IGNORECASE)
     text = re.sub(r"</?(b|strong)\b[^>]*>", "**", text, flags=re.IGNORECASE)

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -123,6 +123,18 @@ def test_tags_with_attributes(tmp_path):
     assert entries == [("00:00:00,000", "00:00:01,000", "*Hi* **there**")]
 
 
+def test_strip_speaker_prefix(tmp_path):
+    srt = """1
+00:00:00,000 --> 00:00:01,000
+- [Narrator] Hello world
+"""
+    path = tmp_path / "speaker.srt"
+    path.write_text(srt)
+
+    entries = stm.parse_srt(path)
+    assert entries == [("00:00:00,000", "00:00:01,000", "Hello world")]
+
+
 def test_parse_srt_edge_cases(tmp_path):
     content = """foo
 1


### PR DESCRIPTION
## Summary
- strip leading speaker labels like `- [Narrator]` when converting SRT captions
- document speaker-prefix handling
- test removing narrator prefixes from captions

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f89ca7ad0832fbae89ca288cc5e1e