### PR TITLE
Handle case-insensitive workflow statuses

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -20,13 +20,16 @@ GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+
 def status_to_emoji(conclusion: str | None) -> str:
     """Return an emoji representing the run conclusion.
 
+    Comparison is case-insensitive so callers may pass ``"SUCCESS"`` or
+    ``"Failure"`` and receive the same result.
+
     - ``"success"`` → ✅
     - ``"failure"`` → ❌
     - anything else (including ``None``) → ❓
     """
-    if conclusion == "success":
+    if conclusion and conclusion.lower() == "success":
         return "✅"
-    if conclusion == "failure":
+    if conclusion and conclusion.lower() == "failure":
         return "❌"
     return "❓"
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -9,6 +9,9 @@ from src.repo_status import status_to_emoji
 def test_status_to_emoji() -> None:
     assert status_to_emoji("success") == "✅"
     assert status_to_emoji("failure") == "❌"
+    # should be case-insensitive
+    assert status_to_emoji("SUCCESS") == "✅"
+    assert status_to_emoji("FAILURE") == "❌"
     assert status_to_emoji(None) == "❓"
     assert status_to_emoji("neutral") == "❓"
 


### PR DESCRIPTION
## Summary
- normalize status_to_emoji inputs so capitalized conclusions map to correct emoji
- test that uppercase workflow statuses return appropriate emoji

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f89ca7ad0832fbae89ca288cc5e1e