### PR TITLE
🧹 : ignore pyspelling dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ video_scripts/*/sources/
 htmlcov/
 cov.json
 
+# spellcheck artifacts
+dictionary.dic
 
 # local footage
 footage/


### PR DESCRIPTION
## Summary
- add pyspelling dictionary cache to .gitignore

## Testing
- `python -m pyspelling -c spellcheck.yaml`
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint` *(fails: could not read package.json)*
- `npm run test:ci` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f89bc4358832fa5e0065f2669bc4a