### PR TITLE
🕒 : normalize media index timestamps

### DIFF
--- a/src/index_local_media.py
+++ b/src/index_local_media.py
@@ -1,8 +1,9 @@
 """Index local media files and write a JSON inventory.
 
 The generated index lists file paths, modification times in UTC,
-and file sizes in bytes. The output file's parent directories are
-created automatically.
+and file sizes in bytes. Modification timestamps are truncated to
+whole seconds for stable output. The output file's parent directories
+are created automatically.
 """
 
 import argparse
@@ -14,8 +15,9 @@ from datetime import datetime, timezone
 def scan_directory(base: pathlib.Path):
     """Return a list of dictionaries describing files under ``base``.
 
-    Each record contains ``path``, ``mtime`` (ISO timestamp in UTC), and
-    file ``size`` in bytes. The list is sorted by modification time and
+    Each record contains ``path``, ``mtime`` (ISO timestamp in UTC without
+    sub-second precision), and file ``size`` in bytes. The list is sorted by
+    modification time and
     then by path to produce deterministic output.
     """
     records = []
@@ -24,6 +26,7 @@ def scan_directory(base: pathlib.Path):
             stat = path.stat()
             mtime = (
                 datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+                .replace(microsecond=0)
                 .isoformat()
                 .replace("+00:00", "Z")
             )

--- a/tests/test_index_local_media.py
+++ b/tests/test_index_local_media.py
@@ -33,6 +33,16 @@ def test_scan_directory_utc_mtime(tmp_path):
     assert mtime.tzinfo == timezone.utc
 
 
+def test_scan_directory_truncates_microseconds(tmp_path):
+    file_path = tmp_path / "clip.mp4"
+    file_path.write_text("data")
+    os.utime(file_path, (1234567890.654321, 1234567890.654321))
+    result = ilm.scan_directory(tmp_path)
+    ts = result[0]["mtime"].replace("Z", "+00:00")
+    mtime = datetime.fromisoformat(ts)
+    assert mtime.microsecond == 0
+
+
 def test_main(tmp_path, capsys):
     f = tmp_path / "x.txt"
     f.write_text("hi")


### PR DESCRIPTION
## Summary
- truncate modification times to whole seconds in media index
- test microsecond truncation for deterministic output

## Testing
- pre-commit run --all-files
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68a00dceba20832f83674ab6e494306c