### PR TITLE
🐛 : handle write errors in source downloader

### DIFF
--- a/src/collect_sources.py
+++ b/src/collect_sources.py
@@ -15,14 +15,14 @@ def download_url(url: str, dest: pathlib.Path) -> bool:
     """Download a single URL to ``dest``.
 
     Uses a ``10s`` timeout and returns ``True`` on success, ``False`` on any
-    ``URLError``.
+    network ``URLError`` or local ``OSError`` such as a write failure.
     """
     try:
         req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
         with urllib.request.urlopen(req, timeout=URL_TIMEOUT) as resp:
             dest.write_bytes(resp.read())
         return True
-    except urllib.error.URLError as exc:
+    except (urllib.error.URLError, OSError) as exc:
         print(f"Failed to download {url}: {exc}", file=sys.stderr)
         return False
 


### PR DESCRIPTION
Handle write failures in collect_sources.download_url.
Prevents crash when destination file cannot be written.

Test: pre-commit run --all-files
Test: pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68a00dceba20832f83674ab6e494306c