### PR TITLE
🐛 : strip whitespace in status_to_emoji

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -20,16 +20,17 @@ GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+
 def status_to_emoji(conclusion: str | None) -> str:
     """Return an emoji representing the run conclusion.
 
-    Comparison is case-insensitive so callers may pass ``"SUCCESS"`` or
-    ``"Failure"`` and receive the same result.
+    Comparison is case-insensitive and ignores surrounding whitespace so
+    callers may pass values like ``"SUCCESS"`` or ``" failure \n"`` and
+    receive the same result.
 
     - ``"success"`` → ✅
     - ``"failure"`` → ❌
     - anything else (including ``None``) → ❓
     """
-    if conclusion and conclusion.lower() == "success":
+    if conclusion and conclusion.strip().lower() == "success":
         return "✅"
-    if conclusion and conclusion.lower() == "failure":
+    if conclusion and conclusion.strip().lower() == "failure":
         return "❌"
     return "❓"
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -16,6 +16,11 @@ def test_status_to_emoji() -> None:
     assert status_to_emoji("neutral") == "❓"
 
 
+def test_status_to_emoji_strips_whitespace() -> None:
+    assert status_to_emoji(" success ") == "✅"
+    assert status_to_emoji("\nFAILURE\t") == "❌"
+
+
 class DummyResp:
     def __init__(self, data: dict):
         self._data = data


### PR DESCRIPTION
## Summary
- trim surrounding whitespace before mapping workflow run results
- test whitespace handling for `status_to_emoji`

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a00dceba20832f83674ab6e494306c