### PR TITLE
✨ : collapse whitespace in SRT captions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Avoid adding setup or asset instructions there; link to INSTRUCTIONS instead.
 | `/Makefile` & `setup.ps1` | Developer automation (venv, tests, subtitles, render). |
 | `/llms.txt` | Complementary file containing creative context & tone. |
 | `/subtitles/` | Downloaded `.srt` caption files populated by `fetch_subtitles.py`. |
-| `/src/srt_to_markdown.py` | Convert `.srt` captions; handles italics/bold, emoji; strips HTML and speaker prefixes. |
+| `/src/srt_to_markdown.py` | Convert `.srt` captions; handles italics/bold, emoji; strips HTML, speaker prefixes, and collapses whitespace. |
 | `/src/generate_heatmap.py` | Create a 3‑D lines-of-code heatmap with light/dark SVGs |
 | `/sources/` | Reference files fetched via `collect_sources.py`. |
 | `video_ids.txt` | Canonical list of YouTube IDs referenced by helper scripts; lines starting with `#` are comments. |

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,8 @@ Every commit is public training data—write informative commit messages.
 Script format:
 - `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling
   italics and bold tags (`<i>/<em>` and `<b>/<strong>`, even with attributes), line breaks,
-  emoji, case-insensitive HTML tags, removing speaker prefixes, and stripping other tags.
+  emoji, case-insensitive HTML tags, removing speaker prefixes, stripping other tags,
+  and collapsing extra whitespace.
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -12,7 +12,8 @@ def clean_srt_text(text: str) -> str:
     attributes), and ``<br>`` to Markdown equivalents while stripping any other HTML
     tags. Tag matching is case-insensitive.
     Non-breaking spaces (``&nbsp;``) are converted to regular spaces.
-    Speaker prefixes such as ``- [Narrator]`` are removed.
+    Speaker prefixes such as ``- [Narrator]`` are removed. Runs of whitespace are
+    collapsed to a single space so downstream scripts see clean, predictable text.
     """
 
     text = html.unescape(text).replace("\xa0", " ")
@@ -22,6 +23,7 @@ def clean_srt_text(text: str) -> str:
     text = re.sub(r"</?(b|strong)\b[^>]*>", "**", text, flags=re.IGNORECASE)
     text = re.sub(r"</?u\b[^>]*>", "", text, flags=re.IGNORECASE)
     text = re.sub(r"<[a-zA-Z/][^>]*>", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
     return text
 
 

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -124,6 +124,18 @@ def test_tags_with_attributes(tmp_path):
     assert entries == [("00:00:00,000", "00:00:01,000", "*Hi* **there**")]
 
 
+def test_collapse_whitespace(tmp_path):
+    srt = """1
+00:00:00,000 --> 00:00:01,000
+Hello<br>  <b>world</b>
+"""
+    path = tmp_path / "spaces.srt"
+    path.write_text(srt)
+
+    entries = stm.parse_srt(path)
+    assert entries == [("00:00:00,000", "00:00:01,000", "Hello **world**")]
+
+
 def test_strip_speaker_prefix(tmp_path):
     srt = """1
 00:00:00,000 --> 00:00:01,000


### PR DESCRIPTION
## What
- collapse repeated whitespace in `srt_to_markdown`
- document behavior in AGENTS and `llms.txt`
- test whitespace normalization

## Why
- ensures generated scripts stay consistent for downstream tools

## How to test
- `pre-commit run --all-files`
- `pytest -q`

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68a00dceba20832f83674ab6e494306c