### PR TITLE
🛠️ fix: install uv before heatmap run

### DIFF
--- a/.github/workflows/contrib-heatmap.yml
+++ b/.github/workflows/contrib-heatmap.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v1
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 2025-08-22
+- fix: install uv before building heatmap workflow

--- a/docs/pms/2025-08-22-heatmap-ci-failure.md
+++ b/docs/pms/2025-08-22-heatmap-ci-failure.md
@@ -1,0 +1,18 @@
+# Heatmap CI failure
+
+- **Date:** 2025-08-22
+- **Author:** codex-bot
+- **Status:** fixed
+
+## What went wrong
+The scheduled "Rebuild 3-D heat-map" workflow failed when running `uv pip`.
+
+## Root cause
+`uv` was never installed, so the command exited with "uv: command not found".
+
+## Impact
+Heatmap SVGs were not regenerated on schedule.
+
+## Actions to take
+- Install `astral-sh/setup-uv` before invoking `uv pip`.
+- Add a test to ensure the workflow includes this step.

--- a/outages/2025-08-22-missing-uv-setup.json
+++ b/outages/2025-08-22-missing-uv-setup.json
@@ -1,0 +1,9 @@
+{
+  "date": "2025-08-22",
+  "workflow": "Rebuild 3-D heat-map",
+  "job": "heatmap",
+  "run_id": 17145073802,
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/17145073802",
+  "root_cause": "workflow called 'uv pip' without installing uv",
+  "resolution": "add astral-sh/setup-uv step before installing dependencies"
+}

--- a/outages/schema.json
+++ b/outages/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Workflow Outage",
+  "type": "object",
+  "properties": {
+    "date": {"type": "string", "format": "date"},
+    "workflow": {"type": "string"},
+    "job": {"type": "string"},
+    "run_id": {"type": "integer"},
+    "run_url": {"type": "string", "format": "uri"},
+    "root_cause": {"type": "string"},
+    "resolution": {"type": "string"}
+  },
+  "required": [
+    "date",
+    "workflow",
+    "job",
+    "run_id",
+    "root_cause",
+    "resolution"
+  ]
+}

--- a/tests/test_heatmap_workflow.py
+++ b/tests/test_heatmap_workflow.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def test_heatmap_workflow_sets_up_uv():
+    content = Path(".github/workflows/contrib-heatmap.yml").read_text()
+    assert "astral-sh/setup-uv@v1" in content

--- a/tests/test_outages_schema.py
+++ b/tests/test_outages_schema.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+
+from jsonschema import validate
+
+
+def test_outage_entries_conform_to_schema():
+    schema = json.loads(Path("outages/schema.json").read_text())
+    for path in Path("outages").glob("*.json"):
+        if path.name == "schema.json":
+            continue
+        data = json.loads(path.read_text())
+        validate(data, schema)


### PR DESCRIPTION
## Summary
- ensure heatmap workflow installs uv before dependency install
- add regression test, outage log and postmortem
- document change in changelog

## Testing
- `pre-commit run --files .github/workflows/contrib-heatmap.yml tests/test_heatmap_workflow.py outages/schema.json outages/2025-08-22-missing-uv-setup.json tests/test_outages_schema.py docs/pms/2025-08-22-heatmap-ci-failure.md docs/CHANGELOG.md`
- `pytest --cov=./src --cov=./tests --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68a8052b7160832f9a4bbddb8a57adae