### PR TITLE
ci: skip heatmap build when GH_TOKEN is unset

### DIFF
--- a/.github/workflows/contrib-heatmap.yml
+++ b/.github/workflows/contrib-heatmap.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   heatmap:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -21,13 +23,16 @@ jobs:
         run: |
           uv pip install --system -r requirements.txt
       - name: Generate heat-map
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        if: env.GH_TOKEN != ''
         run: python src/generate_heatmap.py
       - name: Commit and push
+        if: env.GH_TOKEN != ''
         uses: EndBug/add-and-commit@v9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add: 'assets/heatmap_*.svg'
           message: 'docs: auto-update 3-D LOC heat-map [skip ci]'
+      - name: Skip heat-map build
+        if: env.GH_TOKEN == ''
+        run: echo 'GH_TOKEN not set, skipping heat-map'
 

--- a/docs/pms/2025-08-22-heatmap-token.md
+++ b/docs/pms/2025-08-22-heatmap-token.md
@@ -1,0 +1,18 @@
+# Heatmap job missing GH_TOKEN
+
+- Date: 2025-08-22
+- Author: codex
+- Status: fixed
+
+## What went wrong
+Scheduled heatmap workflow failed during the commit step.
+
+## Root cause
+The GH_TOKEN environment variable was not configured, so no SVGs were generated and `add-and-commit` could not find any files to commit.
+
+## Impact
+Nightly 3-D heatmap SVGs were not updated and the workflow reported failure.
+
+## Actions to take
+- Guard workflow steps behind GH_TOKEN presence.
+- Monitor future runs for similar token issues.

--- a/outages/2025-08-22-missing-gh-token.json
+++ b/outages/2025-08-22-missing-gh-token.json
@@ -1,0 +1,6 @@
+{
+  "date": "2025-08-22",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/17145073802",
+  "root_cause": "Heatmap workflow attempted to commit files when GH_TOKEN was absent, leaving no generated SVGs and failing the commit step.",
+  "resolution": "Conditionally run heatmap generation and commit steps only when GH_TOKEN is present."
+}

--- a/outages/schema.json
+++ b/outages/schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OutageEntry",
+  "type": "object",
+  "required": ["date", "run_url", "root_cause", "resolution"],
+  "properties": {
+    "date": {"type": "string", "format": "date"},
+    "run_url": {"type": "string", "format": "uri"},
+    "root_cause": {"type": "string"},
+    "resolution": {"type": "string"}
+  }
+}

--- a/tests/test_generate_heatmap_svg.py
+++ b/tests/test_generate_heatmap_svg.py
@@ -79,3 +79,5 @@ def test_generate_heatmap_skips_without_token(monkeypatch, capsys, tmp_path):
     generate_heatmap.main()
     captured = capsys.readouterr()
     assert "Skipping heatmap generation" in captured.err
+    assert not (tmp_path / "assets/heatmap_light.svg").exists()
+    assert not (tmp_path / "assets/heatmap_dark.svg").exists()


### PR DESCRIPTION
## Summary
- guard scheduled heatmap workflow so it only runs when `GH_TOKEN` is provided
- document missing-token outage and follow-up
- assert no SVGs are emitted when the token is absent

## Testing
- `ruff check .`
- `black --check .`
- `python -m pytest -q`
- `npm run lint` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `npm run test:ci` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a8052b7160832f9a4bbddb8a57adae