### PR TITLE
📝 : refresh CI fix prompt

### DIFF
--- a/dict/prompt-doc-repos.txt
+++ b/dict/prompt-doc-repos.txt
@@ -1,0 +1,1 @@
+futuroptimist

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,15 +2,15 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts-codex.md](prompts-codex.md) | Futuroptimist Codex baseline |
-| [prompts-codex-spellcheck.md](prompts-codex-spellcheck.md) | Codex spellcheck instructions |
-| [prompts-codex-video-script.md](prompts-codex-video-script.md) | Draft full video scripts |
-| [prompts-codex-video-script-ideas.md](prompts-codex-video-script-ideas.md) | Video ideas prompt |
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Codex automation prompt |
-| [prompts/codex/cad.md](prompts/codex/cad.md) | CAD model update prompt |
-| [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | CI failure fix template |
-| [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Code cleanup workflow |
-| [prompts/codex/fuzzing.md](prompts/codex/fuzzing.md) | Fuzzing experiment prompt |
-| [prompts/codex/physics.md](prompts/codex/physics.md) | Physics simulation prompt |
-| [prompts/codex/propagate.md](prompts/codex/propagate.md) | Propagation script prompt |
-| [prompts/codex/spellcheck.md](prompts/codex/spellcheck.md) | Spellcheck helper prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
+| [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
+| [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |
+| [prompts/codex/fuzzing.md](prompts/codex/fuzzing.md) | Codex Fuzzing Prompt |
+| [prompts/codex/physics.md](prompts/codex/physics.md) | Codex Physics Explainer Prompt |
+| [prompts/codex/propagate.md](prompts/codex/propagate.md) | Codex Prompt Propagation Prompt |
+| [prompts/codex/spellcheck.md](prompts/codex/spellcheck.md) | Codex Spellcheck Prompt |
+| [prompts-codex-spellcheck.md](prompts-codex-spellcheck.md) | Codex Spellcheck Prompt |
+| [prompts-codex-video-script-ideas.md](prompts-codex-video-script-ideas.md) | Video Script Ideas Prompt |
+| [prompts-codex-video-script.md](prompts-codex-video-script.md) | Codex Video Script Prompt |
+| [prompts-codex.md](prompts-codex.md) | Futuroptimist Codex Prompt |

--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -23,12 +23,13 @@ Diagnose a failed GitHub Actions run and produce a fix.
 
 CONTEXT:
 - Given a link to a failed job, fetch the logs, infer the root cause, and create a minimal, well-tested pull request that makes the workflow green again.
-- Consult existing outage entries in `/outages` for similar symptoms.
+- Consult existing outage entries in `docs/outages` for similar symptoms.
 - Constraints:
   * Do **not** break existing functionality.
   * Follow the repository’s style guidelines and commit-lint rules.
   * If the failure involves flaky tests, stabilise them or mark them with an agreed-upon tag.
   * Always run the project’s full test / lint / type-check suite locally (or in CI) before proposing the PR.
+  * Scan staged changes for secrets with repository tooling (e.g., `git diff --cached | ./scripts/scan-secrets.py`).
   * If a new tool or dependency is required, update lock-files and documentation.
   * Add or update **unit tests** *and* **integration tests** to reproduce and prove the fix.
   * Provide a concise changelog entry.
@@ -37,7 +38,7 @@ REQUEST:
 1. Read the failure logs and locate the first real error.
 2. Explain (in the pull-request body) *why* the failure occurred.
 3. Commit the necessary code, configuration, or documentation changes.
-4. Record the incident in `outages/YYYY-MM-DD-<slug>.json` using `outages/schema.json`.
+4. Record the incident in `docs/outages/YYYY-MM-DD-<slug>.json` using `docs/outages/schema.json`.
 5. Push to a branch named `codex/ci-fix/<short-description>`.
 6. Open a pull request that – once merged – makes the default branch CI-green.
 7. After merge, post a follow-up comment on this prompt with lessons learned so we can refine it.
@@ -48,14 +49,14 @@ A GitHub pull request URL. The PR must include:
 * Evidence that **all** checks are now passing (`✔️`).
 * Links to any new or updated tests.
 Copy this block verbatim whenever you want Codex to repair a failing workflow run. After each successful run, refine the instructions in this file so the next run is even smoother.
-After opening the pull request, create a new postmortem file under `docs/pms/` named `YYYY-MM-DD-short-title.md` capturing:
+After opening the pull request, create a new postmortem file under `docs/pms/` (create it if missing) named `YYYY-MM-DD-short-title.md` capturing:
 - Date, author, and status
 - What went wrong
 - Root cause
 - Impact
 - Actions to take
 Keep action items inside the postmortem so each regression has its own standalone record.
-Log each incident in `/outages` so future fixes can reference past outages.
+Log each incident in `docs/outages` so future fixes can reference past outages.
 ```
 
 ### Why this mirrors the existing pattern

--- a/docs/repo_list.txt
+++ b/docs/repo_list.txt
@@ -1,0 +1,1 @@
+futuroptimist

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pre-commit run --all-files
+pytest -q
+
+if [ -f package.json ]; then
+  npm run lint
+  npm run test:ci
+else
+  echo "Skipping npm checks: package.json not found" >&2
+fi
+
+if python - <<'PY'
+import pkgutil
+import sys
+sys.exit(0 if pkgutil.find_loader('flywheel') else 1)
+PY
+then
+  python -m flywheel.fit
+else
+  echo "Skipping flywheel.fit: module not found" >&2
+fi

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Generate docs/prompt-docs-summary.md from prompt docs."""
+import argparse
+import pathlib
+import yaml
+
+
+def parse_title(path: pathlib.Path) -> str:
+    text = path.read_text(encoding="utf-8").splitlines()
+    if text and text[0].strip() == "---":
+        try:
+            end = text[1:].index("---") + 1
+            front = "\n".join(text[1:end])
+            data = yaml.safe_load(front) or {}
+            if "title" in data:
+                return str(data["title"])
+            text = text[end + 1 :]
+        except ValueError:
+            text = text[1:]
+    for line in text:
+        if line.startswith("# "):
+            return line[2:].strip()
+    return path.stem
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repos-from", type=pathlib.Path, required=True)
+    parser.add_argument("--out", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+
+    # Ensure repos-from exists even if unused.
+    if not args.repos_from.exists():
+        raise FileNotFoundError(args.repos_from)
+
+    docs_dir = pathlib.Path("docs")
+    rows = []
+    for path in sorted(docs_dir.rglob("*.md")):
+        if path.resolve() == args.out.resolve():
+            continue
+        rel = path.relative_to(docs_dir).as_posix()
+        title = parse_title(path)
+        rows.append((rel, title))
+
+    lines = [
+        "# Prompt Docs Summary",
+        "",
+        "| Path | Description |",
+        "|------|-------------|",
+    ]
+    for rel, title in rows:
+        lines.append(f"| [{rel}]({rel}) | {title} |")
+
+    args.out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document Codex CI fix workflow with secret-scan step and docs/outages paths
- generate prompt docs summary via new helper script
- add repo lists and checks script for local verification

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint` *(fails: could not read package.json)*
- `npm run test:ci` *(fails: could not read package.json)*
- `python -m flywheel.fit` *(fails: module not found)*
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a805360444832fa95684f9098fa60f