### PR TITLE
📝 docs: refresh propagation prompt

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -12,5 +12,5 @@
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Code cleanup workflow |
 | [prompts/codex/fuzzing.md](prompts/codex/fuzzing.md) | Fuzzing experiment prompt |
 | [prompts/codex/physics.md](prompts/codex/physics.md) | Physics simulation prompt |
-| [prompts/codex/propagate.md](prompts/codex/propagate.md) | Propagation script prompt |
+| [prompts/codex/propagate.md](prompts/codex/propagate.md) | Propagate baseline prompt docs |
 | [prompts/codex/spellcheck.md](prompts/codex/spellcheck.md) | Spellcheck helper prompt |

--- a/docs/prompts/codex/propagate.md
+++ b/docs/prompts/codex/propagate.md
@@ -7,12 +7,12 @@ slug: 'codex-propagate'
 Type: evergreen
 
 Use this prompt to ask Codex to seed missing `prompts-*.md` files across repositories listed in
-[`docs/repo-feature-summary.md`](../../repo-feature-summary.md).
+[`docs/prompt-docs-summary.md`](../../prompt-docs-summary.md).
 
 **Human set-up steps:**
 
-1. Review [`docs/prompts/summary.md`](../summary.md) and compile a list of repos that lack a
-   `docs/prompts/codex/automation.md` baseline.
+1. Review [`docs/prompt-docs-summary.md`](../../prompt-docs-summary.md) and compile a list of repos
+   that lack a `docs/prompts/codex/automation.md` baseline.
 2. Paste that list (one repo per line) at the top of your ChatGPT message.
 3. Add two blank lines, then copy the block below and send it.
 


### PR DESCRIPTION
what: fix propagate prompt doc links and update summary
why: docs referenced removed files
how to test:
- pre-commit run --all-files
- pytest -q
- npm run test:ci # fails: package.json missing
- python -m flywheel.fit # fails: module not found
- bash scripts/checks.sh # missing
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a8051f2668832f9f7f6eab69266db4