### PR TITLE
🔧: ignore hidden files in index_local_media

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -60,7 +60,7 @@ Use `python src/index_local_media.py` to build `footage_index.json`
 so you can quickly locate clips while editing. Each entry includes
 the file path, modification time in UTC, and size in bytes, sorted
 deterministically by timestamp then path. The script creates the
-output directory if needed.
+output directory if needed. Hidden files and directories are skipped.
 
 ## Next Steps
 * Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ Script format:
 - Each script folder may also have a `footage.md` file listing required shots (archive vs new, CGI or generative). Mark generative items to avoid obvious "AI slop".
 - Run `python src/index_local_media.py` to rebuild `footage_index.json`, which lists
   file paths, UTC modification times, and file sizes for assets stored in the
-  local `footage/` directory.
+  local `footage/` directory. Hidden files are ignored.
 
 Run tests with:
 ```bash

--- a/tests/test_index_local_media.py
+++ b/tests/test_index_local_media.py
@@ -43,6 +43,17 @@ def test_scan_directory_truncates_microseconds(tmp_path):
     assert mtime.microsecond == 0
 
 
+def test_scan_directory_ignores_hidden_files(tmp_path):
+    (tmp_path / ".DS_Store").write_text("x")
+    hidden = tmp_path / ".hidden"
+    hidden.mkdir()
+    (hidden / "a.mp4").write_text("x")
+    visible = tmp_path / "clip.mp4"
+    visible.write_text("x")
+    result = ilm.scan_directory(tmp_path)
+    assert [r["path"] for r in result] == ["clip.mp4"]
+
+
 def test_main(tmp_path, capsys):
     f = tmp_path / "x.txt"
     f.write_text("hi")


### PR DESCRIPTION
## Summary
- skip dotfiles and directories when building footage indexes
- document hidden file behaviour

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci` (fails: could not read package.json)
- `python -m flywheel.fit` (fails: No module named 'flywheel')
- `bash scripts/checks.sh` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a80519fc9c832fa0afae359647059e