### PR TITLE
Handle cancelled GitHub runs in repo status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ run via GitHub Actions on each push and pull request and currently reach
 
 ## Related Projects
 _Last updated: 2025-08-22 05:02 UTC; checks hourly_
-Status icons: ✅ latest run succeeded, ❌ failed, ❓ no completed runs.
+Status icons: ✅ latest run succeeded, ❌ failed or cancelled, ❓ no completed runs.
 - ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – scripts and metadata for the channel
 - ✅ **[token.place](https://token.place)** – stateless faucet for LLM inference with zero auth friction ([repo](https://github.com/futuroptimist/token.place))
 - ✅ **[DSPACE](https://democratized.space)** @v3 – offline-first idle-sim where aquariums meet maker quests ([repo](https://github.com/democratizedspace/dspace/tree/v3))

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -26,12 +26,16 @@ def status_to_emoji(conclusion: str | None) -> str:
     receive the same result.
 
     - ``"success"`` → ✅
-    - ``"failure"`` → ❌
+    - ``"failure"``, ``"cancelled"``, ``"timed_out"`` → ❌
     - anything else (including ``None``) → ❓
     """
-    if conclusion and conclusion.strip().lower() == "success":
+    if conclusion:
+        normalized = conclusion.strip().lower()
+    else:
+        normalized = ""
+    if normalized == "success":
         return "✅"
-    if conclusion and conclusion.strip().lower() == "failure":
+    if normalized in {"failure", "cancelled", "timed_out"}:
         return "❌"
     return "❓"
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -21,6 +21,11 @@ def test_status_to_emoji_strips_whitespace() -> None:
     assert status_to_emoji("\nFAILURE\t") == "❌"
 
 
+def test_status_to_emoji_failure_variants() -> None:
+    assert status_to_emoji("cancelled") == "❌"
+    assert status_to_emoji("TIMED_OUT") == "❌"
+
+
 class DummyResp:
     def __init__(self, data: dict):
         self._data = data


### PR DESCRIPTION
🐛 fix: treat cancelled workflows as failures

what: map cancelled and timed_out conclusions to failure emoji
why: repo_status marked cancelled runs as unknown
how to test: pre-commit run --all-files && pytest -q
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68a80519fc9c832fa0afae359647059e