### PR TITLE
🐛 : – add workflow field to outage entry

### DIFF
--- a/outages/2025-08-22-missing-gh-token.json
+++ b/outages/2025-08-22-missing-gh-token.json
@@ -1,5 +1,7 @@
 {
+  "$schema": "./schema.json",
   "date": "2025-08-22",
+  "workflow": "contrib-heatmap",
   "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/17145073802",
   "root_cause": "Heatmap workflow attempted to commit files when GH_TOKEN was absent, leaving no generated SVGs and failing the commit step.",
   "resolution": "Conditionally run heatmap generation and commit steps only when GH_TOKEN is present."


### PR DESCRIPTION
## Summary
- add missing workflow and schema reference to 2025-08-22 outage log

## Testing
- `pyspelling -c spellcheck.yaml`
- `pre-commit run --files outages/2025-08-22-missing-gh-token.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a925adb310832f8bd52dabab11bc0d