### PR TITLE
🛠️ : fix test workflow install order

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v1
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v1
       - name: Install dependencies
         run: |
           uv pip install --system -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2025-08-23
 - fix: add missing workflow field to outage record to restore CI.
+- chore: set up Python before installing dependencies in test workflow.
 
 ## 2025-08-22
 - chore: skip Codecov upload when token is missing to prevent CI failures.

--- a/docs/outages/2025-08-23-python-setup-order.json
+++ b/docs/outages/2025-08-23-python-setup-order.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./schema.json",
+  "date": "2025-08-23",
+  "workflow": "Test Suite",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/17171955249",
+  "root_cause": "Dependencies installed before Python setup so packages were absent for Python 3.12.",
+  "resolution": "Set up Python before running uv pip so dependencies target the active interpreter."
+}

--- a/docs/pms/2025-08-23-python-setup-order.md
+++ b/docs/pms/2025-08-23-python-setup-order.md
@@ -1,0 +1,19 @@
+# Python setup after uv caused test failure
+
+- Date: 2025-08-23
+- Author: codex
+- Status: resolved
+
+## What went wrong
+The `Test Suite` workflow installed dependencies before Python 3.12 was configured, leaving
+`pytest` and other packages unavailable.
+
+## Root cause
+`uv pip` ran against the runner's default Python, so the subsequent 3.12 interpreter had no
+dependencies.
+
+## Impact
+CI failed immediately with `ModuleNotFoundError` when invoking `pytest`.
+
+## Actions to take
+- Set up Python before installing dependencies with `uv pip`.

--- a/outages/2025-08-23-python-setup-order.json
+++ b/outages/2025-08-23-python-setup-order.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./schema.json",
+  "date": "2025-08-23",
+  "workflow": "Test Suite",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/17171955249",
+  "root_cause": "Dependencies installed before Python setup so packages were absent for Python 3.12.",
+  "resolution": "Set up Python before running uv pip so dependencies target the active interpreter."
+}


### PR DESCRIPTION
what: set up Python before uv and document outage
why: deps installed for wrong interpreter broke CI
how to test: pytest --cov=./src --cov=./tests --cov-report=xml


------
https://chatgpt.com/codex/tasks/task_e_68a96e3454d8832fa629bb40bcfc2340