### PR TITLE
🧪 : upgrade setup-uv action in tests workflow

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Setup uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v6
       - name: Install dependencies
         run: |
           uv pip install --system -r requirements.txt


### PR DESCRIPTION
what: bump setup-uv action to v6 in tests workflow.
why: restore CI after Node 16 deprecation.
how to test: pytest --cov=./src --cov=./tests --cov-report=xml.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68aa8aa4e630832fb83336f6ca99eac8