### PR TITLE
🕸️ : crawl external prompt guides

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,16 +2,35 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Codex automation prompt |
-| [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD prompt |
-| [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-failure fix prompt |
-| [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex cleanup prompt |
-| [prompts/codex/fuzzing.md](prompts/codex/fuzzing.md) | Codex fuzzing prompt |
-| [prompts/codex/physics.md](prompts/codex/physics.md) | Codex physics explainer prompt |
-| [prompts/codex/propagate.md](prompts/codex/propagate.md) | Codex propagation prompt |
-| [prompts/codex/spellcheck.md](prompts/codex/spellcheck.md) | Codex spellcheck helper prompt |
-| [prompts-codex-spellcheck.md](prompts-codex-spellcheck.md) | Codex spellcheck instructions |
-| [prompts-codex-video-script-ideas.md](prompts-codex-video-script-ideas.md) | Codex video script ideas prompt |
-| [prompts-codex-video-script.md](prompts-codex-video-script.md) | Codex video script draft prompt |
-| [prompts-codex.md](prompts-codex.md) | Futuroptimist Codex baseline |
-
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
+| [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
+| [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |
+| [prompts/codex/fuzzing.md](prompts/codex/fuzzing.md) | Codex Fuzzing Prompt |
+| [prompts/codex/physics.md](prompts/codex/physics.md) | Codex Physics Explainer Prompt |
+| [prompts/codex/propagate.md](prompts/codex/propagate.md) | Codex Prompt Propagation Prompt |
+| [prompts/codex/spellcheck.md](prompts/codex/spellcheck.md) | Codex Spellcheck Prompt |
+| [prompts-codex-spellcheck.md](prompts-codex-spellcheck.md) | Codex Spellcheck Prompt |
+| [prompts-codex-video-script-ideas.md](prompts-codex-video-script-ideas.md) | Video Script Ideas Prompt |
+| [prompts-codex-video-script.md](prompts-codex-video-script.md) | Codex Video Script Prompt |
+| [prompts-codex.md](prompts-codex.md) | Futuroptimist Codex Prompt |
+| [dspace/prompts-items.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md) | Item Prompts |
+| [dspace/prompts-processes.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md) | Process Prompts |
+| [dspace/prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md) | Quest Prompts |
+| [dspace/prompts-npcs.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-npcs.md) | NPC Prompts |
+| [dspace/prompts-outages.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-outages.md) | Outage Prompts |
+| [dspace/prompts-backups.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-backups.md) | Backup Prompts |
+| [dspace/prompts-monitoring.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-monitoring.md) | Monitoring Prompts |
+| [dspace/prompts-audit.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-audit.md) | Dependency Audit Prompts |
+| [dspace/prompts-docs.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-docs.md) | Documentation Prompts |
+| [dspace/prompts-docs.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-docs.md#cross-link-check-prompt) | Documentation Prompts |
+| [dspace/prompts-docs.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-docs.md#proofreading-prompt) | Documentation Prompts |
+| [dspace/prompts-backend.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-backend.md) | Backend Prompts |
+| [dspace/prompts-frontend.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-frontend.md) | Frontend Prompts |
+| [dspace/prompts-accessibility.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-accessibility.md) | Accessibility Prompts |
+| [dspace/prompts-playwright-tests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-playwright-tests.md) | Playwright Test Prompts |
+| [dspace/prompts-vitest.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-vitest.md) | Vitest Test Prompts |
+| [dspace/prompts-refactors.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-refactors.md) | Refactor Prompts |
+| [dspace/prompts-codex-ci-fix.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-ci-fix.md) | Codex CI-Failure Fix Prompt |
+| [dspace/prompts-codex-meta.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-meta.md) | Codex Meta Prompt |
+| [dspace/prompts-codex-upgrader.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-upgrader.md) | Codex Prompt Upgrader |

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -2,31 +2,94 @@
 """Generate docs/prompt-docs-summary.md from prompt docs."""
 import argparse
 import pathlib
+import urllib.request
+
 import yaml
 
 
-def parse_title(path: pathlib.Path) -> str:
-    text = path.read_text(encoding="utf-8").splitlines()
-    if text and text[0].strip() == "---":
+def parse_title_lines(lines: list[str]) -> str:
+    """Return the title from Markdown lines."""
+
+    if lines and lines[0].strip() == "---":
         try:
-            end = text[1:].index("---") + 1
-            front = "\n".join(text[1:end])
+            end = lines[1:].index("---") + 1
+            front = "\n".join(lines[1:end])
             data = yaml.safe_load(front) or {}
             if "title" in data:
                 return str(data["title"])
-            text = text[end + 1 :]
+            lines = lines[end + 1 :]
         except ValueError:
-            text = text[1:]
-    for line in text:
+            lines = lines[1:]
+    for line in lines:
         if line.startswith("# "):
             return line[2:].strip()
-    return path.stem
+    return ""
+
+
+def parse_title(path: pathlib.Path) -> str:
+    return parse_title_lines(path.read_text(encoding="utf-8").splitlines()) or path.stem
+
+
+def extract_related_links(text: str) -> list[str]:
+    """Return relative links from the 'Related prompt guides' section."""
+
+    lines = text.splitlines()
+    try:
+        start = lines.index("## Related prompt guides") + 1
+    except ValueError:
+        return []
+    links = []
+    for line in lines[start:]:
+        if line.strip().startswith("## "):
+            break
+        if line.strip().startswith("-") and "(" in line and ")" in line:
+            link = line.split("(", 1)[1].split(")", 1)[0]
+            links.append(link)
+    return links
+
+
+def fetch_remote_titles(url: str) -> list[tuple[str, str, str]]:
+    """Fetch remote prompt docs referenced by a prompts-codex URL."""
+
+    with urllib.request.urlopen(
+        url
+    ) as resp:  # pragma: no cover - network stubbed in tests
+        text = resp.read().decode("utf-8")
+    rows = []
+    for rel in extract_related_links(text):
+        anchor = ""
+        if "#" in rel:
+            rel, anchor = rel.split("#", 1)
+            anchor = f"#{anchor}"
+        if rel.startswith("/docs/"):
+            rel_path = rel[len("/docs/") :]
+        else:
+            rel_path = rel.lstrip("/")
+        filename = f"{rel_path}.md"
+        raw = (
+            "https://raw.githubusercontent.com/democratizedspace/dspace/v3/frontend/src/pages/docs/md/"
+            f"{filename}"
+        )
+        with urllib.request.urlopen(
+            raw
+        ) as doc:  # pragma: no cover - network stubbed in tests
+            title = (
+                parse_title_lines(doc.read().decode("utf-8").splitlines()) or filename
+            )
+        html = (
+            "https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/"
+            f"{filename}{anchor}"
+        )
+        display = f"dspace/{filename}"
+        rows.append((display, html, title))
+    return rows
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repos-from", type=pathlib.Path, required=True)
     parser.add_argument("--out", type=pathlib.Path, required=True)
+    parser.add_argument("--external-prompts-codex", type=str, default=None)
     args = parser.parse_args()
 
     # Ensure repos-from exists even if unused.
@@ -36,11 +99,14 @@ def main() -> None:
     docs_dir = pathlib.Path("docs")
     rows = []
     for path in sorted(docs_dir.rglob("*.md")):
-        if path.resolve() == args.out.resolve():
-            continue
         rel = path.relative_to(docs_dir).as_posix()
+        if path.resolve() == args.out.resolve() or "prompts" not in rel:
+            continue
         title = parse_title(path)
-        rows.append((rel, title))
+        rows.append((rel, rel, title))
+
+    if args.external_prompts_codex:
+        rows.extend(fetch_remote_titles(args.external_prompts_codex))
 
     lines = [
         "# Prompt Docs Summary",
@@ -48,8 +114,8 @@ def main() -> None:
         "| Path | Description |",
         "|------|-------------|",
     ]
-    for rel, title in rows:
-        lines.append(f"| [{rel}]({rel}) | {title} |")
+    for display, link, title in rows:
+        lines.append(f"| [{display}]({link}) | {title} |")
 
     args.out.write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/tests/test_update_prompt_docs_summary.py
+++ b/tests/test_update_prompt_docs_summary.py
@@ -1,0 +1,76 @@
+import io
+import sys
+
+import scripts.update_prompt_docs_summary as upd
+
+
+class DummyResp(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_extract_related_links():
+    text = (
+        "## Related prompt guides\n\n"
+        "- [Item](/docs/prompts-items)\n"
+        "- [Docs](/docs/prompts-docs#section)\n\n"
+        "## Next"
+    )
+    links = upd.extract_related_links(text)
+    assert links == ["/docs/prompts-items", "/docs/prompts-docs#section"]
+
+
+def test_fetch_remote_titles(monkeypatch):
+    prompts_text = "## Related prompt guides\n\n- [Item](/docs/prompts-items)\n"
+    item_text = "---\ntitle: Item\n---\n# Item"
+
+    def fake_urlopen(url):
+        if url.endswith("prompts-codex.md"):
+            return DummyResp(prompts_text.encode())
+        if url.endswith("prompts-items.md"):
+            return DummyResp(item_text.encode())
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(upd.urllib.request, "urlopen", fake_urlopen)
+    rows = upd.fetch_remote_titles("https://example.com/prompts-codex.md")
+    assert rows == [
+        (
+            "dspace/prompts-items.md",
+            (
+                "https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/"
+                "prompts-items.md"
+            ),
+            "Item",
+        )
+    ]
+
+
+def test_main_generates_summary_with_remote(tmp_path, monkeypatch):
+    prompts_text = "## Related prompt guides\n\n- [Item](/docs/prompts-items)\n"
+    item_text = "---\ntitle: Item\n---\n# Item"
+
+    def fake_urlopen(url):
+        if url.endswith("prompts-codex.md"):
+            return DummyResp(prompts_text.encode())
+        if url.endswith("prompts-items.md"):
+            return DummyResp(item_text.encode())
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(upd.urllib.request, "urlopen", fake_urlopen)
+    out = tmp_path / "summary.md"
+    argv = [
+        "update_prompt_docs_summary.py",
+        "--repos-from",
+        "dict/prompt-doc-repos.txt",
+        "--out",
+        str(out),
+        "--external-prompts-codex",
+        "https://example.com/prompts-codex.md",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    upd.main()
+    text = out.read_text()
+    assert "dspace/prompts-items.md" in text


### PR DESCRIPTION
what: extend prompt summary crawler to fetch dspace related guides
why: keep prompt-docs-summary in sync with external prompt docs
how to test:
- ruff check --fix scripts/update_prompt_docs_summary.py tests/test_update_prompt_docs_summary.py
- black scripts/update_prompt_docs_summary.py tests/test_update_prompt_docs_summary.py
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68aa94762b68832f8c1ba974c7d9665f