### PR TITLE
🐛 Skip self in media index

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -60,7 +60,8 @@ Use `python src/index_local_media.py` to build `footage_index.json`
 so you can quickly locate clips while editing. Each entry includes
 the file path, modification time in UTC, and size in bytes, sorted
 deterministically by timestamp then path. The script creates the
-output directory if needed.
+output directory if needed and skips the index file itself when rerun
+inside the footage directory.
 
 ## Next Steps
 * Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).

--- a/tests/test_index_local_media.py
+++ b/tests/test_index_local_media.py
@@ -70,6 +70,16 @@ def test_creates_output_parent_dirs(tmp_path):
     assert nested.exists()
 
 
+def test_main_excludes_existing_output(tmp_path):
+    f = tmp_path / "clip.mov"
+    f.write_text("x")
+    out_file = tmp_path / "index.json"
+    out_file.write_text("old")
+    ilm.main([str(tmp_path), "-o", str(out_file)])
+    data = json.loads(out_file.read_text())
+    assert all(entry["path"] != "index.json" for entry in data)
+
+
 def test_scan_directory_deterministic_order(tmp_path, monkeypatch):
     f1 = tmp_path / "b.txt"
     f2 = tmp_path / "a.txt"


### PR DESCRIPTION
## Summary
- exclude existing index file when scanning local footage directories
- document index_local_media's self-skip behavior
- add regression test for output exclusion

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa938c3a44832f8373e97fec02521d