### PR TITLE
🐛 : add newline to index_local_media output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-08-24
+- fix: ensure index_local_media writes newline at end of file.
+
 ## 2025-08-23
 - fix: add missing workflow field to outage record to restore CI.
 - fix: treat 'timed out' variants as failures in status_to_emoji.

--- a/src/index_local_media.py
+++ b/src/index_local_media.py
@@ -65,7 +65,7 @@ def main(argv=None):
     index = scan_directory(base)
     output_path = pathlib.Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(index, indent=2))
+    output_path.write_text(json.dumps(index, indent=2) + "\n")
     print(f"Wrote {args.output}")
 
 

--- a/tests/test_index_local_media.py
+++ b/tests/test_index_local_media.py
@@ -70,6 +70,13 @@ def test_creates_output_parent_dirs(tmp_path):
     assert nested.exists()
 
 
+def test_main_writes_trailing_newline(tmp_path):
+    (tmp_path / "clip.mov").write_text("x")
+    out_file = tmp_path / "index.json"
+    ilm.main([str(tmp_path), "-o", str(out_file)])
+    assert out_file.read_text().endswith("\n")
+
+
 def test_scan_directory_deterministic_order(tmp_path, monkeypatch):
     f1 = tmp_path / "b.txt"
     f2 = tmp_path / "a.txt"


### PR DESCRIPTION
## Summary
- ensure `index_local_media` writes a trailing newline for stable diffs
- cover newline behavior with a regression test
- document the fix in the changelog

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa938c3a44832f8373e97fec02521d