### PR TITLE
🐛: handle 'canceled' workflow status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-08-24
+- fix: treat 'canceled' status as failure in repo_status.
+
 ## 2025-08-23
 - fix: add missing workflow field to outage record to restore CI.
 - fix: treat 'timed out' variants as failures in status_to_emoji.

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -26,7 +26,7 @@ def status_to_emoji(conclusion: str | None) -> str:
     receive the same result.
 
     - ``"success"`` → ✅
-    - ``"failure"``, ``"cancelled"``, ``"timed_out"`` → ❌
+    - ``"failure"``, ``"cancelled"``, ``"canceled"``, ``"timed_out"`` → ❌
     - anything else (including ``None``) → ❓
     """
     if conclusion:
@@ -35,7 +35,7 @@ def status_to_emoji(conclusion: str | None) -> str:
         normalized = ""
     if normalized == "success":
         return "✅"
-    if normalized in {"failure", "cancelled", "timed_out"}:
+    if normalized in {"failure", "cancelled", "canceled", "timed_out"}:
         return "❌"
     return "❓"
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -23,6 +23,7 @@ def test_status_to_emoji_strips_whitespace() -> None:
 
 def test_status_to_emoji_failure_variants() -> None:
     assert status_to_emoji("cancelled") == "❌"
+    assert status_to_emoji("canceled") == "❌"
     assert status_to_emoji("TIMED_OUT") == "❌"
     assert status_to_emoji("timed-out") == "❌"
     assert status_to_emoji("timed out") == "❌"


### PR DESCRIPTION
## Summary
- treat single-L `canceled` as failure in `status_to_emoji`
- document status handling update in changelog

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa938c3a44832f8373e97fec02521d