### PR TITLE
chore: mirror svg3d shading postmortem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-08-24
+- fix: validate svg3d shading factor to reject NaN and infinity.
+
 ## 2025-08-23
 - fix: add missing workflow field to outage record to restore CI.
 - fix: treat 'timed out' variants as failures in status_to_emoji.

--- a/docs/fuzzing-wins.md
+++ b/docs/fuzzing-wins.md
@@ -1,0 +1,6 @@
+# Fuzzing Wins
+
+Incidents uncovered by fuzzing and their postmortems.
+
+- **2025-08-24** – [svg3d non-finite factor](pms/2025-08-24-svg3d-nonfinite-factor.md):
+  reject non-finite shading factors to avoid crashes.

--- a/docs/pms/2025-08-24-svg3d-nonfinite-factor.md
+++ b/docs/pms/2025-08-24-svg3d-nonfinite-factor.md
@@ -1,0 +1,31 @@
+# svg3d shading failed on non-finite factor
+
+- Date: 2025-08-24
+- Author: codex
+- Status: resolved
+
+## Background
+`svg3d._shade` scales RGB components by a caller-supplied factor. The function assumes the factor is a
+finite float between 0 and 1.
+
+## Root cause
+The function multiplied RGB components by `factor` without verifying that the value was finite. When
+`NaN` or `inf` reached `int()`, Python raised a `ValueError` and aborted execution.
+
+## Detailed explanation
+`_shade` underpins `draw_bar`, which renders bars in 3‑D heatmaps. Fuzzing introduced non‑finite
+factors such as `float('nan')`. These values propagated through the multiplication step and failed
+when cast to integers, crashing any script invoking the helper.
+
+## Impact
+Malformed input could crash scripts invoking `_shade` or `draw_bar`.
+
+## Action items
+### Prevent
+- Validate shading factors with `math.isfinite` before computation.
+
+### Detect
+- Keep regression tests for non‑finite shading factors.
+
+### Mitigate
+- Raise a clear `ValueError` when encountering invalid factors.

--- a/outages/2025-08-24-svg3d-nonfinite-factor.json
+++ b/outages/2025-08-24-svg3d-nonfinite-factor.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./schema.json",
+  "date": "2025-08-24",
+  "workflow": "Fuzz Testing",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/0",
+  "root_cause": "svg3d._shade attempted to convert non-finite factor to int, raising ValueError.",
+  "resolution": "Validate factor with math.isfinite and reject non-finite inputs."
+}

--- a/src/svg3d.py
+++ b/src/svg3d.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-
+import math
 import svgwrite as sw
 
 CELL = 12
@@ -18,11 +18,13 @@ def _clamp(val: int) -> int:
 def _shade(color: str, factor: float) -> str:
     """Return ``color`` shaded by ``factor``.
 
-    ``color`` must be a hex string in ``#RRGGBB`` format. A ``ValueError`` is raised
-    if the input does not match this pattern or contains invalid hex digits.
+    ``color`` must be a hex string in ``#RRGGBB`` format. ``factor`` must be a finite
+    number. A ``ValueError`` is raised if inputs are invalid.
     """
     if not isinstance(color, str) or not color.startswith("#") or len(color) != 7:
         raise ValueError("color must be in format '#RRGGBB'")
+    if not math.isfinite(factor):
+        raise ValueError("factor must be finite")
     try:
         c = int(color[1:], 16)
     except ValueError as exc:  # pragma: no cover - defensive

--- a/tests/test_svg3d.py
+++ b/tests/test_svg3d.py
@@ -27,3 +27,10 @@ def test_shade_invalid_color():
         svg3d._shade("123456", 1)
     with pytest.raises(ValueError):
         svg3d._shade("#zzzzzz", 1)
+
+
+def test_shade_rejects_non_finite_factor():
+    with pytest.raises(ValueError, match="factor must be finite"):
+        svg3d._shade("#123456", float("nan"))
+    with pytest.raises(ValueError, match="factor must be finite"):
+        svg3d._shade("#123456", float("inf"))


### PR DESCRIPTION
## Summary
- record svg3d non-finite shading factor outage in fuzzing wins doc
- expand postmortem with background, detailed explanation, and action items

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint` (missing package.json)
- `npm run test:ci` (missing package.json)
- `python -m flywheel.fit` (module not found)

## Links
- [Postmortem](docs/pms/2025-08-24-svg3d-nonfinite-factor.md)
- [dspace entry](https://github.com/democratizedspace/dspace/blob/codex/svg3d-nonfinite-factor/outages/2025-08-24-svg3d-nonfinite-factor.json)
- [Fuzzing wins log](docs/fuzzing-wins.md)


------
https://chatgpt.com/codex/tasks/task_e_68aa93b95998832f8082f7933b07a29b