### PR TITLE
docs: add Codex prompt

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my
 If you're looking for the full project details, see
 [INSTRUCTIONS.md](INSTRUCTIONS.md). We manage Python dependencies with
 [uv](https://docs.astral.sh/uv/); check the instructions for setup steps.
-Guidelines for AI tools live in [AGENTS.md](AGENTS.md); automation prompts are in
-[docs/prompts/codex/automation.md](docs/prompts/codex/automation.md). The automated tests
-run via GitHub Actions on each push and pull request and currently reach **100%** coverage.
+Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
+The canonical Codex prompt for automated contributions is in
+[docs/prompts/codex/automation.md](docs/prompts/codex/automation.md).
+The automated tests run via GitHub Actions on each push and pull request and currently
+reach **100%** coverage.
 
 ## Related Projects
 _Last updated: 2025-08-27 04:02 UTC; checks hourly_

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -25,7 +25,8 @@ Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
 - Follow the conventions in AGENTS.md and README.md.
-- Ensure `pre-commit run --all-files` and `pytest -q` succeed.
+- Ensure `pre-commit run --all-files`, `pytest -q`, `npm run test:ci`,
+  `python -m flywheel.fit`, and `bash scripts/checks.sh` all succeed.
 - Make sure all GitHub Actions workflows pass and keep the README badges green.
 - If browser dependencies are missing, run `npm run playwright:install` or
   prefix tests with `SKIP_E2E=1`.


### PR DESCRIPTION
## Summary
- sync automation prompt instructions with flywheel
- reference canonical Codex prompt from README
- regenerate prompt docs summary
- sort wordlist to keep tests green

## Testing
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae8c61b978832fb101280e6b1c81d5