### PR TITLE
📝 docs: clarify propagation checks and sort wordlist

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/propagate.md
+++ b/docs/prompts/codex/propagate.md
@@ -32,9 +32,12 @@ CONTEXT:
 - If none exist, create `docs/prompts/codex/automation.md` based on the version in
   `futuroptimist/flywheel`.
 - Follow the repository's `AGENTS.md`, style guides, and commit conventions.
-- Run the repository's lint and test suite (e.g., `pre-commit run --all-files`,
-  `pytest -q`, `npm run lint`, `npm run test:ci`, `python -m flywheel.fit`,
-  `bash scripts/checks.sh`) before committing.
+- Run the repository's lint and test suite before committing:
+  - `pre-commit run --all-files`
+  - `pytest -q`
+  - `npm run lint` and `npm run test:ci` if a `package.json` is present
+  - `python -m flywheel.fit` if the module is available
+  - `bash scripts/checks.sh`
 
 REQUEST:
 1. Clone the repository and add the prompt doc.
@@ -60,12 +63,14 @@ You are an automated contributor for the Flywheel repository.
 PURPOSE:
 Keep this propagation prompt accurate for seeding prompt docs.
 
-CONTEXT:
-- Follow `AGENTS.md` and `README.md`.
-- Ensure `pre-commit run --all-files`, `pytest -q`, `npm run lint`,
-  `npm run test:ci`, `python -m flywheel.fit`, and `bash scripts/checks.sh` pass.
-- Regenerate `docs/prompt-docs-summary.md` with
-  `python scripts/update_prompt_docs_summary.py --repos-from \
+ CONTEXT:
+ - Follow `AGENTS.md` and `README.md`.
+ - Ensure `pre-commit run --all-files` and `pytest -q` pass.
+ - If a `package.json` exists, run `npm run lint` and `npm run test:ci`.
+ - If the `flywheel` module is available, run `python -m flywheel.fit`.
+ - Run `bash scripts/checks.sh`.
+ - Regenerate `docs/prompt-docs-summary.md` with
+   `python scripts/update_prompt_docs_summary.py --repos-from \
   dict/prompt-doc-repos.txt --out docs/prompt-docs-summary.md`.
 
 REQUEST:


### PR DESCRIPTION
what: document optional npm/flywheel checks, regenerate prompt summary, alphabetize wordlist
why: remove outdated instructions and keep tests passing
how to test: pre-commit run --all-files; pytest -q; bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68ae8c77bf20832f81d9a0f450980c19