### PR TITLE
📝: add solarpunk project brainstorm

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/ideas/solarpunk_video_project_brainstorm.md
+++ b/ideas/solarpunk_video_project_brainstorm.md
@@ -1,0 +1,5 @@
+- **Solar-Powered Window Farm** – A micro hydroponic tower fed by a thrift-store solar panel brings leafy greens to sunless apartments.
+- **Bioplastic Filament Forge** – Turn kitchen scraps into 3D-printer filament with a solar-heated extruder for zero-waste fabrication.
+- **Sun-Charged Mesh Router** – A palm-sized, PV-backed node keeps neighborhood Wi-Fi alive when the grid blinks.
+- **Rainlight Purifier** – A solar LED lantern that filters collected rainwater, illuminating and hydrating overnight.
+- **Upcycled E-Bike Generator** – Salvage e-bike parts to build a pedal-power station that tops off devices with every commute.


### PR DESCRIPTION
what: add solarpunk project brainstorm and sort wordlist
why: capture sustainable build ideas and keep tests passing
how to test: ruff check . && black --check . && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68ae8c8f98fc832f8d85d6e6293a4aad