### PR TITLE
📝: – refresh CAD prompt doc

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/cad.md
+++ b/docs/prompts/codex/cad.md
@@ -7,10 +7,10 @@ slug: 'codex-cad'
 Type: evergreen
 
 Use this prompt whenever CAD models or STL exports need updating. It mirrors the
-style of DSPACE's `docs/prompts/codex/automation.md` so the automation workflows
-stay consistent.
+conventions in [automation.md](automation.md) so automation workflows stay
+consistent.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the Flywheel repository focused on 3D assets.
 
@@ -18,9 +18,17 @@ PURPOSE:
 Keep CAD sources and exported models current and validated.
 
 CONTEXT:
-- Follow AGENTS.md and README.md.
+- Follow [AGENTS.md](../../../AGENTS.md) and [README.md](../../../README.md).
 - Ensure SCAD files export cleanly to STL and OBJ models.
-- Verify parts fit by running `python -m flywheel.fit`.
+- Verify parts fit with `python -m flywheel.fit`.
+- Ensure these commands succeed:
+  - `pre-commit run --all-files`
+  - `pytest -q`
+  - `npm run test:ci`
+  - `python -m flywheel.fit`
+  - `bash scripts/checks.sh`
+- If browser dependencies are missing, run `npx playwright install chromium`
+  or prefix tests with `SKIP_E2E=1`.
 
 REQUEST:
 1. Look for TODO comments in `cad/*.scad` or open issues tagged `cad`.
@@ -48,7 +56,7 @@ PURPOSE:
 Keep CAD instructions accurate and up to date.
 
 CONTEXT:
-- Follow `AGENTS.md` and `README.md`.
+- Follow [AGENTS.md](../../../AGENTS.md) and [README.md](../../../README.md).
 - Ensure `pre-commit run --all-files`, `pytest -q`, `npm run test:ci`,
   `python -m flywheel.fit`, and `bash scripts/checks.sh` pass.
 - Regenerate `docs/prompt-docs-summary.md` with


### PR DESCRIPTION
## What
- clarify CAD prompt instructions and test list
- regenerate prompt docs summary and sort word list

## Why
- remove stale references and keep prompt docs accurate

## How to test
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci` # fails: package.json missing
- `python -m flywheel.fit` # fails: No module named flywheel.fit
- `bash scripts/checks.sh` # fails: No module named flywheel.fit`

------
https://chatgpt.com/codex/tasks/task_e_68ae8bff4688832faf71c38921f3977a