### PR TITLE
docs: streamline spellcheck prompt instructions

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -22,9 +22,6 @@ CONTEXT:
 - Ensure these commands pass:
   - `pre-commit run --all-files`
   - `pytest -q`
-  - `npm run lint`
-  - `npm run test:ci`
-  - `python -m flywheel.fit`
   - `bash scripts/checks.sh`
 - Regenerate `docs/prompt-docs-summary.md` with:
   `python scripts/update_prompt_docs_summary.py --repos-from dict/prompt-doc-repos.txt --out docs/prompt-docs-summary.md`
@@ -55,8 +52,7 @@ Keep this spellcheck prompt accurate as tooling evolves.
 
 CONTEXT:
 - Follow `AGENTS.md` and `README.md`.
-- Ensure `pre-commit run --all-files`, `pytest -q`, `npm run lint`,
-  `npm run test:ci`, `python -m flywheel.fit`, and
+- Ensure `pre-commit run --all-files`, `pytest -q`, and
   `bash scripts/checks.sh` pass.
 - Regenerate `docs/prompt-docs-summary.md` with
   `python scripts/update_prompt_docs_summary.py --repos-from \

--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -26,8 +26,6 @@ CONTEXT:
   ```bash
   pre-commit run --all-files
   pytest -q
-  npm run test:ci
-  python -m flywheel.fit
   bash scripts/checks.sh
   ```
 - Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
@@ -61,8 +59,7 @@ Keep this spellcheck prompt accurate as tooling evolves.
 
 CONTEXT:
 - Follow `AGENTS.md` and `README.md`.
-- Ensure `pre-commit run --all-files`, `pytest -q`, `npm run test:ci`,
-  `python -m flywheel.fit`, and `bash scripts/checks.sh` pass.
+- Ensure `pre-commit run --all-files`, `pytest -q`, and `bash scripts/checks.sh` pass.
 - Regenerate `docs/prompt-docs-summary.md` with
   `python scripts/update_prompt_docs_summary.py --repos-from \
   dict/prompt-doc-repos.txt --out docs/prompt-docs-summary.md`.


### PR DESCRIPTION
## Summary
- remove outdated npm and flywheel steps from spellcheck prompts
- alphabetize `.wordlist.txt` and regenerate prompt summary

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae8c7cf9dc832fa1e112ac97b7170a