### PR TITLE
📝: expand fuzzing prompt edge cases

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/fuzzing.md
+++ b/docs/prompts/codex/fuzzing.md
@@ -32,6 +32,12 @@ CONTEXT:
 - Fuzz environment variables and config values with control characters, extremely long strings,
   and Unicode normalization quirks.
 - Attack deserializers: feed YAML/JSON/TOML bombs, NaN/Infinity, and mismatched types.
+- Corrupt dependencies and archives: truncated tarballs, mismatched hashes,
+  or supply-chain swaps.
+- Glitch network boundaries with packet loss, slowloris connections, and
+  replayed requests.
+- Trigger TOCTOU races: rename or delete files between opens, crash
+  mid-write, or restart processes.
 - When a crash, security flaw, or undefined behavior is found:
   * Add a minimal failing test reproducing the issue.
   * Patch the code so the new test passes without weakening existing coverage.


### PR DESCRIPTION
what: add supply-chain, network, and TOCTOU fuzzing tips; resort wordlist
why: cover emerging vectors and keep docs and tests in sync
how to test:
- pre-commit run --all-files
- pytest -q
- npm run lint (fails: package.json missing)
- npm run test:ci (fails: package.json missing)
- python -m flywheel.fit (module missing)
- bash scripts/checks.sh


------
https://chatgpt.com/codex/tasks/task_e_68ae8c24799c832f97b0eabfb5a82b5e