### PR TITLE
docs: expand fuzzing prompt guidance

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/fuzzing.md
+++ b/docs/prompts/codex/fuzzing.md
@@ -31,6 +31,9 @@ CONTEXT:
   and non-UTF-8 locales.
 - Fuzz environment variables and config values with control characters, extremely long strings,
   and Unicode normalization quirks.
+- Stress file permissions and sandboxing: read-only mounts, locked files, and privilege drops.
+- Fuzz network interactions: partial or out-of-order packets, TLS handshake quirks,
+  flaky DNS, and connection timeouts.
 - Attack deserializers: feed YAML/JSON/TOML bombs, NaN/Infinity, and mismatched types.
 - When a crash, security flaw, or undefined behavior is found:
   * Add a minimal failing test reproducing the issue.


### PR DESCRIPTION
what: broaden fuzzing prompt with permission and network cases
why: catch emerging edge scenarios and keep docs summarized
how to test: pre-commit run --all-files; pytest -q;
             bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68ae8c24799c832f97b0eabfb5a82b5e