### PR TITLE
🧪: broaden fuzzing guidance with new edge cases

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/fuzzing.md
+++ b/docs/prompts/codex/fuzzing.md
@@ -32,6 +32,10 @@ CONTEXT:
 - Fuzz environment variables and config values with control characters, extremely long strings,
   and Unicode normalization quirks.
 - Attack deserializers: feed YAML/JSON/TOML bombs, NaN/Infinity, and mismatched types.
+- Stress archive handlers with deeply nested or oversized files (e.g. zip bombs).
+- Inject Unicode bidirectional overrides and homoglyphs into paths and identifiers to surface spoofing.
+- Simulate adversarial networks: truncated frames, out-of-order packets,
+  malformed TLS handshakes, and slow-loris streams.
 - When a crash, security flaw, or undefined behavior is found:
   * Add a minimal failing test reproducing the issue.
   * Patch the code so the new test passes without weakening existing coverage.


### PR DESCRIPTION
what: note zip bombs, unicode spoofing, and network faults in fuzzing prompt
why: keep fuzzing instructions aligned with emerging vectors
how to test: pre-commit run --all-files && pytest -q && bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68ae8c24799c832f97b0eabfb5a82b5e