### PR TITLE
fix: resort word list to restore CI

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-08-27
+- chore: resort `.wordlist.txt` to fix failing wordlist test.
+- docs: add outage record and postmortem for wordlist sorting regression.
+
 ## 2025-08-25
 - fix: treat 'startup_failure' status as failure in repo_status.
 - fix: replace invalid UTF-8 bytes when parsing SRT files to prevent crashes.

--- a/docs/outages/2025-08-27-wordlist-unsorted.json
+++ b/docs/outages/2025-08-27-wordlist-unsorted.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "./schema.json",
+    "date": "2025-08-27",
+    "workflow": "Test Suite",
+    "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/0",
+    "root_cause": ".wordlist.txt contained out-of-order entries (gitignored before github) causing test_wordlist_is_alphabetized to fail.",
+    "resolution": "Resorted and deduplicated .wordlist.txt to restore CI."
+}

--- a/docs/pms/2025-08-27-wordlist-unsorted.md
+++ b/docs/pms/2025-08-27-wordlist-unsorted.md
@@ -1,0 +1,18 @@
+# wordlist sorting regression
+
+- Date: 2025-08-27
+- Author: codex
+- Status: resolved
+
+## What went wrong
+The custom spellcheck word list `.wordlist.txt` contained an out-of-order entry.
+
+## Root cause
+`gitignored` was inserted ahead of `github`, violating the alphabetical constraint enforced by `test_wordlist_is_alphabetized`.
+
+## Impact
+The Test Suite workflow failed, blocking CI for new commits.
+
+## Actions to take
+- Sort and deduplicate `.wordlist.txt` after adding new terms.
+- Keep `test_wordlist_is_alphabetized` to detect regressions early.


### PR DESCRIPTION
## Summary
- resort `.wordlist.txt` to restore alphabetical order
- record outage and postmortem for wordlist regression

The Test Suite failed because `.wordlist.txt` listed `gitignored` before `github`, tripping `test_wordlist_is_alphabetized`.

## Testing
- `uv run pytest --cov=./src --cov=./tests --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae8c06fc64832fba4aa4d9a22edb7e