### PR TITLE
📝: clarify CI-fix prompt checks

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -72,14 +72,28 @@ Ensure this file lives at `docs/prompts/codex/ci-fix.md`.
 Regenerate the prompt summary:
 
 ```bash
-python scripts/update_prompt_docs_summary.py --repos-from dict/prompt-doc-repos.txt --out docs/prompt-docs-summary.md
+python scripts/update_prompt_docs_summary.py \
+  --repos-from dict/prompt-doc-repos.txt \
+  --out docs/prompt-docs-summary.md
 ```
 
-Ensure `dict/prompt-doc-repos.txt` matches `docs/repo_list.txt` so downstream repositories stay connected.
+Run the repository checks before committing:
 
-Push and open a PR in flywheel; once merged, downstream repos can import the new prompt automatically through Flywheel’s existing propagation workflow.
+```bash
+pre-commit run --all-files
+pytest -q
+bash scripts/checks.sh
+git diff --cached | ./scripts/scan-secrets.py
+```
 
-If you later need to reference the prompt programmatically, its slug (codex-ci-fix) will generate /docs/prompts/codex/ci-fix at build time.
+Ensure `dict/prompt-doc-repos.txt` matches `docs/repo_list.txt` so downstream repos stay
+connected.
+
+Push and open a PR in flywheel. Once merged, downstream repos can import the new
+prompt automatically through Flywheel’s existing propagation workflow.
+
+If you later need to reference the prompt programmatically, its slug (codex-ci-fix) will
+generate `/docs/prompts/codex/ci-fix` at build time.
 
 ## 3 – Further reading & references
 OpenAI Codex overview and prompt design basics


### PR DESCRIPTION
what: document CI-fix checks and secret scan; refresh summary; sort wordlist
why: align prompt with workflow and keep tests green
how to test:
- pre-commit run --all-files
- pytest -q
- bash scripts/checks.sh


------
https://chatgpt.com/codex/tasks/task_e_68ae8c12a9d0832fa0fea4d65476961e