### PR TITLE
📝: – align CI fix prompt with workflow

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -128,6 +128,7 @@ Keep this CI-fix prompt aligned with current workflow patterns.
 
   CONTEXT:
   - Follow `AGENTS.md` and `README.md`.
+  - Inspect `.github/workflows/` and mirror CI steps locally.
   - Ensure `pre-commit run --all-files`, `pytest -q`, and
     `bash scripts/checks.sh` pass.
   - Scan staged changes for secrets with


### PR DESCRIPTION
## What
- clarify CI-fix prompt to mirror `.github/workflows/`
- alphabetize `.wordlist.txt`
- regenerate prompt summary

## Why
- keep instructions current and tests green

## How to test
- `pre-commit run --all-files`
- `pytest -q`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae8c12a9d0832fa0fea4d65476961e