### PR TITLE
Skip reversed SRT timecodes

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/pms/2025-08-27-reversed-srt-times.md
+++ b/docs/pms/2025-08-27-reversed-srt-times.md
@@ -1,0 +1,7 @@
+# Reversed SRT times
+
+- **Date**: 2025-08-27
+- **Summary**: `parse_srt` allowed captions where the start time was after the end time, creating negative-duration entries.
+- **Root Cause**: The parser missed validation for non-increasing timecodes.
+- **Resolution**: Ignore caption entries with start times greater than or equal to their end times.
+- **Lessons**: Fuzz timestamp order to catch reversed ranges early.

--- a/docs/pms/dspace/2025-08-27-reversed-srt-times.md
+++ b/docs/pms/dspace/2025-08-27-reversed-srt-times.md
@@ -1,0 +1,7 @@
+# Reversed SRT times
+
+- **Date**: 2025-08-27
+- **Summary**: `parse_srt` allowed captions where the start time was after the end time, creating negative-duration entries.
+- **Root Cause**: The parser missed validation for non-increasing timecodes.
+- **Resolution**: Ignore caption entries with start times greater than or equal to their end times.
+- **Lessons**: Fuzz timestamp order to catch reversed ranges early.

--- a/outages/2025-08-27-reversed-srt-times.json
+++ b/outages/2025-08-27-reversed-srt-times.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./schema.json",
+  "date": "2025-08-27",
+  "workflow": "tests",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/0",
+  "root_cause": "parse_srt accepted captions with start >= end time",
+  "resolution": "skip entries with non-increasing timecodes"
+}

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -61,7 +61,7 @@ def parse_srt(path: pathlib.Path) -> List[Tuple[str, str, str]]:
                 text_lines.append(lines[i].strip())
                 i += 1
             text = clean_srt_text(" ".join(text_lines))
-            if text:
+            if text and start < end:
                 entries.append((start, end, text))
         else:
             i += 1

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -1,6 +1,7 @@
 import sys
 import runpy
 import warnings
+import random
 import src.srt_to_markdown as stm
 
 
@@ -162,6 +163,17 @@ Real line
 
     entries = stm.parse_srt(path)
     assert entries == [("00:00:01,500", "00:00:02,000", "Real line")]
+
+
+def test_skip_reversed_times_fuzz(tmp_path):
+    random.seed(0)
+    path = tmp_path / "bad.srt"
+    for _ in range(10):
+        start_ms = random.randint(500, 999)
+        end_ms = random.randint(0, 499)
+        srt = f"1\n00:00:00,{start_ms:03d} --> 00:00:00,{end_ms:03d}\nBad timing\n"
+        path.write_text(srt)
+        assert stm.parse_srt(path) == []
 
 
 def test_parse_srt_edge_cases(tmp_path):


### PR DESCRIPTION
## Summary
- ignore captions where start >= end to avoid negative durations
- add fuzz test covering reversed timecodes
- document outage and postmortem

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint` *(fails: package.json missing)*
- `npm run test:ci` *(fails: package.json missing)*
- `python -m flywheel.fit` *(fails: module not found)*
- `bash scripts/checks.sh`

Postmortem: docs/pms/2025-08-27-reversed-srt-times.md
Dspace: https://github.com/democratizedspace/dspace/blob/v3/futuroptimist/2025-08-27-reversed-srt-times.md

------
https://chatgpt.com/codex/tasks/task_e_68ae8c20db08832fa493bb81c757760e