### PR TITLE
Clarify CAD prompt fallback

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/cad.md
+++ b/docs/prompts/codex/cad.md
@@ -27,6 +27,7 @@ REQUEST:
 2. Update the SCAD geometry or regenerate STL/OBJ files if they are outdated.
 3. Run `python -m flywheel.fit` to confirm dimensions match.
 4. Commit updated models and documentation.
+5. If none of the above reveal work, polish a small part of the CAD workflow or docs.
 
 OUTPUT:
 A pull request summarizing the CAD changes and test results.


### PR DESCRIPTION
## Summary
- note fallback step to make small CAD improvements when no TODOs remain
- regenerate prompt docs summary and sort project wordlist

## Testing
- `linkchecker README.md docs/`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae8bf7bd10832f88fe77f904392548