### PR TITLE
📝 : – encourage fallback CAD refinements

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,7 +2,7 @@
 
 | Path | Description |
 |------|-------------|
-| [prompts/codex/automation.md](prompts/codex/automation.md) | Flywheel Codex Prompt |
+| [prompts/codex/automation.md](prompts/codex/automation.md) | Futuroptimist Codex Prompt |
 | [prompts/codex/cad.md](prompts/codex/cad.md) | Codex CAD Prompt |
 | [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [prompts/codex/cleanup.md](prompts/codex/cleanup.md) | Codex Prompt Cleanup |

--- a/docs/prompts/codex/cad.md
+++ b/docs/prompts/codex/cad.md
@@ -24,6 +24,7 @@ CONTEXT:
 
 REQUEST:
 1. Look for TODO comments in `cad/*.scad` or open issues tagged `cad`.
+   If none are found, identify and apply a minor improvement to the CAD sources or related docs.
 2. Update the SCAD geometry or regenerate STL/OBJ files if they are outdated.
 3. Run `python -m flywheel.fit` to confirm dimensions match.
 4. Commit updated models and documentation.


### PR DESCRIPTION
what: prompt tells agents to make minor CAD tweaks when no TODOs.
why: avoids no-op runs; keeps prompt-docs-summary current.
how to test: pre-commit run --files docs/prompts/codex/cad.md;
pytest -q; bash scripts/checks.sh (npm/flywheel checks skipped).
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68ae8bf7bd10832f88fe77f904392548