### PR TITLE
🐛 : strip leading dashes from SRT captions

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-08-27
+- fix: strip leading dashes from SRT caption lines.
+- chore: alphabetize custom word list.
+
 ## 2025-08-25
 - fix: treat 'startup_failure' status as failure in repo_status.
 - fix: replace invalid UTF-8 bytes when parsing SRT files to prevent crashes.

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -12,12 +12,14 @@ def clean_srt_text(text: str) -> str:
     attributes), and ``<br>`` to Markdown equivalents while stripping any other HTML
     tags. Tag matching is case-insensitive.
     Non-breaking spaces (``&nbsp;``) are converted to regular spaces.
-    Speaker prefixes such as ``- [Narrator]`` are removed. Runs of whitespace are
-    collapsed to a single space so downstream scripts see clean, predictable text.
+    Speaker prefixes such as ``- [Narrator]`` and standalone leading dashes are
+    removed. Runs of whitespace are collapsed to a single space so downstream
+    scripts see clean, predictable text.
     """
 
     text = html.unescape(text).replace("\xa0", " ")
     text = re.sub(r"^-?\s*\[[^\]]+\]\s*:?\s*", "", text)
+    text = re.sub(r"^[\-\u2013\u2014]\s+", "", text)
     text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
     text = re.sub(r"</?(i|em)\b[^>]*>", "*", text, flags=re.IGNORECASE)
     text = re.sub(r"</?(b|strong)\b[^>]*>", "**", text, flags=re.IGNORECASE)

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -1,6 +1,7 @@
 import sys
 import runpy
 import warnings
+import pytest
 import src.srt_to_markdown as stm
 
 
@@ -142,6 +143,19 @@ def test_strip_speaker_prefix(tmp_path):
 - [Narrator] Hello world
 """
     path = tmp_path / "speaker.srt"
+    path.write_text(srt)
+
+    entries = stm.parse_srt(path)
+    assert entries == [("00:00:00,000", "00:00:01,000", "Hello world")]
+
+
+@pytest.mark.parametrize("dash", ["-", "\u2013", "\u2014"])
+def test_strip_leading_dash(tmp_path, dash):
+    srt = f"""1
+00:00:00,000 --> 00:00:01,000
+{dash} Hello world
+"""
+    path = tmp_path / "dash.srt"
     path.write_text(srt)
 
     entries = stm.parse_srt(path)


### PR DESCRIPTION
## Summary
- drop leading dash markers when converting SRT to markdown
- keep custom word list alphabetized

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae8bf16b1c832f99c412cde7d1a2af