### PR TITLE
🛡️: – detect fine-grained GitHub tokens

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,8 +50,8 @@ gabriel
 gambusia
 gfx
 gh
-gitignored
 github
+gitignored
 gitshelves
 graphql
 gridfinity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-08-27
+- feat: detect fine-grained GitHub tokens in scan-secrets script.
+
 ## 2025-08-25
 - fix: treat 'startup_failure' status as failure in repo_status.
 - fix: replace invalid UTF-8 bytes when parsing SRT files to prevent crashes.

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -3,7 +3,7 @@
 
 Reads unified diff content from ``stdin`` and scans only the **added** lines
 for secret-like patterns such as AWS keys, private keys, generic API key
-assignments, and GitHub tokens (``ghp_…`` etc.). The scan is intentionally
+assignments, and GitHub tokens (``ghp_…`` or ``github_pat_…``). The scan is intentionally
 lightweight and should be supplemented with dedicated tools for thorough
 auditing.
 """
@@ -17,6 +17,7 @@ PATTERNS = [
     re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----"),
     re.compile(r"(?i)(api_key|apikey|password|secret)[\s:=]+[^\n]+"),
     re.compile(r"gh[pousr]_[0-9A-Za-z]{36}"),
+    re.compile(r"github_pat_[0-9A-Za-z_]{22}_[0-9A-Za-z]{59}"),
 ]
 
 

--- a/tests/test_scan_secrets.py
+++ b/tests/test_scan_secrets.py
@@ -18,3 +18,12 @@ def test_flags_github_token() -> None:
     assert proc.returncode == 1
     assert "Possible secrets detected" in proc.stderr
     assert token in proc.stderr
+
+
+def test_flags_github_pat_token() -> None:
+    token = "github_pat_" + "A" * 22 + "_" + "B" * 59
+    diff = "diff --git a/x b/x\n" "--- a/x\n" "+++ b/x\n" "@@\n" f"+token={token}\n"
+    proc = run_scan(diff)
+    assert proc.returncode == 1
+    assert "Possible secrets detected" in proc.stderr
+    assert token in proc.stderr


### PR DESCRIPTION
what: detect GitHub fine-grained tokens in scan-secrets.
why: broaden secret scanning for leaked PATs.
how to test: pre-commit run --all-files && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68ae8bf16b1c832f99c412cde7d1a2af