### PR TITLE
🧹 : drop pyheif dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-09-01
+- chore: drop pyheif dependency and simplify HEIF conversion.
+
 ## 2025-08-27
 - feat: detect fine-grained GitHub tokens in scan-secrets script.
 - chore: whitelist project jargon for spellcheck.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ pillow>=10.0.0
 pillow-heif>=0.15.0
 rawpy>=0.23.0
 imageio>=2.34.0
-pyheif>=0.7.1

--- a/src/convert_assets.py
+++ b/src/convert_assets.py
@@ -431,8 +431,9 @@ def _convert_with_libraries(conv: Conversion) -> bool:
             from PIL import Image, ImageOps, ImageCms
             import io
 
-            # Try pillow-heif first, then pyheif fallback
+            # Use pillow-heif to read HEIF/HEIC images
             image = None
+            icc = None
             try:
                 from pillow_heif import read_heif
 
@@ -440,19 +441,7 @@ def _convert_with_libraries(conv: Conversion) -> bool:
                 image = Image.frombytes(heif.mode, heif.size, heif.data)
                 icc = heif.info.get("icc_profile")
             except Exception:
-                try:
-                    import pyheif
-
-                    h = pyheif.read(str(conv.src))
-                    image = Image.frombytes(h.mode, h.size, h.data, "raw", h.mode, 0, 1)
-                    icc = None
-                    for meta in h.metadata or []:
-                        if meta.get("type") == "prof":
-                            icc = meta.get("data")
-                            break
-                except Exception:
-                    image = None
-                    icc = None
+                image = None
             if image is None:
                 return False
             # Apply EXIF orientation


### PR DESCRIPTION
## What
- remove pyheif fallback and dependency
- document change in changelog

## Why
- pyheif requires libheif headers not available in CI

## How to Test
- `pre-commit run --files requirements.txt src/convert_assets.py CHANGELOG.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b541b9b05c832fae8cf070d6c34f38