### PR TITLE
🩹 : bump rawpy for Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2025-09-01
 - chore: drop pyheif dependency and simplify HEIF conversion.
+- fix: bump rawpy to avoid Python 3.12 build failures.
+- docs: record rawpy wheel outage.
 
 ## 2025-08-27
 - feat: detect fine-grained GitHub tokens in scan-secrets script.

--- a/outages/2025-09-01-rawpy-py312-wheel.json
+++ b/outages/2025-09-01-rawpy-py312-wheel.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "./schema.json",
+    "date": "2025-09-01",
+    "workflow": "tests",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/17370113596",
+  "root_cause": "rawpy 0.23 lacked Python 3.12 wheels, causing uv pip install to fail",
+  "resolution": "pinned rawpy to 0.25.1 which ships prebuilt wheels"
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pyyaml>=6.0.0
 imageio-ffmpeg>=0.4.9
 pillow>=10.0.0
 pillow-heif>=0.15.0
-rawpy>=0.23.0
+rawpy>=0.25.1
 imageio>=2.34.0

--- a/verify_report.json
+++ b/verify_report.json
@@ -1,4 +1,1 @@
-{
-  "errors": [],
-  "count": 0
-}
+{"errors": [], "count": 0}


### PR DESCRIPTION
## Summary
- bump rawpy to 0.25.1 so CI installs wheels on Python 3.12
- document rawpy wheel outage

## Testing
- `pytest --cov=./src --cov=./tests --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_68b54534af10832fbd93d5d3873aac0d