### PR TITLE
🩹 pin rawpy to 0.25.1 for reliable tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-09-02
+- fix: pin rawpy to 0.25.1 to ensure Python 3.12 wheels.
+- test: assert rawpy requirement is pinned.
+- docs: record test suite outage for rawpy pin.
+
 ## 2025-09-01
 - chore: drop pyheif dependency and simplify HEIF conversion.
 - fix: bump rawpy to avoid Python 3.12 build failures.

--- a/outages/2025-09-02-rawpy-pin.json
+++ b/outages/2025-09-02-rawpy-pin.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./schema.json",
+  "date": "2025-09-02",
+  "workflow": "Test Suite",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/17370644977",
+  "root_cause": "rawpy >=0.25.1 allowed a wheel-less release that failed to build on Python 3.12",
+  "resolution": "pinned rawpy to 0.25.1 which ships prebuilt wheels"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pyyaml>=6.0.0
 imageio-ffmpeg>=0.4.9
 pillow>=10.0.0
 pillow-heif>=0.15.0
-rawpy>=0.25.1
+rawpy==0.25.1
 imageio>=2.34.0

--- a/tests/test_rawpy_pin.py
+++ b/tests/test_rawpy_pin.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_rawpy_pinned() -> None:
+    """Ensure rawpy is pinned to a prebuilt version."""
+    reqs = Path("requirements.txt").read_text().splitlines()
+    for line in reqs:
+        if line.startswith("rawpy"):
+            assert line.strip() == "rawpy==0.25.1"
+            break
+    else:  # pragma: no cover - executed only if rawpy missing
+        pytest.fail("rawpy not listed in requirements.txt")


### PR DESCRIPTION
## Summary
- pin rawpy to 0.25.1 to ensure Python 3.12 wheel availability
- add test enforcing the pinned rawpy version
- record test suite outage for missing rawpy wheels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6830cc298832fa5147fd737fe7b60