### PR TITLE
🧪 pin tests to Python 3.11

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
       - name: Create virtualenv

--- a/outages/2025-09-02-py312-rawpy.json
+++ b/outages/2025-09-02-py312-rawpy.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./schema.json",
+  "date": "2025-09-02",
+  "workflow": "02-tests.yml",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/17370644977",
+  "root_cause": "rawpy wheel missing for Python 3.12 causing uv pip install to fail",
+  "resolution": "Pinned workflow to Python 3.11 until wheels are available"
+}


### PR DESCRIPTION
## Summary
- run CI tests on Python 3.11 to avoid rawpy wheel error
- log rawpy wheel outage

## Testing
- `pre-commit run --files .github/workflows/02-tests.yml outages/2025-09-02-py312-rawpy.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6830cc298832fa5147fd737fe7b60