### PR TITLE
📝 : clarify CI mirroring in CI-fix prompt

### DIFF
--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -23,6 +23,7 @@ Diagnose a failed GitHub Actions run and produce a fix.
 
 CONTEXT:
 - Given a link to a failed job, fetch the logs, infer the root cause, and create a minimal, well-tested pull request that makes the workflow green again.
+- Inspect the repository's `.github/workflows/` and mirror the failing job's steps locally.
 - Consult existing outage entries in `outages` for similar symptoms.
 - Constraints:
   * Do **not** break existing functionality.


### PR DESCRIPTION
what: add instruction to mirror workflows and refresh summary
why: keep ci-fix guidance current
how to test: pre-commit run --all-files && pytest -q && bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b7d52111fc832faf47e9097ddab7b8