### PR TITLE
📝 : refine ci-fix prompt

### DIFF
--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -38,8 +38,9 @@ REQUEST:
 1. Read the failure logs and locate the first real error.
 2. Explain (in the pull-request body) *why* the failure occurred.
 3. Commit the necessary code, configuration, or documentation changes.
-4. Record the incident in `outages/YYYY-MM-DD-<slug>.json` using `outages/schema.json`.
-5. Push to a branch named `codex/ci-fix/<short-description>`.
+4. Record the incident in `outages/YYYY-MM-DD-<slug>.json` using `outages/schema.json`,
+   and write a matching `outages/YYYY-MM-DD-<slug>.md` postmortem.
+5. Push to a branch named `codex/ci-fix` (extend with `-<short>` if helpful).
 6. Open a pull request that – once merged – makes the default branch CI-green.
 7. After merge, post a follow-up comment on this prompt with lessons learned so we can refine it.
 


### PR DESCRIPTION
what: clarify outage record and branch naming in ci-fix doc
why: keep ci-fix prompt aligned with workflow
how to test: pre-commit run --all-files && pytest -q && bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b7d52111fc832faf47e9097ddab7b8