### PR TITLE
docs: align CI-fix prompt with workflow

### DIFF
--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -78,9 +78,11 @@ python scripts/update_prompt_docs_summary.py \
   --out docs/prompt-docs-summary.md
 ```
 
-Run the repository checks before committing:
+Install dependencies and run the repository checks before committing:
 
 ```bash
+uv venv
+uv pip install -r requirements.txt
 pre-commit run --all-files
 pytest -q
 bash scripts/checks.sh


### PR DESCRIPTION
what: add uv setup step to CI-fix prompt; refresh prompt summary
why: ensure instructions match repo workflow
how to test: pre-commit run --all-files; pytest -q; bash scripts/checks.sh
Refs: none

------
https://chatgpt.com/codex/tasks/task_e_68b7d52111fc832faf47e9097ddab7b8