### PR TITLE
🛠️ fix: allow multi-digit SRT hour fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-09-03
+- fix: allow multi-digit hour fields in `parse_srt` for very long videos.
+- test: cover SRT parsing with hours beyond 99.
+- docs: record SRT hour overflow outage and postmortem.
+
 ## 2025-09-02
 - fix: set up Python before uv in docs workflow.
 - docs: record docs workflow outage.

--- a/outages/2025-09-03-srt-hour-overflow.json
+++ b/outages/2025-09-03-srt-hour-overflow.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./schema.json",
+  "date": "2025-09-03",
+  "workflow": "tests",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/0",
+  "root_cause": "parse_srt rejected captions when hour fields exceeded two digits",
+  "resolution": "allow multi-digit hour values in SRT timecodes"
+}

--- a/outages/2025-09-03-srt-hour-overflow.md
+++ b/outages/2025-09-03-srt-hour-overflow.md
@@ -1,0 +1,7 @@
+# SRT hour overflow
+
+- **Date**: 2025-09-03
+- **Summary**: `parse_srt` skipped captions when hour fields used more than two digits.
+- **Root Cause**: The regex expected exactly two digits for the hour component.
+- **Resolution**: Permit multi-digit hour values so long-duration captions parse correctly.
+- **Lessons**: Fuzz time fields with large values to catch format limits early.

--- a/outages/dspace/2025-09-03-srt-hour-overflow.md
+++ b/outages/dspace/2025-09-03-srt-hour-overflow.md
@@ -1,0 +1,7 @@
+# SRT hour overflow
+
+- **Date**: 2025-09-03
+- **Summary**: `parse_srt` skipped captions when hour fields used more than two digits.
+- **Root Cause**: The regex expected exactly two digits for the hour component.
+- **Resolution**: Permit multi-digit hour values so long-duration captions parse correctly.
+- **Lessons**: Fuzz time fields with large values to catch format limits early.

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -47,8 +47,9 @@ def parse_srt(path: pathlib.Path) -> List[Tuple[str, str, str]]:
             if i + 1 >= len(lines):
                 break
             time_line = lines[i + 1].strip()
+            # Support captions exceeding 99 hours by allowing multi-digit hour fields.
             match = re.match(
-                r"(\d{2}:\d{2}:\d{2},\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2},\d{3})",
+                r"(\d{2,}:\d{2}:\d{2},\d{3})\s*-->\s*(\d{2,}:\d{2}:\d{2},\d{3})",
                 time_line,
             )
             if not match:

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -228,3 +228,14 @@ def test_parse_srt_invalid_utf8(tmp_path):
     p.write_bytes(data)
     entries = stm.parse_srt(p)
     assert entries == [("00:00:00,000", "00:00:01,000", "Hi�")]
+
+
+def test_parse_srt_large_hour_values(tmp_path):
+    srt = """1
+100:00:00,000 --> 100:00:01,000
+Hello
+"""
+    path = tmp_path / "long.srt"
+    path.write_text(srt)
+    entries = stm.parse_srt(path)
+    assert entries == [("100:00:00,000", "100:00:01,000", "Hello")]


### PR DESCRIPTION
what: allow parse_srt to handle hours over two digits
why: long SRT files skipped lines when hours reached 100+
how to test: pre-commit run --all-files && pytest -q
postmortem: outages/2025-09-03-srt-hour-overflow.md
dspace: outages/dspace/2025-09-03-srt-hour-overflow.md

------
https://chatgpt.com/codex/tasks/task_e_68b7d49ae50c832f86071e7c78581f06