### PR TITLE
🛡️ : expand fuzzing prompt edge cases

### DIFF
--- a/docs/prompts/codex/fuzzing.md
+++ b/docs/prompts/codex/fuzzing.md
@@ -41,6 +41,11 @@ CONTEXT:
   replayed requests.
 - Trigger TOCTOU races: rename or delete files between opens, crash
   mid-write, or restart processes.
+- Stress signal handling: rapid SIGINT, SIGTERM, SIGHUP, and SIGPIPE
+  to verify cleanup and restart logic.
+- Probe container boundaries and sandbox escapes: shifting cgroup limits,
+  seccomp filter misconfigurations, and `LD_PRELOAD` tricks.
+- Inject corrupted caches or partial writes to test persistence and recovery paths.
 - When a crash, security flaw, or undefined behavior is found:
   * Add a minimal failing test reproducing the issue.
   * Patch the code so the new test passes without weakening existing coverage.


### PR DESCRIPTION
What: document signal storms, container escapes, and cache corruption in fuzzing prompt.
Why: keep guidance aligned with emerging attack vectors.
How to test: pre-commit run --all-files; pytest -q; bash scripts/checks.sh.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b7d49f435c832fa1b20fbfcea525e6