### PR TITLE
🐛 : – handle action_required in repo_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix: pin rawpy to 0.25.1 to ensure Python 3.12 wheels.
 - test: assert rawpy requirement is pinned.
 - docs: record test suite outage for rawpy pin.
+- fix: treat 'action_required' status as failure in repo_status.
 
 ## 2025-09-01
 - chore: drop pyheif dependency and simplify HEIF conversion.

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -29,7 +29,7 @@ def status_to_emoji(conclusion: str | None) -> str:
 
     - ``"success"`` → ✅
     - ``"failure"``, ``"cancelled"``, ``"canceled"``, ``"timed_out"``,
-      ``"startup_failure"`` → ❌
+      ``"startup_failure"``, ``"action_required"`` → ❌
     - anything else (including ``None`` or non-strings) → ❓
     """
     if not isinstance(conclusion, str) or not conclusion:
@@ -44,6 +44,7 @@ def status_to_emoji(conclusion: str | None) -> str:
         "canceled",
         "timed_out",
         "startup_failure",
+        "action_required",
     }:
         return "❌"
     return "❓"
@@ -95,6 +96,7 @@ def fetch_repo_status(
         "canceled",
         "timed_out",
         "startup_failure",
+        "action_required",
     }
 
     def _fetch() -> str | None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -38,6 +38,9 @@ def test_status_to_emoji_failure_variants() -> None:
     assert status_to_emoji("timed out") == "❌"
     assert status_to_emoji("startup_failure") == "❌"
     assert status_to_emoji("STARTUP FAILURE") == "❌"
+    assert status_to_emoji("action_required") == "❌"
+    assert status_to_emoji("action-required") == "❌"
+    assert status_to_emoji("action required") == "❌"
 
 
 class DummyResp:


### PR DESCRIPTION
what: map action_required conclusions to failure
why: show ❌ when manual action is needed
how to test: pre-commit run --all-files && pytest -q
Refs: #123

------
https://chatgpt.com/codex/tasks/task_e_68b7d429386c832f8059b69e662f0649