### PR TITLE
Handle missing npm in checks script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-09-03
+- fix: handle missing npm in checks script and ensure trailing newline.
+- test: verify checks script handles missing npm and newline.
+
 ## 2025-09-02
 - fix: set up Python before uv in docs workflow.
 - docs: record docs workflow outage.

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 pre-commit run --all-files
 pytest -q
 
-if [ -f package.json ]; then
+if [ -f package.json ] && command -v npm >/dev/null 2>&1; then
   npm run lint
   npm run test:ci
 else
-  echo "Skipping npm checks: package.json not found" >&2
+  echo "Skipping npm checks: package.json not found or npm missing" >&2
 fi
 
 if python - <<'PY'

--- a/tests/test_checks_script.py
+++ b/tests/test_checks_script.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_checks_script_has_trailing_newline():
+    data = Path("scripts/checks.sh").read_bytes()
+    assert data.endswith(b"\n"), "checks.sh should end with a newline"
+
+
+def test_checks_script_handles_missing_npm():
+    text = Path("scripts/checks.sh").read_text()
+    assert "command -v npm >/dev/null 2>&1" in text
+    assert "package.json not found or npm missing" in text
+


### PR DESCRIPTION
## Summary
- skip npm lint/test steps when package.json is absent or npm missing
- test checks script for npm guard and trailing newline

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint` *(fails: package.json not found)*
- `npm run test:ci` *(fails: package.json not found)*
- `python -m flywheel.fit` *(fails: module not found)*
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b7d429386c832f8059b69e662f0649