### PR TITLE
🧹 : refine cleanup prompt instructions

### DIFF
--- a/docs/prompts/codex/cleanup.md
+++ b/docs/prompts/codex/cleanup.md
@@ -6,7 +6,7 @@ slug: 'codex-cleanup'
 # Obsolete Prompt Cleanup
 Type: evergreen
 
-Use this prompt to delete one-off prompts already implemented and remove any lingering references.
+Use this prompt to remove one-off prompts already implemented and clean up lingering references.
 
 ```text
 SYSTEM: You are an automated contributor for the Flywheel repository.
@@ -15,24 +15,24 @@ PURPOSE:
 Maintain prompt hygiene by deleting fulfilled one-off prompts and clearing outdated references.
 
 CONTEXT:
-- Scan `docs/` for prompts marked `Type: one-off` whose features exist in the codebase.
-- Delete those prompt sections or files.
-- Regenerate `docs/prompt-docs-summary.md` with
-  `python scripts/update_prompt_docs_summary.py --repos-from dict/prompt-doc-repos.txt --out docs/prompt-docs-summary.md`.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
+- Search `docs/` for prompts marked `Type: one-off` whose features now exist in the codebase.
+- Delete those prompts or sections.
+- Regenerate `docs/prompt-docs-summary.md` with:
+  `python scripts/update_prompt_docs_summary.py --repos-from dict/prompt-doc-repos.txt \`
+  `--out docs/prompt-docs-summary.md`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 - Run checks:
-  `pre-commit run --all-files`,
-  `pytest -q`,
-  `npm ci` (if `package.json` exists),
-  `npm run lint` (if `package.json` exists),
-  `npm run test:ci` (if `package.json` exists),
-  `python -m flywheel.fit` (if installed), and
-  `bash scripts/checks.sh`.
+  - `pre-commit run --all-files`
+  - `pytest -q`
+  - `npm ci` (if `package.json` exists)
+  - `npm run lint` (if `package.json` exists)
+  - `npm run test:ci` (if `package.json` exists)
+  - `python -m flywheel.fit` (if installed)
+  - `bash scripts/checks.sh`
 
 REQUEST:
-1. Identify an obsolete prompt.
-2. Remove it and update references.
+1. Locate an obsolete prompt.
+2. Remove it and refresh references such as `docs/prompt-docs-summary.md`.
 3. Run all required checks before committing.
 
 OUTPUT:
@@ -54,11 +54,17 @@ Keep this cleanup prompt effective for removing obsolete items.
 CONTEXT:
 - Follow `AGENTS.md` and `README.md`.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
-- Ensure `pre-commit run --all-files`, `pytest -q`, `npm ci` (if `package.json` exists),
-  `npm run lint` (if `package.json` exists), `npm run test:ci` (if `package.json` exists),
-  `python -m flywheel.fit` (if installed), and `bash scripts/checks.sh` pass.
-- Regenerate `docs/prompt-docs-summary.md` with
-  `python scripts/update_prompt_docs_summary.py --repos-from dict/prompt-doc-repos.txt --out docs/prompt-docs-summary.md`.
+- Run checks:
+  - `pre-commit run --all-files`
+  - `pytest -q`
+  - `npm ci` (if `package.json` exists)
+  - `npm run lint` (if `package.json` exists)
+  - `npm run test:ci` (if `package.json` exists)
+  - `python -m flywheel.fit` (if installed)
+  - `bash scripts/checks.sh`
+- Regenerate `docs/prompt-docs-summary.md` with:
+  `python scripts/update_prompt_docs_summary.py --repos-from dict/prompt-doc-repos.txt \`
+  `--out docs/prompt-docs-summary.md`.
 
 REQUEST:
 1. Review this file for outdated steps or unclear language.


### PR DESCRIPTION
what: clarify cleanup prompt steps and reformat check list
why: keep instructions current for removing obsolete prompts
how to test:
- pre-commit run --all-files
- pytest -q
- bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b7d4956dfc832fb065ef3c4be433cc