### PR TITLE
📝 : clarify CI-fix prompt checks

### DIFF
--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -146,14 +146,16 @@ Keep this CI-fix prompt aligned with current workflow patterns.
   - Inspect `.github/workflows/` and mirror CI steps locally.
   - Ensure `pre-commit run --all-files`, `pytest -q`, and
     `bash scripts/checks.sh` pass.
+  - If `package.json` exists, `scripts/checks.sh` also runs
+    `npm run lint` and `npm run test:ci`.
   - Scan staged changes for secrets with
     `git diff --cached | ./scripts/scan-secrets.py`.
   - Regenerate `docs/prompt-docs-summary.md` with
     `python scripts/update_prompt_docs_summary.py --repos-from \
     dict/prompt-doc-repos.txt --out docs/prompt-docs-summary.md`.
-- Keep `dict/prompt-doc-repos.txt` in sync with `docs/repo_list.txt`. These
-  repositories are "small flywheels" belted to this codebase—if the summary
-  script drops any, fix the repo or integration instead of removing it.
+  - Keep `dict/prompt-doc-repos.txt` in sync with `docs/repo_list.txt`. These
+    repositories are "small flywheels" belted to this codebase—if the summary
+    script drops any, fix the repo or integration instead of removing it.
 
 REQUEST:
 1. Audit this document for outdated guidance or missing steps.


### PR DESCRIPTION
what: document npm checks in CI-fix prompt and nest repo list note
why: keep CI-fix instructions current
how to test: pre-commit run --all-files && pytest -q && bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68b7d48ba598832fac397ccb99aebfec