### PR TITLE
📝: note coverage in ci-fix prompt

### DIFF
--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -82,7 +82,7 @@ Run the repository checks before committing:
 
 ```bash
 pre-commit run --all-files
-pytest -q
+pytest --cov=./src --cov=./tests
 bash scripts/checks.sh
 git diff --cached | ./scripts/scan-secrets.py
 ```
@@ -144,7 +144,7 @@ Keep this CI-fix prompt aligned with current workflow patterns.
   CONTEXT:
   - Follow `AGENTS.md` and `README.md`.
   - Inspect `.github/workflows/` and mirror CI steps locally.
-  - Ensure `pre-commit run --all-files`, `pytest -q`, and
+  - Ensure `pre-commit run --all-files`, `pytest --cov=./src --cov=./tests`, and
     `bash scripts/checks.sh` pass.
   - Scan staged changes for secrets with
     `git diff --cached | ./scripts/scan-secrets.py`.


### PR DESCRIPTION
## Summary
- document running pytest with coverage in the CI-fix prompt

## Testing
- `python scripts/update_prompt_docs_summary.py --repos-from dict/prompt-doc-repos.txt --out docs/prompt-docs-summary.md`
- `pre-commit run --all-files`
- `pytest --cov=./src --cov=./tests`
- `bash scripts/checks.sh`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d48ba598832fac397ccb99aebfec