### PR TITLE
docs: clarify Playwright install in CAD prompt

### DIFF
--- a/docs/prompts/codex/cad.md
+++ b/docs/prompts/codex/cad.md
@@ -27,7 +27,7 @@ CONTEXT:
   - `npm run test:ci`
   - `python -m flywheel.fit`
   - `bash scripts/checks.sh`
-- If browser dependencies are missing, run `npx playwright install chromium`
+- If browser dependencies are missing, run `npm run playwright:install`
   or prefix tests with `SKIP_E2E=1`.
 
 REQUEST:


### PR DESCRIPTION
what: clarify Playwright install guidance in CAD prompt.
why: match current npm script name.
how to test:
- pre-commit run --all-files
- pytest -q
- npm run lint # package.json missing
- npm run test:ci # package.json missing
- python -m flywheel.fit # module not found
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68b7d4679984832fbbec51d885c2e0ef