### PR TITLE
📐 : document yield-based flywheel speed limit

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,6 +50,7 @@ fi
 finalise
 fmt
 formatters
+frac
 frontend
 futuroptimist
 gabriel
@@ -133,6 +134,7 @@ shigley
 slugify
 solarpunk
 spacex
+sqrt
 src
 srcset
 srt

--- a/docs/flywheel-construction.md
+++ b/docs/flywheel-construction.md
@@ -55,6 +55,16 @@ where $\rho$ is the material density. At 3 000 rpm the stress is about
 $0.5\,\text{MPa}$, well below the alloy's $276\,\text{MPa}$ yield strength.
 Compare the computed stress to the material limit to set a safe operating speed.
 
+Setting $\sigma$ equal to the alloy's yield strength $\sigma_y$ and solving for
+angular velocity gives a conservative limit,
+
+$$\omega_{\max} \approx \sqrt{\frac{3\sigma_y}{\rho r_o^2}}.$$
+For $\sigma_y = 276\,\text{MPa}$ and $r_o = 75\,\text{mm}$, the maximum speed is
+about $7.4\times10^3\,\text{rad·s}^{-1}$ (roughly $70\,000\,\text{rpm}$).
+Designers typically apply a safety factor to this value to account for fatigue
+and manufacturing tolerances.
+
+
 ```
     outer radius r
       ┌────────────┐


### PR DESCRIPTION
## Summary
- note how to compute max angular velocity from 6061‑T6 yield strength
- allow math macros in wordlist to satisfy spellcheck

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci` *(fails: package.json missing)*
- `python3 -m flywheel.fit` *(fails: No module named 'flywheel')*
- `bash scripts/checks.sh` *(skips npm checks; flywheel.fit missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d44db6c8832f9764df8db86a608d