### PR TITLE
Fix 02-tests workflow secrets gating

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -22,9 +24,9 @@ jobs:
       - name: Run tests
         run: uv run pytest --cov=./src --cov=./tests --cov-report=xml
       - name: Upload coverage reports to Codecov
-        if: ${{ secrets.CODECOV_TOKEN }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/outages/2025-09-24-tests-secrets-if.json
+++ b/outages/2025-09-24-tests-secrets-if.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./schema.json",
+  "date": "2025-09-24",
+  "workflow": "tests",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/17991609228",
+  "root_cause": "The tests workflow used `if: ${{ secrets.CODECOV_TOKEN }}`, but the `secrets` context is unavailable in step conditions so GitHub rejected the workflow before any jobs ran.",
+  "resolution": "Expose the Codecov token via a job-level environment variable and gate the upload step on that env value instead of referencing the secrets context directly."
+}

--- a/outages/2025-09-24-tests-secrets-if.md
+++ b/outages/2025-09-24-tests-secrets-if.md
@@ -1,0 +1,9 @@
+# Invalid secrets context in tests workflow
+
+- **Date**: 2025-09-24
+- **Summary**: GitHub Actions refused to run `.github/workflows/02-tests.yml` because it referenced the `secrets` context inside a step `if` expression.
+- **Impact**: The "Test Suite" workflow terminated immediately on every push and pull request, so no tests or coverage ran and the badge stayed ❓.
+- **Root Cause**: `if: ${{ secrets.CODECOV_TOKEN }}` is not allowed—`secrets` context cannot be used in step conditions, so the workflow validation failed before scheduling any jobs.
+- **Resolution**: Promote the Codecov token into a job-level environment variable and guard the upload step with `if: ${{ env.CODECOV_TOKEN != '' }}` while passing the env value to the action.
+- **Lessons**: Lint workflows for forbidden contexts (e.g., with actionlint) and rely on env-scoped flags instead of referencing `secrets` directly in conditions.
+- **Links**: [Outage record](2025-09-24-tests-secrets-if.json)

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -10,3 +11,12 @@ def test_workflows_parse():
     for path in WORKFLOWS_DIR.glob("*.yml"):
         with path.open("r", encoding="utf-8") as f:
             yaml.safe_load(f)
+
+
+def test_workflows_do_not_use_secrets_in_if():
+    for path in WORKFLOWS_DIR.glob("*.yml"):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if line.strip().startswith("if:") and "secrets." in line:
+                pytest.fail(
+                    f"{path.name}:{lineno} uses secrets context in if expression"
+                )


### PR DESCRIPTION
## Summary
- ensure the tests workflow exposes the Codecov token via env vars and only runs the upload step when the token is present to satisfy GitHub's workflow validation
- add a regression test that fails if any workflow uses the secrets context inside an `if` expression
- record the outage caused by the invalid secrets context in both JSON and Markdown logs

## Testing
- `uv run pytest --cov=./src --cov=./tests --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68d474bfcf0c832f8386b6b5fec61f56