### PR TITLE
🛠️ : collapse rerun noise in repo status

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The automated tests run via GitHub Actions on each push and pull request and cur
 reach **100%** coverage.
 
 ## Related Projects
-_Last updated: 2025-09-26 05:02 UTC; checks hourly_
+_Last updated: 2025-09-26 05:40 UTC; checks hourly_
 Status icons: ✅ latest run succeeded, ❌ failed or cancelled, ❓ no completed runs.
 
 - ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – central hub for
@@ -32,7 +32,7 @@ Status icons: ✅ latest run succeeded, ❌ failed or cancelled, ❓ no complete
 - ✅ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach
   real-world hobbies with NPC guides; offline-first so your space-base thrives without a
   signal ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles
+- ✅ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles
   lint, tests, docs, and release automation with LLM agents so solo builders ship like a
   team
 - ✅ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first "guardian angel"

--- a/outages/2025-09-26-related-projects-flywheel.json
+++ b/outages/2025-09-26-related-projects-flywheel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./schema.json",
+  "date": "2025-09-26",
+  "workflow": "Update Repo Statuses",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/runs/18028361184",
+  "root_cause": "fetch_repo_status treated earlier failed attempts as failures even after a rerun succeeded",
+  "resolution": "deduplicated workflow runs by workflow/run number and kept only the latest attempt before evaluating conclusions"
+}

--- a/outages/2025-09-26-related-projects-flywheel.md
+++ b/outages/2025-09-26-related-projects-flywheel.md
@@ -1,0 +1,15 @@
+# Related Projects flywheel false alarm
+
+- **Date**: 2025-09-26
+- **Summary**: The hourly status updater marked the flywheel repo as failing even though the latest
+  workflow rerun succeeded.
+- **Impact**: The README's Related Projects section showed a ❌ badge for flywheel, creating a false
+  perception that the template was unhealthy.
+- **Root Cause**: `fetch_repo_status` treated any historical failure for a commit as authoritative,
+  even when a newer rerun of the same workflow succeeded.
+- **Resolution**: Deduplicate workflow runs by workflow/run number and keep only the most recent
+  attempt before evaluating the conclusion. Added a regression test and verified the API now reports
+  ✅ for `futuroptimist/flywheel`.
+- **Lessons Learned**: When sampling GitHub Actions history, collapse reruns so stale data cannot
+  override the current signal.
+- **Links**: [Outage record](2025-09-26-related-projects-flywheel.json)


### PR DESCRIPTION
what: dedupe workflow runs, honor scheduled badges, document outage.
why: flywheel badge showed ❌ after a passing rerun.
how: pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d62613e8d0832fafe2fcc6d7c172c5