### PR TITLE
Split SRT captions into sentence-level narrator lines

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -20,7 +20,10 @@ Script format:
 - `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling
   italics and bold tags (`<i>/<em>` and `<b>/<strong>`, even with attributes), line breaks,
   emoji, case-insensitive HTML tags, removing speaker prefixes, stripping other tags,
-  collapsing extra whitespace, and skipping non-dialog lines like `[Music]`.
+  collapsing extra whitespace, and skipping non-dialog lines like `[Music]`. Tests such as
+  `tests/test_srt_to_markdown.py::test_to_markdown_splits_sentences` and
+  `::test_to_markdown_handles_abbreviations` ensure multi-sentence captions expand into one
+  `[NARRATOR]` line per thought without breaking common abbreviations.
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -238,6 +238,43 @@ def test_entrypoint(tmp_path, monkeypatch, capsys):
     assert "[NARRATOR]: Hi" in captured.out
 
 
+def test_to_markdown_splits_sentences():
+    entries = [
+        (
+            "00:00:00,000",
+            "00:00:05,000",
+            "First sentence. Second sentence? Third sentence!",
+        )
+    ]
+    md = stm.to_markdown(entries, "", "")
+    narrator_lines = [
+        line for line in md.splitlines() if line.startswith("[NARRATOR]: ")
+    ]
+    assert narrator_lines == [
+        "[NARRATOR]: First sentence.  <!-- 00:00:00,000 -> 00:00:05,000 -->",
+        "[NARRATOR]: Second sentence?  <!-- 00:00:00,000 -> 00:00:05,000 -->",
+        "[NARRATOR]: Third sentence!  <!-- 00:00:00,000 -> 00:00:05,000 -->",
+    ]
+
+
+def test_to_markdown_handles_abbreviations():
+    entries = [
+        (
+            "00:00:10,000",
+            "00:00:15,000",
+            "Dr. Smith arrives soon. Ready to roll.",
+        )
+    ]
+    md = stm.to_markdown(entries, "", "")
+    narrator_lines = [
+        line for line in md.splitlines() if line.startswith("[NARRATOR]: ")
+    ]
+    assert narrator_lines == [
+        "[NARRATOR]: Dr. Smith arrives soon.  <!-- 00:00:10,000 -> 00:00:15,000 -->",
+        "[NARRATOR]: Ready to roll.  <!-- 00:00:10,000 -> 00:00:15,000 -->",
+    ]
+
+
 def test_parse_srt_invalid_utf8(tmp_path):
     data = b"1\n00:00:00,000 --> 00:00:01,000\nHi\x80\n"
     p = tmp_path / "bad.srt"


### PR DESCRIPTION
what: split multi-sentence captions into per-sentence narrator lines and document the tests
why: AGENTS.md already promises sentence-scoped `[NARRATOR]` lines for imported transcripts
how to test:
- pytest -q
- pre-commit run --all-files (SKIP=heatmap)
- npm run test:ci (fails: package.json is absent)
- python -m flywheel.fit (fails: module not installed)
- bash scripts/checks.sh (SKIP=heatmap)


------
https://chatgpt.com/codex/tasks/task_e_68dcc4a8f498832fbe0005372b3c7e4e