### PR TITLE
Add heuristic image captions to describe_images

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -35,7 +35,7 @@ make test       # run unit tests
 make subtitles  # download captions listed in video_ids.txt
 make index_footage  # build simple footage_index.json (paths, mtime, size)
 make index_assets   # build rich assets_index.json from per-video assets.json
-make describe_images  # scan images and write image_descriptions.md
+make describe_images  # scan images and write heuristic captions to image_descriptions.md
 make convert_assets   # convert incompatible originals/ into converted/ via ffmpeg
 make convert_all      # convert images+videos for all slugs (or SLUG=YYYYMMDD_slug)
 make verify_assets    # verify converted assets match originals
@@ -82,6 +82,9 @@ Asset conversion (Premiere compatibility): run `make convert_assets` to scan
 `footage/<slug>/originals/` for formats like HEIC/HEIF, DNG, WEBP and convert
 them to Premiere-friendly JPG/PNG under `footage/<slug>/converted/` with the
 same relative structure. Originals are preserved. Use `python src/convert_assets.py --dry-run` to preview and `--force` to overwrite existing outputs.
+
+`tests/test_describe_images.py` covers the heuristic captioning so changes to
+`src/describe_images.py` keep emitting meaningful alt-text summaries.
 
 ## Next Steps
 * Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).

--- a/docs/video-editing-playbook.md
+++ b/docs/video-editing-playbook.md
@@ -73,7 +73,7 @@ Purpose: A fast, repeatable path from long selects to a tight 3–5 minute video
 ```bash
 make convert_all SLUG=<slug>
 make verify_assets
-make describe_images
+make describe_images  # refresh heuristic image captions
 make index_assets
 ```
 

--- a/src/describe_images.py
+++ b/src/describe_images.py
@@ -1,19 +1,36 @@
-"""Generate rough image descriptions for footage images into a markdown file.
+"""Generate heuristic image descriptions for footage assets.
 
-This script currently creates a placeholder list of images with filenames and
-basic metadata (size, mtime). Hook points are provided to integrate a real
-vision model (e.g., CLIP/LAION/OpenCLIP or cloud APIs) when available.
+The script scans a footage directory, gathers lightweight metadata, and now
+generates a short natural-language summary for each image by sampling colours,
+estimating brightness, and reporting the orientation. This keeps
+``image_descriptions.md`` useful even without an external vision model while
+leaving room to swap in richer captions later.
 """
 
 from __future__ import annotations
 
 import argparse
+import colorsys
 import mimetypes
 import pathlib
 from datetime import datetime, timezone
 
+from PIL import Image, ImageStat
+
 
 IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".heic", ".dng", ".webp"}
+
+
+def _register_heif() -> None:
+    try:
+        from pillow_heif import register_heif_opener  # type: ignore
+
+        register_heif_opener()
+    except Exception:
+        pass
+
+
+_register_heif()
 
 
 def is_image(path: pathlib.Path) -> bool:
@@ -23,6 +40,96 @@ def is_image(path: pathlib.Path) -> bool:
     # Fallback using mimetypes
     mt, _ = mimetypes.guess_type(path.name)
     return bool(mt and mt.startswith("image/"))
+
+
+def _load_image_stats(
+    path: pathlib.Path,
+) -> tuple[int, int, tuple[float, float, float]]:
+    with Image.open(path) as image:
+        width, height = image.size
+        preview = image.copy()
+        preview.thumbnail((96, 96))
+        stat = ImageStat.Stat(preview.convert("RGB"))
+    return width, height, (stat.mean[0], stat.mean[1], stat.mean[2])
+
+
+def _raw_dimensions(path: pathlib.Path) -> tuple[int, int] | None:
+    if path.suffix.lower() != ".dng":
+        return None
+    try:
+        import rawpy  # type: ignore
+
+        with rawpy.imread(str(path)) as raw:
+            return int(raw.sizes.width), int(raw.sizes.height)
+    except Exception:
+        return None
+
+
+def _orientation(width: int | None, height: int | None) -> str:
+    if not width or not height:
+        return "framed"
+    ratio = width / height
+    if ratio >= 1.15:
+        return "landscape"
+    if ratio <= 0.87:
+        return "portrait"
+    return "square"
+
+
+def _color_summary(mean: tuple[float, float, float] | None) -> tuple[str, str]:
+    if mean is None:
+        return "Textured", "neutral tones"
+    r, g, b = (channel / 255.0 for channel in mean)
+    hue, lightness, saturation = colorsys.rgb_to_hls(r, g, b)
+    brightness = (
+        "Dim" if lightness < 0.35 else "Vivid" if lightness > 0.65 else "Balanced"
+    )
+    if saturation < 0.12:
+        return brightness, "neutral tones"
+    hue = (hue * 360.0) % 360.0
+    palette_map = [
+        (30, "warm red tones"),
+        (60, "orange highlights"),
+        (90, "golden yellow tones"),
+        (150, "fresh green tones"),
+        (210, "cool teal tones"),
+        (270, "ocean blue tones"),
+        (330, "purple accents"),
+        (360, "warm red tones"),
+    ]
+    for boundary, label in palette_map:
+        if hue < boundary:
+            return brightness, label
+    return brightness, "neutral tones"
+
+
+def _summarise_image(path: pathlib.Path) -> str:
+    width: int | None = None
+    height: int | None = None
+    mean: tuple[float, float, float] | None = None
+    try:
+        width, height, mean = _load_image_stats(path)
+    except Exception:
+        dims = _raw_dimensions(path)
+        if dims:
+            width, height = dims
+    orientation = _orientation(width, height)
+    brightness, palette = _color_summary(mean)
+    base = (
+        f"{brightness} {orientation} image"
+        if orientation != "framed"
+        else f"{brightness} image"
+    )
+    description = f"{base} with {palette}" if palette else base
+    details: list[str] = []
+    ext = path.suffix.lstrip(".")
+    if ext:
+        details.append(ext.upper())
+    if width and height:
+        details.append(f"{width}x{height}")
+    if details:
+        description = f"{description} ({', '.join(details)})"
+    return description
 
 
 def describe_images(root: pathlib.Path) -> list[dict]:
@@ -41,8 +148,7 @@ def describe_images(root: pathlib.Path) -> list[dict]:
                     "path": p.as_posix(),
                     "size": stat.st_size,
                     "mtime": mtime,
-                    # Placeholder. Integrate a real model here.
-                    "description": "",
+                    "description": _summarise_image(p),
                 }
             )
     entries.sort(key=lambda e: e["path"])

--- a/tests/test_describe_images.py
+++ b/tests/test_describe_images.py
@@ -1,6 +1,8 @@
 import pathlib
 
-from src.describe_images import is_image, describe_images
+from PIL import Image
+
+from src.describe_images import describe_images, is_image
 
 
 def test_is_image_detection():
@@ -10,12 +12,20 @@ def test_is_image_detection():
     assert not is_image(pathlib.Path("d.mp4"))
 
 
-def test_describe_images_collects(tmp_path):
-    img = tmp_path / "x.jpg"
-    img.write_bytes(b"1234")
+def test_describe_images_generates_summary(tmp_path):
+    img = tmp_path / "x.png"
+    Image.new("RGB", (40, 20), color=(240, 120, 10)).save(img)
+
     vid = tmp_path / "y.mp4"
     vid.write_bytes(b"zz")
+
     entries = describe_images(tmp_path)
-    paths = [e["path"] for e in entries]
-    assert img.as_posix() in paths
-    assert all(".mp4" not in p for p in paths)
+    paths = [entry["path"] for entry in entries]
+    record = {entry["path"]: entry for entry in entries}[img.as_posix()]
+    description = record["description"].lower()
+
+    assert "landscape" in description
+    assert "png" in description
+    assert "40x20" in description
+    assert "pending" not in description
+    assert all(not p.endswith(".mp4") for p in paths)


### PR DESCRIPTION
## Summary
- replace the placeholder describe_images output with colour/orientation heuristics so every entry gains a short caption
- extend tests/test_describe_images.py to cover the new summaries and guard against regressions
- document the refreshed behaviour in INSTRUCTIONS.md and the video editing playbook

## Testing
- SKIP=heatmap pre-commit run --all-files
- pytest -q
- npm run test:ci *(fails: repository has no package.json)*
- python -m flywheel.fit *(fails: module not installed in this environment)*
- SKIP=heatmap bash scripts/checks.sh


------
https://chatgpt.com/codex/tasks/task_e_68dcc4a8f498832fbe0005372b3c7e4e