### PR TITLE
feat: add YouTube metadata enrichment

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -87,11 +87,16 @@ same relative structure. HEIC/HEIF/DNG stills are exported as high-quality
 existing outputs. See `tests/test_convert_assets.py` for regression coverage of
 the extension mapping.
 
+Run `python src/enrich_metadata.py` to pull each video's title, publish date,
+and duration directly from the YouTube Data v3 API when `metadata.json`
+contains a `youtube_id`. Export `YOUTUBE_API_KEY` before running; add
+`--dry-run` to preview which files would change. The behaviour is covered by
+`tests/test_enrich_metadata.py` so future edits stay regression-tested.
+
 `tests/test_describe_images.py` covers the heuristic captioning so changes to
 `src/describe_images.py` keep emitting meaningful alt-text summaries.
 
 ## Next Steps
-* Automate enrichment of each video entry via the YouTube Data v3 API (publish date, title, duration, etc.).
 * Convert `.srt` caption timing into fully-fledged markdown scripts.
 * Build a lightweight RAG pipeline that indexes past scripts for rapid outline generation of future videos.
 

--- a/llms.txt
+++ b/llms.txt
@@ -34,6 +34,10 @@ Script format:
   file paths, UTC modification times, and file sizes for assets stored in the
   local `footage/` directory. Use `--exclude PATH` (repeatable) to skip
   files or folders.
+- Run `python src/enrich_metadata.py` to sync `metadata.json` title,
+  publish date, and duration fields from the YouTube Data v3 API whenever
+  `YOUTUBE_API_KEY` is exported. Add `--dry-run` to preview changes; see
+  `tests/test_enrich_metadata.py` for coverage.
 
 Run tests with:
 ```bash

--- a/src/enrich_metadata.py
+++ b/src/enrich_metadata.py
@@ -17,9 +17,7 @@ import urllib.request
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 VIDEO_ROOT = BASE_DIR / "video_scripts"
 ENV_VAR = "YOUTUBE_API_KEY"
-API_URL = (
-    "https://www.googleapis.com/youtube/v3/videos?part=snippet,contentDetails&id={ids}&key={key}"
-)
+API_URL = "https://www.googleapis.com/youtube/v3/videos?part=snippet,contentDetails&id={ids}&key={key}"
 
 
 @dataclass(frozen=True)
@@ -72,7 +70,9 @@ def _chunked(items: Sequence[str], size: int) -> Iterable[list[str]]:
         yield list(items[i : i + size])
 
 
-def fetch_video_metadata(video_ids: Sequence[str], youtube_key: str) -> dict[str, VideoInfo]:
+def fetch_video_metadata(
+    video_ids: Sequence[str], youtube_key: str
+) -> dict[str, VideoInfo]:
     """Fetch metadata for ``video_ids`` using the YouTube Data v3 API."""
 
     results: dict[str, VideoInfo] = {}
@@ -94,7 +94,9 @@ def fetch_video_metadata(video_ids: Sequence[str], youtube_key: str) -> dict[str
             content = item.get("contentDetails") or {}
             title = snippet.get("title") or ""
             published_at = snippet.get("publishedAt")
-            publish_date = _extract_date(published_at) if isinstance(published_at, str) else None
+            publish_date = (
+                _extract_date(published_at) if isinstance(published_at, str) else None
+            )
             duration_seconds = parse_duration(content.get("duration", ""))
             results[video_id] = VideoInfo(
                 title=title,
@@ -137,7 +139,9 @@ def apply_updates(
             changed = True
         if changed:
             if not dry_run:
-                meta_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+                meta_path.write_text(
+                    json.dumps(data, indent=2) + "\n", encoding="utf-8"
+                )
             updated.append(meta_path)
     return updated
 

--- a/src/enrich_metadata.py
+++ b/src/enrich_metadata.py
@@ -1,0 +1,217 @@
+"""Enrich metadata.json files with details from the YouTube Data API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Sequence
+import urllib.parse
+import urllib.request
+
+BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
+VIDEO_ROOT = BASE_DIR / "video_scripts"
+ENV_VAR = "YOUTUBE_API_KEY"
+API_URL = (
+    "https://www.googleapis.com/youtube/v3/videos?part=snippet,contentDetails&id={ids}&key={key}"
+)
+
+
+@dataclass(frozen=True)
+class VideoInfo:
+    """Minimal metadata returned by the YouTube API."""
+
+    title: str
+    publish_date: str | None
+    duration_seconds: int
+
+
+_DURATION_RE = re.compile(
+    r"^P(?:(?P<weeks>\d+)W)?(?:(?P<days>\d+)D)?(?:T(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+)S)?)?$"
+)
+
+
+def parse_duration(value: str) -> int:
+    """Return the number of seconds represented by an ISO-8601 duration string."""
+
+    if not value:
+        return 0
+    match = _DURATION_RE.match(value)
+    if not match:
+        return 0
+    parts = {name: match.group(name) for name in _DURATION_RE.groupindex}
+    total = 0
+    if parts.get("weeks"):
+        total += int(parts["weeks"]) * 7 * 24 * 3600
+    if parts.get("days"):
+        total += int(parts["days"]) * 24 * 3600
+    if parts.get("hours"):
+        total += int(parts["hours"]) * 3600
+    if parts.get("minutes"):
+        total += int(parts["minutes"]) * 60
+    if parts.get("seconds"):
+        total += int(parts["seconds"])
+    return total
+
+
+def _extract_date(value: str) -> str | None:
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt.date().isoformat()
+
+
+def _chunked(items: Sequence[str], size: int) -> Iterable[list[str]]:
+    for i in range(0, len(items), size):
+        yield list(items[i : i + size])
+
+
+def fetch_video_metadata(video_ids: Sequence[str], youtube_key: str) -> dict[str, VideoInfo]:
+    """Fetch metadata for ``video_ids`` using the YouTube Data v3 API."""
+
+    results: dict[str, VideoInfo] = {}
+    if not video_ids:
+        return results
+    for batch in _chunked(video_ids, 50):
+        ids = ",".join(batch)
+        url = API_URL.format(
+            ids=urllib.parse.quote(ids, safe=","),
+            key=urllib.parse.quote(youtube_key, safe=""),
+        )
+        with urllib.request.urlopen(url) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        for item in data.get("items", []):
+            video_id = item.get("id")
+            if not isinstance(video_id, str):
+                continue
+            snippet = item.get("snippet") or {}
+            content = item.get("contentDetails") or {}
+            title = snippet.get("title") or ""
+            published_at = snippet.get("publishedAt")
+            publish_date = _extract_date(published_at) if isinstance(published_at, str) else None
+            duration_seconds = parse_duration(content.get("duration", ""))
+            results[video_id] = VideoInfo(
+                title=title,
+                publish_date=publish_date,
+                duration_seconds=duration_seconds,
+            )
+    return results
+
+
+def apply_updates(
+    metadata_paths: Iterable[pathlib.Path],
+    info_map: dict[str, VideoInfo],
+    *,
+    dry_run: bool = False,
+) -> list[pathlib.Path]:
+    """Apply API data to each metadata file and return the ones that changed."""
+
+    updated: list[pathlib.Path] = []
+    for meta_path in metadata_paths:
+        try:
+            data = json.loads(meta_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            print(f"Skipping invalid JSON: {meta_path}", file=sys.stderr)
+            continue
+        youtube_id = str(data.get("youtube_id", "")).strip()
+        if not youtube_id:
+            continue
+        info = info_map.get(youtube_id)
+        if not info:
+            continue
+        changed = False
+        if info.title and data.get("title") != info.title:
+            data["title"] = info.title
+            changed = True
+        if info.publish_date and data.get("publish_date") != info.publish_date:
+            data["publish_date"] = info.publish_date
+            changed = True
+        if data.get("duration_seconds") != info.duration_seconds:
+            data["duration_seconds"] = info.duration_seconds
+            changed = True
+        if changed:
+            if not dry_run:
+                meta_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            updated.append(meta_path)
+    return updated
+
+
+def _collect_metadata(video_root: pathlib.Path) -> tuple[list[pathlib.Path], list[str]]:
+    paths: list[pathlib.Path] = []
+    ids: list[str] = []
+    seen: set[str] = set()
+    for meta_path in sorted(video_root.glob("*/metadata.json")):
+        try:
+            data = json.loads(meta_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            print(f"Skipping invalid JSON: {meta_path}", file=sys.stderr)
+            continue
+        youtube_id = str(data.get("youtube_id", "")).strip()
+        if not youtube_id:
+            continue
+        paths.append(meta_path)
+        if youtube_id not in seen:
+            seen.add(youtube_id)
+            ids.append(youtube_id)
+    return paths, ids
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Enrich video metadata using the YouTube Data API",
+    )
+    parser.add_argument(
+        "--video-root",
+        default=str(VIDEO_ROOT),
+        help="Directory containing video_scripts/*/metadata.json",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show which files would change without writing",
+    )
+    args = parser.parse_args(argv)
+
+    youtube_key = os.getenv(ENV_VAR)
+    if not youtube_key:
+        print(f"{ENV_VAR} must be set", file=sys.stderr)
+        return 1
+
+    video_root = pathlib.Path(args.video_root)
+    paths, ids = _collect_metadata(video_root)
+    if not ids:
+        print("No metadata files with youtube_id found.")
+        return 0
+
+    info_map = fetch_video_metadata(ids, youtube_key)
+    updated = apply_updates(paths, info_map, dry_run=args.dry_run)
+
+    if args.dry_run:
+        if updated:
+            print("Would update:")
+            for path in updated:
+                print(f" - {path}")
+        else:
+            print("No changes needed.")
+    else:
+        if updated:
+            print("Updated:")
+            for path in updated:
+                print(f" - {path}")
+        else:
+            print("Metadata already up to date.")
+
+    missing = sorted(set(ids) - set(info_map))
+    if missing:
+        print("No API data for:", ", ".join(missing))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_enrich_metadata.py
+++ b/tests/test_enrich_metadata.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import src.enrich_metadata as em
+
+
+@pytest.fixture
+def sample_metadata(tmp_path: Path) -> Path:
+    video_root = tmp_path / "video_scripts" / "20240101_demo"
+    video_root.mkdir(parents=True)
+    meta = video_root / "metadata.json"
+    meta.write_text(
+        json.dumps(
+            {
+                "youtube_id": "abc123",
+                "title": "Placeholder",
+                "publish_date": "2024-01-01",
+                "duration_seconds": 0,
+                "status": "draft",
+                "description": "",
+            }
+        )
+        + "\n"
+    )
+    return meta
+
+
+def test_apply_updates_writes_changes(sample_metadata: Path) -> None:
+    info = em.VideoInfo(
+        title="Updated Title",
+        publish_date="2024-01-02",
+        duration_seconds=321,
+    )
+    updated = em.apply_updates([sample_metadata], {"abc123": info}, dry_run=False)
+    assert updated == [sample_metadata]
+    data = json.loads(sample_metadata.read_text())
+    assert data["title"] == "Updated Title"
+    assert data["publish_date"] == "2024-01-02"
+    assert data["duration_seconds"] == 321
+    assert sample_metadata.read_bytes().endswith(b"\n")
+
+
+def test_apply_updates_dry_run(sample_metadata: Path) -> None:
+    info = em.VideoInfo(
+        title="Another Title",
+        publish_date="2024-02-10",
+        duration_seconds=111,
+    )
+    updated = em.apply_updates([sample_metadata], {"abc123": info}, dry_run=True)
+    assert updated == [sample_metadata]
+    data = json.loads(sample_metadata.read_text())
+    # No changes because dry-run
+    assert data["title"] == "Placeholder"
+    assert data["publish_date"] == "2024-01-01"
+    assert data["duration_seconds"] == 0
+
+
+def test_main_dry_run(monkeypatch: pytest.MonkeyPatch, sample_metadata: Path) -> None:
+    video_root = sample_metadata.parent.parent
+    seen: list[tuple[str, ...]] = []
+
+    def fake_fetch(ids, youtube_key: str):
+        seen.append(tuple(ids))
+        assert youtube_key == "TOKEN"
+        return {
+            "abc123": em.VideoInfo(
+                title="CLI Title",
+                publish_date="2024-03-04",
+                duration_seconds=222,
+            )
+        }
+
+    monkeypatch.setenv("YOUTUBE_API_KEY", "TOKEN")
+    monkeypatch.setattr(em, "fetch_video_metadata", fake_fetch)
+    exit_code = em.main(["--video-root", str(video_root), "--dry-run"])
+    assert exit_code == 0
+    assert seen == [("abc123",)]
+    # Original file remains unchanged because dry-run
+    data = json.loads(sample_metadata.read_text())
+    assert data["title"] == "Placeholder"
+
+
+@pytest.mark.parametrize(
+    "duration,expected",
+    [
+        ("PT5M33S", 5 * 60 + 33),
+        ("PT1H2M3S", 3723),
+        ("PT0S", 0),
+        ("P1DT1H", 24 * 3600 + 3600),
+        ("P1W", 7 * 24 * 3600),
+    ],
+)
+def test_parse_duration(duration: str, expected: int) -> None:
+    assert em.parse_duration(duration) == expected


### PR DESCRIPTION
## Summary
- add a YouTube Data API enrichment CLI that updates metadata.json files with title, publish date, and duration
- cover the enrichment helper with dedicated pytest cases and dry-run coverage
- document the workflow in INSTRUCTIONS.md and llms.txt for discoverability

## Testing
- pre-commit run --all-files *(fails: local heatmap hook cannot import src.generate_heatmap)*
- pytest -q
- npm run test:ci *(fails: repository has no package.json)*
- python -m flywheel.fit *(fails: flywheel module not installed)*
- bash scripts/checks.sh *(fails: local heatmap hook cannot import src.generate_heatmap)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd4206fa8832fb6be9cbe83215df8