### PR TITLE
✨ : add npm doc checks

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -48,6 +48,14 @@ make fmt       # format code with black & ruff
 pre-commit install  # optional: run hooks (formatters) on commit
 ```
 
+Use the companion npm scripts to keep prompt docs tidy:
+
+```bash
+npm run lint         # flag trailing whitespace in docs/prompts/codex/*.md
+npm run format:check # ensure package.json stays two-space formatted with a trailing newline
+npm run test:ci      # verify docs/prompt-docs-summary.md renders a two-column table
+```
+
 Some helper scripts require a GitHub token to access the GraphQL API. Export
 `GH_TOKEN` (or `GITHUB_TOKEN`) with a personal access token that includes `repo`
 and `read:org` scopes. You may also set `GH_TOKEN_FILE` or `GITHUB_TOKEN_FILE`

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -27,6 +27,8 @@ CONTEXT:
 - Follow the conventions in AGENTS.md and README.md.
 - Ensure `pre-commit run --all-files`, `pytest -q`, `npm run test:ci`,
   `python -m flywheel.fit`, and `bash scripts/checks.sh` all succeed.
+- `npm run test:ci` now checks that `docs/prompt-docs-summary.md` renders a
+  valid two-column table so linked prompt guides stay readable.
 - Make sure all GitHub Actions workflows pass and keep the README badges green.
 - If browser dependencies are missing, run `npm run playwright:install` or
   prefix tests with `SKIP_E2E=1`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "futuroptimist-repo-tools",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Utility npm scripts for Futuroptimist docs and prompt hygiene checks.",
+  "scripts": {
+    "lint": "node scripts/npm/run-checks.mjs lint",
+    "format:check": "node scripts/npm/run-checks.mjs format",
+    "test:ci": "node scripts/npm/run-checks.mjs test"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/npm/run-checks.mjs
+++ b/scripts/npm/run-checks.mjs
@@ -1,0 +1,117 @@
+import { readFileSync, readdirSync, statSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function listMarkdownFiles(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listMarkdownFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function checkTrailingWhitespace() {
+  const targetsDir = path.join(repoRoot, 'docs', 'prompts', 'codex');
+  if (!statSync(targetsDir, { throwIfNoEntry: false })) {
+    return true;
+  }
+  let ok = true;
+  const files = listMarkdownFiles(targetsDir);
+  for (const file of files) {
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/);
+    lines.forEach((line, idx) => {
+      if (line && line !== line.trimEnd()) {
+        console.error(`Trailing whitespace in ${path.relative(repoRoot, file)}:${idx + 1}`);
+        ok = false;
+      }
+    });
+  }
+  return ok;
+}
+
+function checkPackageJsonFormat() {
+  const pkgPath = path.join(repoRoot, 'package.json');
+  let data;
+  try {
+    const raw = readFileSync(pkgPath, 'utf8');
+    data = JSON.parse(raw);
+    const normalized = `${JSON.stringify(data, null, 2)}\n`;
+    if (normalized !== raw) {
+      console.error('package.json is not formatted with 2-space indentation.');
+      return false;
+    }
+  } catch (error) {
+    console.error(`Failed to read package.json: ${error.message}`);
+    return false;
+  }
+  if (!data || typeof data !== 'object') {
+    console.error('package.json did not parse into an object.');
+    return false;
+  }
+  return true;
+}
+
+function checkPromptDocsSummary() {
+  const summaryPath = path.join(repoRoot, 'docs', 'prompt-docs-summary.md');
+  let raw;
+  try {
+    raw = readFileSync(summaryPath, 'utf8');
+  } catch (error) {
+    console.error(`Failed to read docs/prompt-docs-summary.md: ${error.message}`);
+    return false;
+  }
+  const lines = raw.split(/\r?\n/);
+  const startIndex = lines.findIndex((line) => line.startsWith('|------'));
+  const dataLines = startIndex >= 0 ? lines.slice(startIndex + 1) : [];
+  const pattern = /^\| \[[^\]]+\]\([^)]+\) \|[^|]+\|$/;
+  let ok = true;
+  let rowCount = 0;
+  for (const line of dataLines) {
+    if (!line.startsWith('|')) {
+      continue;
+    }
+    const trimmed = line.trimEnd();
+    if (!trimmed) {
+      continue;
+    }
+    rowCount += 1;
+    if (!pattern.test(trimmed)) {
+      console.error(
+        `docs/prompt-docs-summary.md row ${rowCount} is not a two-column Markdown table: ${trimmed}`,
+      );
+      ok = false;
+    }
+  }
+  if (rowCount === 0) {
+    console.error('docs/prompt-docs-summary.md contains no table rows after the header.');
+    ok = false;
+  }
+  return ok;
+}
+
+const commands = {
+  lint: checkTrailingWhitespace,
+  format: checkPackageJsonFormat,
+  test: checkPromptDocsSummary,
+};
+
+const command = process.argv[2] ?? 'test';
+const runner = commands[command];
+
+if (!runner) {
+  console.error(`Unknown command '${command}'. Use one of: ${Object.keys(commands).join(', ')}.`);
+  process.exit(1);
+}
+
+const result = runner();
+process.exit(result ? 0 : 1);

--- a/src/update_video_metadata.py
+++ b/src/update_video_metadata.py
@@ -47,7 +47,7 @@ def parse_duration(value: str | None) -> int:
 def iter_metadata_files(
     root: pathlib.Path, slugs: set[str] | None
 ) -> Iterable[pathlib.Path]:
-    for meta in root.glob("*/metadata.json"):
+    for meta in sorted(root.glob("*/metadata.json")):
         if slugs and meta.parent.name not in slugs:
             continue
         yield meta

--- a/tests/test_package_json.py
+++ b/tests/test_package_json.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_package_json_scripts_present() -> None:
+    pkg_path = Path("package.json")
+    assert pkg_path.exists(), "package.json must exist so npm run commands work"
+    data = json.loads(pkg_path.read_text(encoding="utf-8"))
+    scripts = data.get("scripts", {})
+    required = ["lint", "format:check", "test:ci"]
+    for name in required:
+        assert name in scripts, f"npm script '{name}' must be defined"
+        assert str(scripts[name]).strip(), f"npm script '{name}' must not be empty"


### PR DESCRIPTION
what:
- add repo-local npm scripts for prompt doc lint/test commands
- document npm helpers and note what npm run test:ci now validates
- iterate metadata.json files deterministically when updating

why:
- repo prompts instruct contributors to run npm run test:ci/lint
- stable metadata ordering keeps partial-update tests deterministic

how to test:
- pytest -q
- npm run test:ci
- pre-commit run --all-files (fails: missing src.generate_heatmap)
- python -m flywheel.fit (fails: module not installed)
- bash scripts/checks.sh (fails: missing src.generate_heatmap)

------
https://chatgpt.com/codex/tasks/task_e_68de03ee4d60832fa640f0d2c5f7c323