### PR TITLE
Add npm playwright install helper

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -48,6 +48,15 @@ make fmt       # format code with black & ruff
 pre-commit install  # optional: run hooks (formatters) on commit
 ```
 
+If Playwright-based tests complain about missing browsers, install them via:
+
+```bash
+npm run playwright:install
+```
+
+This wrapper calls `npx playwright install --with-deps` so CI and local runs stay aligned and
+is covered by `tests/test_package_json.py::test_package_json_exposes_playwright_install_script`.
+
 `make report_funnel` normalises selects entries so the resulting
 `selections.json` stores repo-relative `footage/<slug>/converted/...` paths.
 See `tests/test_report_funnel.py::test_build_manifest_normalizes_select_paths`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "node scripts/npm/run-checks.mjs lint",
     "format:check": "node scripts/npm/run-checks.mjs format",
-    "test:ci": "node scripts/npm/run-checks.mjs test"
+    "test:ci": "node scripts/npm/run-checks.mjs test",
+    "playwright:install": "npx playwright install --with-deps"
   },
   "engines": {
     "node": ">=18"

--- a/tests/test_package_json.py
+++ b/tests/test_package_json.py
@@ -13,3 +13,12 @@ def test_package_json_scripts_present() -> None:
     for name in required:
         assert name in scripts, f"npm script '{name}' must be defined"
         assert str(scripts[name]).strip(), f"npm script '{name}' must not be empty"
+
+
+def test_package_json_exposes_playwright_install_script() -> None:
+    pkg_path = Path("package.json")
+    data = json.loads(pkg_path.read_text(encoding="utf-8"))
+    scripts = data.get("scripts", {})
+    command = scripts.get("playwright:install")
+    assert command, "npm script 'playwright:install' must be defined"
+    assert command.strip() == "npx playwright install --with-deps"


### PR DESCRIPTION
✨ : add playwright install helper

what: add npm playwright:install script and document the helper.
why: docs referenced the helper but package.json lacked the script.
how to test:
- SKIP=heatmap pre-commit run --all-files
- pytest -q
- npm run lint
- npm run test:ci
- python -m flywheel.fit (fails: ModuleNotFoundError: flywheel)
- SKIP=heatmap bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68debfcbdcfc832fb5a6fd7fbdd44e99