### PR TITLE
Add docs lint npm command for prompt table checks

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -48,6 +48,11 @@ make fmt       # format code with black & ruff
 pre-commit install  # optional: run hooks (formatters) on commit
 ```
 
+Run `npm run docs-lint` to validate prompt documentation formatting. The
+command piggybacks on the Node checks (`tests/test_package_json.py` ensures the
+script exists while `tests/test_update_prompt_docs_summary.py` covers the table
+validation logic) so Markdown table pipes stay intact between repositories.
+
 `make report_funnel` normalises selects entries so the resulting
 `selections.json` stores repo-relative `footage/<slug>/converted/...` paths.
 See `tests/test_report_funnel.py::test_build_manifest_normalizes_select_paths`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "node scripts/npm/run-checks.mjs lint",
     "format:check": "node scripts/npm/run-checks.mjs format",
-    "test:ci": "node scripts/npm/run-checks.mjs test"
+    "test:ci": "node scripts/npm/run-checks.mjs test",
+    "docs-lint": "node scripts/npm/run-checks.mjs docs"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/npm/run-checks.mjs
+++ b/scripts/npm/run-checks.mjs
@@ -99,10 +99,17 @@ function checkPromptDocsSummary() {
   return ok;
 }
 
+function lintDocs() {
+  const summaryOk = checkPromptDocsSummary();
+  const whitespaceOk = checkTrailingWhitespace();
+  return summaryOk && whitespaceOk;
+}
+
 const commands = {
   lint: checkTrailingWhitespace,
   format: checkPackageJsonFormat,
   test: checkPromptDocsSummary,
+  docs: lintDocs,
 };
 
 const command = process.argv[2] ?? 'test';

--- a/tests/test_package_json.py
+++ b/tests/test_package_json.py
@@ -9,7 +9,7 @@ def test_package_json_scripts_present() -> None:
     assert pkg_path.exists(), "package.json must exist so npm run commands work"
     data = json.loads(pkg_path.read_text(encoding="utf-8"))
     scripts = data.get("scripts", {})
-    required = ["lint", "format:check", "test:ci"]
+    required = ["lint", "format:check", "test:ci", "docs-lint"]
     for name in required:
         assert name in scripts, f"npm script '{name}' must be defined"
         assert str(scripts[name]).strip(), f"npm script '{name}' must not be empty"


### PR DESCRIPTION
## What
- add an npm run docs-lint command that runs the docs lint helper
- extend the package.json script test to require docs-lint
- document the docs-lint workflow in the contributor instructions

## Why
- docs/prompts/codex/automation.md already asks contributors to run
  npm run docs-lint, but the script was missing

## Testing
- pre-commit run --all-files (fails: src.generate_heatmap missing; reran
  with SKIP=heatmap)
- pytest -q
- npm run test:ci
- python -m flywheel.fit (fails: module not found)
- SKIP=heatmap bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68debfcbdcfc832fb5a6fd7fbdd44e99