### PR TITLE
feat: classify audio selects in report funnel

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -69,6 +69,8 @@ Markdown table shape in `docs/prompt-docs-summary.md` and whitespace hygiene in
 
 `make report_funnel` normalises selects entries so the resulting
 `selections.json` stores repo-relative `footage/<slug>/converted/...` paths.
+It also classifies selects as images, video, or audio (see
+`tests/test_report_funnel.py::test_build_manifest_with_selects`).
 See `tests/test_report_funnel.py::test_build_manifest_normalizes_select_paths`
 for coverage of this behaviour.
 

--- a/schemas/selection_manifest.schema.json
+++ b/schemas/selection_manifest.schema.json
@@ -24,7 +24,7 @@
         "required": ["path", "kind"],
         "properties": {
           "path": { "type": "string" },
-          "kind": { "type": "string", "enum": ["image", "video"] },
+          "kind": { "type": "string", "enum": ["image", "video", "audio"] },
           "duration_sec": { "type": "number", "minimum": 0 },
           "ranges": {
             "type": "array",

--- a/src/report_funnel.py
+++ b/src/report_funnel.py
@@ -21,6 +21,7 @@ from typing import Iterable
 
 IMAGE_EXTS = {".png", ".jpg", ".jpeg"}
 VIDEO_EXTS = {".mp4"}
+AUDIO_EXTS = {".wav", ".mp3", ".aac", ".m4a", ".flac", ".ogg"}
 
 
 def _utc_now_iso() -> str:
@@ -92,11 +93,14 @@ def build_manifest(
                 continue
             seen_paths.add(display_path)
             ext = resolved.suffix.lower()
-            kind = (
-                "image"
-                if ext in IMAGE_EXTS
-                else ("video" if ext in VIDEO_EXTS else "image")
-            )
+            if ext in IMAGE_EXTS:
+                kind = "image"
+            elif ext in VIDEO_EXTS:
+                kind = "video"
+            elif ext in AUDIO_EXTS:
+                kind = "audio"
+            else:
+                kind = "image"
             selected_assets.append({"path": display_path, "kind": kind})
 
     manifest = {

--- a/tests/test_report_funnel.py
+++ b/tests/test_report_funnel.py
@@ -29,13 +29,16 @@ def test_build_manifest_with_selects(tmp_path: Path):
     (root / slug / "converted").mkdir(parents=True)
     (root / slug / "converted" / "a.png").write_bytes(b"x")
     (root / slug / "converted" / "b.mp4").write_bytes(b"x")
+    (root / slug / "converted" / "c.wav").write_bytes(b"x")
     selects = tmp_path / "selects.txt"
-    selects.write_text("\n".join(["converted/a.png", "converted/b.mp4"]))
+    selects.write_text(
+        "\n".join(["converted/a.png", "converted/b.mp4", "converted/c.wav"])
+    )
 
     manifest = build_manifest(root, slug, selects)
-    assert manifest["selected_count"] == 2
+    assert manifest["selected_count"] == 3
     kinds = {a["kind"] for a in manifest["selected_assets"]}
-    assert kinds == {"image", "video"}
+    assert kinds == {"image", "video", "audio"}
 
 
 def test_build_manifest_normalizes_select_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- classify audio assets in `report_funnel` manifests so selects use the right kind
- allow the selection manifest schema and docs to reference the new audio classification

## Testing
- pre-commit run --all-files *(fails: local heatmap hook cannot import `src.generate_heatmap`)*
- pytest -q
- npm run test:ci
- python -m flywheel.fit *(fails: module not installed in environment)*
- bash scripts/checks.sh *(fails: heatmap hook cannot import `src.generate_heatmap`)*

------
https://chatgpt.com/codex/tasks/task_e_68df7a6f3048832fb10c5ae19a22ef94