### PR TITLE
✨ add subtitle script generator

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -101,6 +101,7 @@ md
 meta's
 metaverse
 microcontroller
+mjs
 mpa
 mtime
 nas

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -20,12 +20,20 @@ uv pip install -r requirements.txt
 # 2. Download available English subtitles into ./subtitles
 python src/fetch_subtitles.py
 
-# 3. Run the full test suite (schema, naming, e2e)
+# 3. Convert subtitles into Futuroptimist script format
+python src/generate_scripts_from_subtitles.py
+
+# 4. Run the full test suite (schema, naming, e2e)
 make test
 ```
 The script fetches **manual** subtitles only. Videos without manual captions are skipped. Files are saved as `subtitles/<videoid>.srt`.
 If YouTube only offers WebVTT tracks, the fallback path converts them to `.srt` so downstream
 tools stay compatible (see `tests/test_fetch_subtitles.py::test_download_subtitles_fallback_converts_vtt`).
+Generate Markdown scripts from the downloaded captions with
+`python src/generate_scripts_from_subtitles.py` (or `make scripts_from_subtitles`). The helper
+creates `video_scripts/<slug>/script.md` files using the narration style covered by
+`tests/test_generate_scripts_from_subtitles.py` so `[NARRATOR]` lines and timestamp comments match
+the existing pipeline.
 
 ## Development Workflow
 
@@ -43,6 +51,7 @@ make convert_all      # convert images+videos for all slugs (or SLUG=YYYYMMDD_sl
 make verify_assets    # verify converted assets match originals
 make report_funnel SLUG=<slug> [SELECTS=path]  # write selections.json for the slug
 make process SLUG=<slug> [SELECTS=path]        # one-command: convert+verify+report
+make scripts_from_subtitles  # regenerate script.md files from subtitles
 make clean      # remove the virtualenv and caches
 make fmt       # format code with black & ruff
 pre-commit install  # optional: run hooks (formatters) on commit
@@ -132,7 +141,7 @@ contains a `youtube_id`. Export `YOUTUBE_API_KEY` before running; add
 `src/describe_images.py` keep emitting meaningful alt-text summaries.
 
 ## Next Steps
-* Convert `.srt` caption timing into fully-fledged markdown scripts.
+* ~~Convert `.srt` caption timing into fully-fledged markdown scripts.~~ ✅ Use `make scripts_from_subtitles`.
 * Build a lightweight RAG pipeline that indexes past scripts for rapid outline generation of future videos.
 
 ## 🌱 Roadmap / Flywheel Enhancements

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ help:
 	@echo "  index_footage  Index local media under ./footage to footage_index.json"
 	@echo "  index_assets   Build rich assets_index.json from per-video manifests"
 	@echo "  describe_images  Generate image_descriptions.md from ./footage"
-        @echo "  convert_assets  Convert incompatible originals/ into converted/ using ffmpeg"
-        @echo "  verify_assets  Verify converted/ matches originals/ dimensions/aspect"
-        @echo "  convert_missing Convert only missing items from verify_report.json"
-        @echo "  scripts_from_subtitles Generate script.md files from subtitles"
+	@echo "  convert_assets  Convert incompatible originals/ into converted/ using ffmpeg"
+	@echo "  verify_assets  Verify converted/ matches originals/ dimensions/aspect"
+	@echo "  convert_missing Convert only missing items from verify_report.json"
+	@echo "  scripts_from_subtitles Generate script.md files from subtitles"
 	@echo "  convert_all    Convert images+videos for all footage (or SLUG=...)"
 	@echo "  report_funnel  Write selections.json for a slug (use SLUG=...)"
 	@echo "  update_metadata  Refresh metadata via YouTube API (SLUG=...)"
@@ -67,10 +67,10 @@ verify_assets:
 	$(PY) src/verify_converted_assets.py footage
 
 convert_missing:
-        $(PY) src/convert_missing.py --report verify_report.json
+	$(PY) src/convert_missing.py --report verify_report.json
 
 scripts_from_subtitles:
-        $(PY) src/generate_scripts_from_subtitles.py
+	$(PY) src/generate_scripts_from_subtitles.py
 
 # Convert images and videos in one command. Optionally limit to a slug:
 #   make convert_all SLUG=20251001_indoor-aquariums-tour

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ else
 endif
 PIP := uv pip
 
+# NOTE: Keep recipe indentation as tabs; GNU Make treats spaces as errors.
 .PHONY: help setup test subtitles clean fmt index_footage index_assets describe_images convert_assets verify_assets convert_missing convert_all report_funnel process update_metadata scripts_from_subtitles
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
 endif
 PIP := uv pip
 
-.PHONY: help setup test subtitles clean fmt index_footage index_assets describe_images convert_assets verify_assets convert_missing convert_all report_funnel process update_metadata
+.PHONY: help setup test subtitles clean fmt index_footage index_assets describe_images convert_assets verify_assets convert_missing convert_all report_funnel process update_metadata scripts_from_subtitles
 
 help:
 	@echo "Targets:"
@@ -24,9 +24,10 @@ help:
 	@echo "  index_footage  Index local media under ./footage to footage_index.json"
 	@echo "  index_assets   Build rich assets_index.json from per-video manifests"
 	@echo "  describe_images  Generate image_descriptions.md from ./footage"
-	@echo "  convert_assets  Convert incompatible originals/ into converted/ using ffmpeg"
-	@echo "  verify_assets  Verify converted/ matches originals/ dimensions/aspect"
-	@echo "  convert_missing Convert only missing items from verify_report.json"
+        @echo "  convert_assets  Convert incompatible originals/ into converted/ using ffmpeg"
+        @echo "  verify_assets  Verify converted/ matches originals/ dimensions/aspect"
+        @echo "  convert_missing Convert only missing items from verify_report.json"
+        @echo "  scripts_from_subtitles Generate script.md files from subtitles"
 	@echo "  convert_all    Convert images+videos for all footage (or SLUG=...)"
 	@echo "  report_funnel  Write selections.json for a slug (use SLUG=...)"
 	@echo "  update_metadata  Refresh metadata via YouTube API (SLUG=...)"
@@ -66,7 +67,10 @@ verify_assets:
 	$(PY) src/verify_converted_assets.py footage
 
 convert_missing:
-	$(PY) src/convert_missing.py --report verify_report.json
+        $(PY) src/convert_missing.py --report verify_report.json
+
+scripts_from_subtitles:
+        $(PY) src/generate_scripts_from_subtitles.py
 
 # Convert images and videos in one command. Optionally limit to a slug:
 #   make convert_all SLUG=20251001_indoor-aquariums-tour

--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,10 @@ Script format:
   `tests/test_srt_to_markdown.py::test_to_markdown_splits_sentences` and
   `::test_to_markdown_handles_abbreviations` ensure multi-sentence captions expand into one
   `[NARRATOR]` line per thought without breaking common abbreviations.
+- `generate_scripts_from_subtitles.py` scans `video_scripts/*/metadata.json`, resolves each
+  transcript in `subtitles/`, and produces `script.md` files via the converter above. The
+  workflow is covered by `tests/test_generate_scripts_from_subtitles.py` to keep narration
+  comments and `[NARRATOR]` lines consistent.
 - `[NARRATOR]:` spoken lines.
 - `[VISUAL]:` cues right after the dialogue they support.
 - Leave a blank line between narration and visuals.

--- a/src/generate_scripts_from_subtitles.py
+++ b/src/generate_scripts_from_subtitles.py
@@ -36,7 +36,9 @@ def _resolve_transcript(
     return None
 
 
-def _load_metadata_paths(video_root: pathlib.Path, slugs: Iterable[str] | None) -> list[pathlib.Path]:
+def _load_metadata_paths(
+    video_root: pathlib.Path, slugs: Iterable[str] | None
+) -> list[pathlib.Path]:
     allowed = set(slugs) if slugs is not None else None
     paths: list[pathlib.Path] = []
     for meta_path in sorted(video_root.glob("*/metadata.json")):

--- a/src/generate_scripts_from_subtitles.py
+++ b/src/generate_scripts_from_subtitles.py
@@ -1,0 +1,154 @@
+"""Generate Markdown scripts from downloaded SRT transcripts.
+
+Iterates through ``video_scripts/*/metadata.json`` files, locates their
+transcripts under ``subtitles/`` (preferring the ``transcript_file`` value when
+present and falling back to ``subtitles/<youtube_id>.srt``), and writes a
+``script.md`` file for each folder using :mod:`src.srt_to_markdown`.
+
+Existing scripts are left untouched unless ``--force`` is provided.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from typing import Iterable
+
+from src import srt_to_markdown
+
+
+def _resolve_transcript(
+    repo_root: pathlib.Path,
+    subtitles_root: pathlib.Path,
+    transcript_ref: str,
+    youtube_id: str,
+) -> pathlib.Path | None:
+    candidates: list[pathlib.Path] = []
+    if transcript_ref:
+        ref_path = repo_root / transcript_ref
+        candidates.append(ref_path)
+    if youtube_id:
+        candidates.append(subtitles_root / f"{youtube_id}.srt")
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _load_metadata_paths(video_root: pathlib.Path, slugs: Iterable[str] | None) -> list[pathlib.Path]:
+    allowed = set(slugs) if slugs is not None else None
+    paths: list[pathlib.Path] = []
+    for meta_path in sorted(video_root.glob("*/metadata.json")):
+        slug = meta_path.parent.name
+        if allowed is not None and slug not in allowed:
+            continue
+        paths.append(meta_path)
+    return paths
+
+
+def generate_scripts(
+    *,
+    video_root: pathlib.Path,
+    subtitles_root: pathlib.Path,
+    force: bool = False,
+    slugs: Iterable[str] | None = None,
+    dry_run: bool = False,
+) -> dict[str, list[pathlib.Path]]:
+    """Generate scripts from subtitles and return a summary of the run."""
+
+    video_root = video_root.resolve()
+    subtitles_root = subtitles_root.resolve()
+    repo_root = video_root.parent
+
+    written: list[pathlib.Path] = []
+    skipped: list[pathlib.Path] = []
+    missing: list[pathlib.Path] = []
+
+    for meta_path in _load_metadata_paths(video_root, slugs):
+        slug_dir = meta_path.parent
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+        youtube_id = str(data.get("youtube_id", "")).strip()
+        transcript_ref = str(data.get("transcript_file", "")).strip()
+        transcript_path = _resolve_transcript(
+            repo_root, subtitles_root, transcript_ref, youtube_id
+        )
+        if transcript_path is None:
+            missing.append(meta_path)
+            continue
+        script_path = slug_dir / "script.md"
+        if script_path.exists() and not force:
+            skipped.append(script_path)
+            continue
+
+        entries = srt_to_markdown.parse_srt(transcript_path)
+        title = str(data.get("title") or slug_dir.name.replace("_", " ").title())
+        markdown = srt_to_markdown.to_markdown(entries, title, youtube_id)
+        if not markdown.endswith("\n"):
+            markdown += "\n"
+        if not markdown.endswith("\n\n"):
+            markdown += "\n"
+        if dry_run:
+            written.append(script_path)
+            continue
+        script_path.write_text(markdown, encoding="utf-8")
+        written.append(script_path)
+
+    return {"written": written, "skipped": skipped, "missing": missing}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate script.md files from subtitles",
+    )
+    parser.add_argument(
+        "--video-root",
+        default="video_scripts",
+        help="Directory containing video script folders",
+    )
+    parser.add_argument(
+        "--subtitles-root",
+        default="subtitles",
+        help="Directory containing downloaded SRT files",
+    )
+    parser.add_argument(
+        "--slug",
+        action="append",
+        default=None,
+        help="Limit to specific slug(s)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing script.md files",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview generated files without writing",
+    )
+    args = parser.parse_args(argv)
+
+    video_root = pathlib.Path(args.video_root)
+    subtitles_root = pathlib.Path(args.subtitles_root)
+
+    result = generate_scripts(
+        video_root=video_root,
+        subtitles_root=subtitles_root,
+        force=args.force,
+        slugs=args.slug,
+        dry_run=args.dry_run,
+    )
+
+    for path in result["written"]:
+        print(f"Wrote {path}")
+    for path in result["skipped"]:
+        print(f"Skipped existing {path}")
+    for meta in result["missing"]:
+        print(f"Missing transcript for {meta}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_generate_scripts_from_subtitles.py
+++ b/tests/test_generate_scripts_from_subtitles.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src import generate_scripts_from_subtitles as gss
+
+
+@pytest.fixture
+def repo_structure(tmp_path: Path) -> Path:
+    repo = tmp_path
+    video_dir = repo / "video_scripts" / "20240101_demo"
+    video_dir.mkdir(parents=True)
+    metadata = {
+        "youtube_id": "abc123",
+        "title": "Demo Title",
+        "publish_date": "2024-01-01",
+        "duration_seconds": 0,
+        "status": "draft",
+        "description": "",
+    }
+    (video_dir / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    subs = repo / "subtitles"
+    subs.mkdir()
+    (subs / "abc123.srt").write_text(
+        "1\n00:00:00,000 --> 00:00:02,000\nHello world!\n\n"
+    )
+    return repo
+
+
+def test_generate_scripts_from_subtitles_creates_markdown(repo_structure: Path) -> None:
+    repo = repo_structure
+    result = gss.generate_scripts(
+        video_root=repo / "video_scripts",
+        subtitles_root=repo / "subtitles",
+        force=False,
+    )
+    script_path = repo / "video_scripts" / "20240101_demo" / "script.md"
+    assert script_path.exists()
+    content = script_path.read_text()
+    assert "# Demo Title" in content
+    assert "[NARRATOR]: Hello world!" in content
+    assert result["written"] == [script_path]
+
+
+def test_generate_scripts_from_subtitles_skips_existing(repo_structure: Path) -> None:
+    repo = repo_structure
+    script_path = repo / "video_scripts" / "20240101_demo" / "script.md"
+    script_path.write_text("Existing content\n")
+    result = gss.generate_scripts(
+        video_root=repo / "video_scripts",
+        subtitles_root=repo / "subtitles",
+        force=False,
+    )
+    assert script_path.read_text() == "Existing content\n"
+    assert result["written"] == []
+    assert result["skipped"] == [script_path]


### PR DESCRIPTION
## Summary
- add generate_scripts_from_subtitles CLI to convert SRT captions into script.md files
- exercise the new workflow with tests and expose a make scripts_from_subtitles helper
- document the shipped feature in INSTRUCTIONS and llms.txt while marking the roadmap item complete

## Testing
- pre-commit run --all-files *(fails: missing src.generate_heatmap module referenced by local hook)*
- pytest -q
- npm run test:ci
- python -m flywheel.fit *(fails: module not installed in this environment)*
- bash scripts/checks.sh *(fails: missing src.generate_heatmap module referenced by local hook)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b6060308832fa9760fb956de48d2