### PR TITLE
Normalize report funnel slug selects

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -72,7 +72,9 @@ Markdown table shape in `docs/prompt-docs-summary.md` and whitespace hygiene in
 It also classifies selects as images, video, or audio (see
 `tests/test_report_funnel.py::test_build_manifest_with_selects`).
 See `tests/test_report_funnel.py::test_build_manifest_normalizes_select_paths`
-for coverage of this behaviour.
+for coverage of this behaviour and
+`tests/test_report_funnel.py::test_build_manifest_normalizes_slug_prefixed_paths`
+for slug-prefixed selects that omit the `converted/` segment.
 
 Some helper scripts require a GitHub token to access the GraphQL API. Export
 `GH_TOKEN` (or `GITHUB_TOKEN`) with a personal access token that includes `repo`

--- a/src/report_funnel.py
+++ b/src/report_funnel.py
@@ -57,15 +57,20 @@ def _normalize_select_path(
     if raw_path.is_absolute():
         return raw_path
 
-    parts = raw_path.parts
+    parts = list(raw_path.parts)
+
     if parts and parts[0] == "footage":
-        return repo_root / raw_path
-    if parts and parts[0] == slug:
-        return footage_root / raw_path
-    if parts and parts[0] == "converted":
-        tail = pathlib.Path(*parts[1:]) if len(parts) > 1 else pathlib.Path()
-        return footage_root / slug / "converted" / tail
-    return footage_root / slug / "converted" / raw_path
+        parts = parts[1:]
+        if parts and parts[0] == slug:
+            parts = parts[1:]
+    elif parts and parts[0] == slug:
+        parts = parts[1:]
+
+    if parts and parts[0].lower() == "converted":
+        parts = parts[1:]
+
+    tail = pathlib.Path(*parts) if parts else pathlib.Path()
+    return footage_root / slug / "converted" / tail
 
 
 def build_manifest(

--- a/tests/test_report_funnel.py
+++ b/tests/test_report_funnel.py
@@ -64,3 +64,20 @@ def test_build_manifest_normalizes_select_paths(tmp_path: Path) -> None:
         f"footage/{slug}/converted/a.png",
         f"footage/{slug}/converted/b.mp4",
     ]
+
+
+def test_build_manifest_normalizes_slug_prefixed_paths(tmp_path: Path) -> None:
+    root = tmp_path / "footage"
+    slug = "20260101_future"
+    converted = root / slug / "converted"
+    converted.mkdir(parents=True)
+    (converted / "clip.png").write_bytes(b"x")
+    selects = tmp_path / "selects.txt"
+    selects.write_text("\n".join([slug, f"{slug}/clip.png"]))
+
+    manifest = build_manifest(root, slug, selects)
+    paths = [entry["path"] for entry in manifest["selected_assets"]]
+    assert paths == [
+        f"footage/{slug}/converted",
+        f"footage/{slug}/converted/clip.png",
+    ]


### PR DESCRIPTION
## Summary
- ensure `report_funnel` rewrites slug-prefixed selects into `footage/<slug>/converted/...` paths so selections.json matches the documented contract
- add regression coverage for slug-prefixed entries and reference the new test in the instructions

## Testing
- pre-commit run --all-files *(SKIP=heatmap)*
- pytest -q
- npm run test:ci
- python -m flywheel.fit *(fails: module not found)*
- SKIP=heatmap bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1b6060308832fa9760fb956de48d2