### PR TITLE
Add repo feature summary doc

### DIFF
--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -64,6 +64,8 @@ Each prompt is file-scoped, single-purpose and immediately actionable.
 - Use the CI matrix to test on Node 18 LTS and the latest Node 20.
 - Rerun `npm run docs-lint` after any markdown change to preserve table pipes.
 - Tip – Codex can `npm i`, run tests and open PRs autonomously; keep your goal sentence tight and your acceptance check explicit.
+- `docs/repo-feature-summary.md` tracks automation coverage; see
+  `tests/test_repo_feature_summary.py` for the structure guard.
 
 ## Upgrade Prompt
 Type: evergreen

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -1,0 +1,22 @@
+# Repo Feature Summary
+
+This page tracks the Futuroptimist automation surfaces that are currently live and highlights
+related projects that share the same tooling foundations.
+
+## Futuroptimist automation snapshot
+| Feature | Status | Notes |
+| ---- | ------ | ----- |
+| Prompt library | ✅ | Automation, CI fix, cleanup, spellcheck, and CAD prompts ship in-tree. |
+| Testing guardrails | ✅ | Pytest keeps 100% coverage for subtitles, assets, metadata, prompts. |
+| Credential scanning | ✅ | `scan-secrets.py` and the pre-commit wrapper block credential patterns. |
+| Asset pipeline | ✅ | Conversion, verification, and funnel scripts keep footage reproducible. |
+| Documentation hygiene | ✅ | `npm run docs-lint` plus repo summary tests keep tables aligned. |
+
+## Companion projects quick scan
+| Repo | Focus | Automation highlights |
+| ---- | ----- | --------------------- |
+| [flywheel](https://github.com/futuroptimist/flywheel) | Template | Prompts + pre-commit + CI. |
+| [token.place](https://github.com/futuroptimist/token.place) | Mesh | Flywheel prompts + AGENTS. |
+| [gabriel](https://github.com/futuroptimist/gabriel) | Security | Shared prompts + scanning. |
+| [axel](https://github.com/futuroptimist/axel) | Tracker | Codex automation triage. |
+| [jobbot](https://github.com/futuroptimist/jobbot3000) | Copilot | Mirrors Futuroptimist prompts. |

--- a/tests/test_repo_feature_summary.py
+++ b/tests/test_repo_feature_summary.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_repo_feature_summary_exists() -> None:
+    summary_path = Path("docs/repo-feature-summary.md")
+    assert summary_path.exists(), "docs/repo-feature-summary.md must exist"
+    content = summary_path.read_text(encoding="utf-8")
+    assert "# Repo Feature Summary" in content
+
+    lines = [line.strip() for line in content.splitlines()]
+    assert "| Feature | Status | Notes |" in lines
+    header_index = lines.index("| Feature | Status | Notes |")
+    assert lines[header_index + 1].startswith("| ----")
+
+    data_lines: list[str] = []
+    for line in lines[header_index + 2 :]:
+        if not line.startswith("|"):
+            break
+        data_lines.append(line)
+    assert data_lines, "Feature table must contain at least one row"
+
+

--- a/tests/test_repo_feature_summary.py
+++ b/tests/test_repo_feature_summary.py
@@ -20,5 +20,3 @@ def test_repo_feature_summary_exists() -> None:
             break
         data_lines.append(line)
     assert data_lines, "Feature table must contain at least one row"
-
-


### PR DESCRIPTION
## Summary
- add `docs/repo-feature-summary.md` to describe Futuroptimist automation coverage and related projects
- introduce `tests/test_repo_feature_summary.py` to ensure the summary table stays present and populated
- mention the new guard in `docs/prompts/codex/automation.md` so prompt authors know about the test

## Testing
- `pre-commit run --all-files` *(fails: hook `heatmap` requires missing `src.generate_heatmap` module)*
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit` *(fails: module not available in container)*
- `bash scripts/checks.sh` *(fails via the same missing heatmap module)*
- `git diff --cached | ./scripts/scan-secrets.py`

------
https://chatgpt.com/codex/tasks/task_e_68e3f8036ac8832f879aa1e68fba62b0