### PR TITLE
✅ : enforce prompt repo list sync

### DIFF
--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -93,7 +93,8 @@ git diff --cached | ./scripts/scan-secrets.py
 ```
 
 Ensure `dict/prompt-doc-repos.txt` matches `docs/repo_list.txt` so downstream repos stay
-connected.
+connected. Regression coverage lives in `tests/test_repo_list_sync.py` to prevent the lists
+from drifting.
 
 Push and open a PR in flywheel. Once merged, downstream repos can import the new
 prompt automatically through Flywheel’s existing propagation workflow.

--- a/docs/repo_list.txt
+++ b/docs/repo_list.txt
@@ -1,3 +1,4 @@
+flywheel
 futuroptimist
 jobbot3000
 pr-reaper

--- a/tests/test_repo_list_sync.py
+++ b/tests/test_repo_list_sync.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _read_entries(path: Path) -> list[str]:
+    entries: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            entries.append(line)
+    return entries
+
+
+def test_prompt_repo_lists_match() -> None:
+    repos_from = Path("dict/prompt-doc-repos.txt")
+    repo_list = Path("docs/repo_list.txt")
+
+    assert repos_from.exists(), "dict/prompt-doc-repos.txt must exist"
+    assert repo_list.exists(), "docs/repo_list.txt must exist"
+
+    repos_entries = _read_entries(repos_from)
+    list_entries = _read_entries(repo_list)
+
+    assert list_entries == repos_entries, (
+        "docs/repo_list.txt must match dict/prompt-doc-repos.txt. "
+        f"Expected {repos_entries}, got {list_entries}."
+    )


### PR DESCRIPTION
## Summary
- add regression coverage that compares dict/prompt-doc-repos.txt with docs/repo_list.txt
- align docs/repo_list.txt with the prompt repos referenced by automation scripts
- note the new regression test in docs/prompts/codex/ci-fix.md so the requirement is discoverable

## Testing
- pre-commit run --all-files *(fails: local heatmap hook depends on missing src.generate_heatmap module)*
- pytest -q
- npm run lint
- npm run test:ci
- python -m flywheel.fit *(fails: module not installed in environment)*
- bash scripts/checks.sh *(fails: heatmap hook cannot import src.generate_heatmap)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bf6f5f08832f8847098bdbfef02e