### PR TITLE
Add notes metadata to assets index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Avoid adding setup or asset instructions there; link to INSTRUCTIONS instead.
 | `/subtitles/` | Downloaded `.srt` caption files populated by `fetch_subtitles.py`. |
 | `/src/srt_to_markdown.py` | Convert `.srt` captions; handles italics/bold, emoji; strips HTML, speaker prefixes, collapses whitespace, and skips non-dialog lines like `[Music]`. |
 | `/src/index_local_media.py` | Build a flat `footage_index.json` of local media under `footage/`. |
-| `/src/index_assets.py` | Build a rich `assets_index.json` by scanning per‑video manifests. |
+| `/src/index_assets.py` | Build a rich `assets_index.json` from per-video manifests (labels + optional notes paths). |
 | `/src/index_script_segments.py` | Export `[NARRATOR]` segments to JSON for embeddings and retrieval. |
 | `/src/update_video_metadata.py` | Refresh video metadata (title/date/duration) via YouTube API. |
 | `/sources/` | Reference files fetched via `collect_sources.py`. |

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -131,10 +131,12 @@ files when values change and is covered by
 
 Per‑video manifests: add `video_scripts/<folder>/assets.json` conforming to
 `schemas/assets_manifest.schema.json` to declare which `footage/` directories
-belong to that script, optional label files (`labels.json`), capture date, and
-tags. Then run `make index_assets` to generate a rich `assets_index.json` with
-per-asset path, size, UTC mtime, linked script folder, tags, capture date, and
-labels.
+belong to that script, optional label files (`labels.json`), capture date, tags,
+and an optional `notes_file` pointer for shoot notes. Then run
+`make index_assets` to generate a rich `assets_index.json` with per-asset path,
+size, UTC mtime, linked script folder, tags, capture date, labels, and the
+manifest's notes file so edit checklists stay discoverable (see
+`tests/test_index_assets.py::test_build_index_with_labels`).
 
 Asset conversion (Premiere compatibility): run `make convert_assets` to scan
 `footage/<slug>/originals/` for formats like HEIC/HEIF, DNG, WEBP and convert

--- a/src/index_assets.py
+++ b/src/index_assets.py
@@ -62,6 +62,7 @@ class AssetRecord:
     tags: list[str]
     capture_date: str | None
     labels: dict[str, Any] | None
+    notes_file: str | None = None
     width: int | None = None
     height: int | None = None
     aspect_ratio: float | None = None
@@ -76,6 +77,7 @@ class AssetRecord:
             "tags": self.tags,
             "capture_date": self.capture_date,
             "labels": self.labels,
+            "notes_file": self.notes_file,
             "width": self.width,
             "height": self.height,
             "aspect_ratio": self.aspect_ratio,
@@ -111,6 +113,10 @@ def build_index() -> list[dict[str, Any]]:
         script_folder = manifest_path.parent.name
         tags = list(data.get("tags", []))
         capture_date = data.get("capture_date")
+        notes_file_raw = data.get("notes_file")
+        notes_file = None
+        if isinstance(notes_file_raw, str) and notes_file_raw.strip():
+            notes_file = notes_file_raw.strip()
         labels_map = _load_labels(list(data.get("labels_files", [])))
         for dir_str in data["footage_dirs"]:
             d = REPO_ROOT / dir_str
@@ -168,6 +174,7 @@ def build_index() -> list[dict[str, Any]]:
                         tags=tags,
                         capture_date=capture_date,
                         labels=labels,
+                        notes_file=notes_file,
                         width=width,
                         height=height,
                         aspect_ratio=aspect,

--- a/tests/test_index_assets.py
+++ b/tests/test_index_assets.py
@@ -27,6 +27,7 @@ def test_build_index_with_labels(tmp_path, monkeypatch):
             "footage/20251001_indoor-aquariums-tour/selects",
         ],
         "labels_files": ["footage/20251001_indoor-aquariums-tour/labels.json"],
+        "notes_file": "footage/20251001_indoor-aquariums-tour/notes.md",
         "tags": ["aquariums"],
         "capture_date": "2025-08-30",
     }
@@ -64,6 +65,8 @@ def test_build_index_with_labels(tmp_path, monkeypatch):
     labeled = next(e for e in index if e["path"].endswith("clip1.mp4"))
     assert labeled["labels"]["script_lines"] == [23, 31]
     assert labeled["tags"] == ["aquariums"]
+    # notes_file should be propagated so downstream tooling can locate shoot notes
+    assert labeled["notes_file"] == ("footage/20251001_indoor-aquariums-tour/notes.md")
 
 
 def test_entrypoint_runs(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- propagate the optional `notes_file` from assets manifests into `assets_index.json`
- extend the index regression test to cover the notes path alongside labels
- document the notes pointer in INSTRUCTIONS and AGENTS so editors can find shoot notes

## Testing
- `pre-commit run --all-files` *(fails: local heatmap hook cannot import `src.generate_heatmap` in this environment)*
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit` *(fails: module not installed in container)*
- `bash scripts/checks.sh` *(fails for the same missing `src.generate_heatmap` hook)*
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68e4bf6f5f08832f8847098bdbfef02e