### PR TITLE
Harden report funnel select normalization

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -91,7 +91,10 @@ Markdown table shape in `docs/prompt-docs-summary.md` and whitespace hygiene in
 `make report_funnel` normalises selects entries so the resulting
 `selections.json` stores repo-relative `footage/<slug>/converted/...` paths.
 It also classifies selects as images, video, or audio (see
-`tests/test_report_funnel.py::test_build_manifest_with_selects`).
+`tests/test_report_funnel.py::test_build_manifest_with_selects`). Entries that
+attempt to escape the `converted/` directory (absolute paths or `..`
+segments) are ignored so manifests can't reference outside assets (see
+`tests/test_report_funnel.py::test_build_manifest_skips_outside_converted_entries`).
 See `tests/test_report_funnel.py::test_build_manifest_normalizes_select_paths`
 for coverage of this behaviour and
 `tests/test_report_funnel.py::test_build_manifest_normalizes_slug_prefixed_paths`


### PR DESCRIPTION
## Summary
- ignore selects entries that escape the converted directory and always
  normalise their display paths
- document the behaviour in INSTRUCTIONS and add a regression test for
  outside-converted entries

## Testing
- pre-commit run --all-files *(fails: local heatmap hook requires src.generate_heatmap)*
- pytest -q
- npm run test:ci
- python -m flywheel.fit *(fails: flywheel module not installed)*
- bash scripts/checks.sh *(fails: local heatmap hook requires src.generate_heatmap)*

------
https://chatgpt.com/codex/tasks/task_e_68e55bf895c0832fa30cd8316ee45df0