### PR TITLE
feat: expand collect_sources overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-10-08
+- feat: expand collect_sources overrides to resolve `~` and env variables.
+- test: cover collect_sources override expansion cases.
+- docs: reference the new override tests in INSTRUCTIONS.
+
 ## 2025-09-03
 - fix: handle missing npm in checks script and ensure trailing newline.
 - test: verify checks script handles missing npm and newline.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -101,7 +101,10 @@ Some helper scripts require a GitHub token to access the GraphQL API. Export
 `GH_TOKEN` (or `GITHUB_TOKEN`) with a personal access token that includes `repo`
 and `read:org` scopes. You may also set `GH_TOKEN_FILE` or `GITHUB_TOKEN_FILE`
 to point at a file containing the token. Paths in these variables may include
-`~` or environment variables and will be expanded.
+`~` or environment variables and will be expanded (see
+`tests/test_collect_sources.py::test_resolve_source_urls_file_expands_env_and_user`
+and
+`tests/test_collect_sources.py::test_resolve_global_sources_dir_expands_env_and_user`).
 
 Create new script folders from the IDs in `video_ids.txt`:
 

--- a/src/collect_sources.py
+++ b/src/collect_sources.py
@@ -72,7 +72,9 @@ def _resolve_source_urls_file(source_file: pathlib.Path | None = None) -> pathli
         return source_file
     override = os.environ.get(SOURCE_URLS_ENV, "").strip()
     if override:
-        return pathlib.Path(override)
+        expanded = os.path.expandvars(override)
+        expanded = os.path.expanduser(expanded)
+        return pathlib.Path(expanded)
     return SOURCE_URLS_FILE
 
 
@@ -81,7 +83,9 @@ def _resolve_global_sources_dir(dest_dir: pathlib.Path | None = None) -> pathlib
         return dest_dir
     override = os.environ.get(GLOBAL_SOURCES_ENV, "").strip()
     if override:
-        return pathlib.Path(override)
+        expanded = os.path.expandvars(override)
+        expanded = os.path.expanduser(expanded)
+        return pathlib.Path(expanded)
     return GLOBAL_SOURCES_DIR
 
 

--- a/tests/test_collect_sources.py
+++ b/tests/test_collect_sources.py
@@ -187,3 +187,25 @@ def test_process_global_sources(monkeypatch, tmp_path):
     output_path = global_dir / "sources.json"
     assert json.loads(output_path.read_text()) == mapping
     assert output_path.read_text().endswith("\n")
+
+
+def test_resolve_source_urls_file_expands_env_and_user(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CUSTOM_SEGMENT", "overrides")
+    override = "~/data/$CUSTOM_SEGMENT/urls.txt"
+    monkeypatch.setenv(cs.SOURCE_URLS_ENV, override)
+
+    resolved = cs._resolve_source_urls_file()
+
+    assert resolved == tmp_path / "data" / "overrides" / "urls.txt"
+
+
+def test_resolve_global_sources_dir_expands_env_and_user(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DEST_SUBDIR", "downloads")
+    override = "~/cache/$DEST_SUBDIR"
+    monkeypatch.setenv(cs.GLOBAL_SOURCES_ENV, override)
+
+    resolved = cs._resolve_global_sources_dir()
+
+    assert resolved == tmp_path / "cache" / "downloads"


### PR DESCRIPTION
## Summary
- expand `collect_sources` overrides so `~` and env vars resolve before use
- add regression tests for the env/user override paths
- document the behavior in INSTRUCTIONS and log it in the changelog

## Testing
- SKIP=heatmap pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit *(fails: module not installed in this environment)*
- SKIP=heatmap bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e55bf895c0832fa30cd8316ee45df0