### PR TITLE
fix metadata schema guard for video scripts

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -12,6 +12,10 @@ This document collects the full workflow for managing video scripts and metadata
 
 > Video scripts live in `video_scripts/YYYYMMDD_slug/script.md` (auto-scaffolded). Idea files are collected in `ideas/` as checklists without date prefixes.
 
+Schema guardrails: `tests/test_metadata_schema.py` now scans every
+`video_scripts/**/metadata.json` and enforces `schemas/video_metadata.schema.json`
+so malformed front-matter is caught during CI.
+
 ## Quick Start
 ```bash
 # 1. Install dependencies (yt-dlp only for now)

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -6,11 +6,19 @@ import pytest
 SCHEMA_PATH = pathlib.Path("schemas/video_metadata.schema.json")
 SCHEMA = json.loads(SCHEMA_PATH.read_text())
 
-VIDEO_DIR = pathlib.Path("scripts")
+VIDEO_DIR = pathlib.Path("video_scripts")
+
+
+def _iter_metadata_files(base: pathlib.Path) -> list[pathlib.Path]:
+    return sorted(p for p in base.rglob("metadata.json") if p.is_file())
 
 
 def test_metadata_files_validate():
-    for meta_path in VIDEO_DIR.glob("*/metadata.json"):
+    metadata_files = _iter_metadata_files(VIDEO_DIR)
+    assert (
+        metadata_files
+    ), "video_scripts should contain at least one metadata.json to validate"
+    for meta_path in metadata_files:
         data = json.loads(meta_path.read_text())
         try:
             validate(instance=data, schema=SCHEMA)


### PR DESCRIPTION
## Summary
- update the metadata schema test to scan video_scripts/**/metadata.json
- document the CI guard so contributors know malformed metadata now fails fast

## Testing
- `SKIP=heatmap pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit` *(fails: module not found)*
- `SKIP=heatmap bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68e55bf895c0832fa30cd8316ee45df0