### PR TITLE
docs: split profile README into profile + repository-guide; add failure links to repo status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,8 +129,9 @@ YouTube Data API for upload.
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in INSTRUCTIONS or RUNBOOK.
+- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in [docs/repository-guide.md](docs/repository-guide.md), INSTRUCTIONS, or RUNBOOK.
 - Avoid detailed how-tos like subtitle downloading; store them in other docs.
+- [Repository guide](docs/repository-guide.md): repo map, setup pointers, automation/script/metadata/subtitle summary, and YouTube Transcript MCP service details.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
 - [RUNBOOK](RUNBOOK.md): production checklist.
 - [Video Editing Playbook](docs/video-editing-playbook.md): concise guide to structure, pacing, and post steps.

--- a/README.md
+++ b/README.md
@@ -1,130 +1,41 @@
 # Futuroptimist 👋
 
-*Building open-source tools so anyone can invent, automate & explore.*
+Hi, I'm Daniel/Futuroptimist: a maker-minded developer building open-source tools, creative infrastructure, and AI-adjacent workflows that help ideas move from sketchbook to working demo.
 
-[![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/futuroptimist/actions/workflows/01-lint-format.yml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/futuroptimist/actions/workflows/02-tests.yml)
-[![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://app.codecov.io/gh/futuroptimist/futuroptimist/branch/main)
-[![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
-[![License](https://img.shields.io/github/license/futuroptimist/futuroptimist)](LICENSE)
+I use this GitHub account to explore reproducible automation, YouTube production pipelines, 3D printing, lightweight local tooling, and optimistic technology projects around space, sustainability, and hands-on learning.
 
-Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my
-[YouTube channel](https://www.youtube.com/@futuroptimist).
-If you're looking for the full project details, see
-[INSTRUCTIONS.md](INSTRUCTIONS.md). We manage Python dependencies with
-[uv](https://docs.astral.sh/uv/); check the instructions for setup steps.
-Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
-The canonical Codex prompt for automated contributions is in
-[docs/prompts/codex/automation.md](docs/prompts/codex/automation.md).
-The automated tests run via GitHub Actions on each push and pull request and currently
-reach **100%** coverage.
+[YouTube channel](https://www.youtube.com/@futuroptimist) · Repo internals: automation, scripts, metadata, subtitles, and MCP service details live in [repository guide](docs/repository-guide.md).
 
-## Map of the repo
+## What I build
 
-**Navigate in three hops:**
-
-1. **Setup** – Follow [INSTRUCTIONS.md](INSTRUCTIONS.md) for `uv` environment steps and
-   contributor onboarding.
-2. **Run** – Explore the [Makefile](Makefile) targets for day-to-day automation; CLI helpers
-   live in [`src/`](src).
-3. **Test** – Execute `make test` (documented in `INSTRUCTIONS.md`) to run the full pytest
-   suite with coverage.
-
-| Category | Path / resource | Notes |
-|----------|----------------|-------|
-| Apps | _n/a_ | Entry points live in `src/`; no standalone services yet. |
-| Packages | [`src/`](src) | Shared Python modules and CLI entry points. |
-| Scripts | [`scripts/`](scripts) | Operational helpers (e.g., prompt migrations, scans). |
-| Data | [`data/prompt-docs/`](data/prompt-docs) | Lightweight reference lists synced with docs. |
-| Docs | [`docs/`](docs) | Prompts, playbooks, and supporting guides. |
-| Tests | [`tests/`](tests) | Pytest suite mirroring production helpers. |
-| Pipelines | [`outages/`](outages) | Incident logs and schema describing stability. |
-| Infra | [`.github/workflows/`](.github/workflows) | CI for lint, tests, docs, status updates. |
-
-Prompt templates stay grouped under
-[`docs/prompts/codex/`](docs/prompts/codex) with an index in
-[`docs/README.md`](docs/README.md). Video narration lives in [`video_scripts/`](video_scripts),
-and multimedia assets are catalogued via the Makefile targets above.
-
-> **uv cheat sheet**: `uv sync` installs dependencies from `requirements.txt`,
-> `uv run pytest` mirrors `make test`, and `uvx <tool>` launches one-off binaries without
-> polluting the virtual environment.
-
-## YouTube Transcript MCP Service
-
-`tools/youtube_mcp/` packages a transcript fetcher that powers a CLI, FastAPI microservice, and
-MCP-compatible stdio tool. It normalises captions for retrieval, stores 14-day cached payloads in
-SQLite, and preserves provenance via timestamped cite URLs.
-
-- **HTTP**: `python -m tools.youtube_mcp --host 127.0.0.1 --port 8765`
-- **CLI**: `python -m tools.youtube_mcp.cli transcript --url https://youtu.be/VIDEOID`
-- **MCP**: `python tools/youtube_mcp/mcp_server.py`
-
-Example HTTP call:
-
-```bash
-curl "http://127.0.0.1:8765/transcript?url=https://youtu.be/VIDEOID"
-```
-
-**Policy notes**: the service only uses `youtube_transcript_api` and the public oEmbed endpoint,
-rejecting private/unlisted videos when signals are available. It never scrapes HTML or bypasses
-authentication walls.
-
-**Caching**: responses are keyed by video ID, language, and track type with a default 14-day TTL;
-expired rows are purged automatically when accessed.
-
-**Error codes**: `InvalidArgument`, `VideoUnavailable`, `NoCaptionsAvailable`, `PolicyRejected`,
-`RateLimited`, and `NetworkError` map to consistent HTTP responses and MCP error payloads.
+- **Creative automation** that turns repeatable production chores into tested scripts.
+- **Maker tools** for 3D-printed objects, local media workflows, and project documentation.
+- **AI-adjacent infrastructure** that keeps humans in the loop while making research, narration, and iteration easier.
+- **Learning systems** that package side projects as checklists, quests, videos, and reusable prompts.
 
 ## Related Projects
 _Last updated: 2026-06-08 17:03 UTC; checks hourly_
 
-_Last updated: 2025-11-06 08:02 UTC; checks hourly_
-Status icons: ✅ latest run succeeded, ❌ failed or cancelled, ❓ no completed runs.
-The unknown state is enforced by
-`tests/test_repo_status.py::test_fetch_repo_status_no_runs_returns_unknown`, ensuring repositories
-without completed workflows render `❓` instead of failing the dashboard.
+Status legend: ✅ latest CI run succeeded; ❌ latest relevant CI run failed, cancelled, or needs action; ❓ no completed run was found yet. When available, ❌ entries include direct failure links.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – central hub for
-  reproducible scripts, data pipelines, and tests that turn maker experiments into
-  polished YouTube episodes
-- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network that
-  lets volunteers share idle compute through ephemeral, encrypted tokens—no sign-ups
-  required ([repo](https://github.com/futuroptimist/token.place))
-- ✅ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach
-  real-world hobbies with NPC guides; offline-first so your space-base thrives without a
-  signal ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles
-  lint, tests, docs, and release automation with LLM agents so solo builders ship like a
-  team
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first "guardian angel"
-  LLM that learns your environment and delivers local, actionable security coaching
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex
-  task pages, grabs failing GitHub logs, and pipes concise reports straight to your
-  clipboard to speed debugging
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that
-  analyzes your repos and curates next steps to keep side projects moving
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with
-  push-to-talk voice control, running speech-to-text, LLM, and TTS in a 3D-printed case so
-  commands stay local
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns your GitHub
-  contributions into stackable 3D-printable blocks that fit 42 mm Gridfinity baseplates,
-  turning commit history into shelf art
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning to knit and
-  crochet while evolving toward robotic looms, bridging CAD workflows with textiles
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform
-  and cube art installation for Raspberry Pi clusters, making off-grid edge Kubernetes
-  plug-and-play
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that closes
-  your own stale pull requests in bulk with a safe dry-run
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js
-  playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job search copilot
-  sharing the same automation scaffold as this repo
+- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production workshop for turning maker experiments into reproducible scripts, metadata, and YouTube episodes
+- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network that lets volunteers share idle compute through ephemeral, encrypted tokens—no sign-ups required ([repo](https://github.com/futuroptimist/token.place))
+- ✅ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides; offline-first so your space-base thrives without a signal ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles lint, tests, docs, and release automation with LLM agents so solo builders can ship with a stronger scaffold
+- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first "guardian angel" LLM that learns your environment and delivers local, actionable security coaching
+- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex task pages, grabs failing GitHub logs, and pipes concise reports to your clipboard for faster debugging
+- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repos and curates next steps to keep side projects moving
+- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control, speech-to-text, LLM, and TTS in a 3D-printed case
+- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns GitHub contributions into stackable 3D-printable blocks that fit 42 mm Gridfinity baseplates
+- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning knitting and crochet while evolving toward robotic looms, bridging CAD workflows with textiles
+- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for Raspberry Pi clusters, making off-grid edge Kubernetes approachable
+- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that closes your own stale pull requests in bulk with a safe dry-run
+- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job search copilot sharing the same automation scaffold as this repo
 
 ## Values
 
-We aim for a positive-sum, empathetic community that shares knowledge openly.
+Build in public, keep tools understandable, document the path behind the polished result, and favor technology that expands what curious people can make for themselves.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Futuroptimist Documentation Index
 
+## Repository internals
+
+- [repository-guide.md](repository-guide.md) — Map of repo contents, setup pointers, automation/script/metadata/subtitle summaries, and YouTube Transcript MCP service details.
+
 ## Prompt docs (Codex)
 
 All Codex-ready prompts live under `docs/prompts/codex/`, and filenames already omit the

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -1,0 +1,107 @@
+# Futuroptimist Repository Guide
+
+This guide collects the repo-internal details that used to live in the profile README. Use it when you want to run automation, understand the project layout, or work on the YouTube production helpers behind the Futuroptimist channel.
+
+[![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/futuroptimist/actions/workflows/01-lint-format.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/futuroptimist/actions/workflows/02-tests.yml)
+[![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://app.codecov.io/gh/futuroptimist/futuroptimist/branch/main)
+[![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
+
+## Purpose
+
+This repository hosts scripts, metadata, prompt guides, tests, and small services for the [Futuroptimist YouTube channel](https://www.youtube.com/@futuroptimist). The goal is to make video creation as repeatable as writing code: finalized scripts live beside structured metadata, footage checklists, sources, and automation that can later feed retrieval or lightweight ML experiments.
+
+For end-to-end contributor setup and roadmap details, see [INSTRUCTIONS.md](../INSTRUCTIONS.md). AI-agent guidance lives in [AGENTS.md](../AGENTS.md), and the canonical Codex automation prompt lives in [docs/prompts/codex/automation.md](prompts/codex/automation.md).
+
+## Map of the repo
+
+**Navigate in three hops:**
+
+1. **Setup** – Follow [INSTRUCTIONS.md](../INSTRUCTIONS.md) for `uv` environment steps and contributor onboarding.
+2. **Run** – Explore the [Makefile](../Makefile) targets for day-to-day automation; CLI helpers live in [`src/`](../src).
+3. **Test** – Execute `make test` or `python -m pytest -q` to run the pytest suite.
+
+| Category | Path / resource | Notes |
+|----------|----------------|-------|
+| Packages | [`src/`](../src) | Shared Python modules and CLI entry points for subtitles, metadata, assets, rendering, analytics, and status updates. |
+| Scripts | [`scripts/`](../scripts) | Operational helpers such as prompt migrations and safety checks. |
+| Video scripts | [`video_scripts/`](../video_scripts) | Per-video folders named `YYYYMMDD_slug` with `script.md`, `metadata.json`, and optional `assets.json`, `sources.txt`, or `footage.md`. |
+| Subtitles | [`subtitles/`](../subtitles) | Downloaded caption files populated by subtitle helpers. |
+| Schemas | [`schemas/`](../schemas) | JSON Schemas for metadata and asset manifests. |
+| Data | [`data/`](../data) | Lightweight generated/reference data used by prompt and retrieval helpers. |
+| Docs | [`docs/`](.) | Prompt docs, playbooks, this guide, and supporting documentation. |
+| Tests | [`tests/`](../tests) | Pytest suite mirroring production helpers. |
+| Pipelines | [`outages/`](../outages) | Incident logs and schema describing stability. |
+| Infra | [`.github/workflows/`](../.github/workflows) | CI for linting, tests, docs, and scheduled status updates. |
+
+Prompt templates stay grouped under [`docs/prompts/codex/`](prompts/codex/) with an index in [`docs/README.md`](README.md). Local multimedia assets belong under a gitignored `footage/` directory and are indexed through Makefile helpers when available.
+
+## Setup and common commands
+
+Dependencies are managed with [uv](https://docs.astral.sh/uv/) and `requirements.txt`.
+
+```bash
+make setup   # create .venv and install dependencies
+make test    # run pytest through the venv
+make fmt     # run black and ruff --fix
+```
+
+If `make setup` fails on your platform, run:
+
+```bash
+python3 -m venv .venv
+uv pip install -r requirements.txt
+python -m pytest -q
+```
+
+Useful direct commands:
+
+```bash
+uv sync
+uv run pytest
+uvx <tool>
+python -m pytest -q
+python -m pytest --cov=./src --cov=./tests
+```
+
+Before committing code changes, follow the repo guidance in [AGENTS.md](../AGENTS.md): format with Black/Ruff, run relevant tests, and scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` when `scripts/scan-secrets.py` is present.
+
+## Automation, scripts, metadata, and subtitles
+
+- `src/scaffold_videos.py` creates dated `video_scripts/YYYYMMDD_slug/` folders from `video_ids.txt`.
+- `src/fetch_subtitles.py` and Makefile target `make subtitles` download captions for known videos.
+- `src/srt_to_markdown.py` converts `.srt` captions into the repo's script format with `[NARRATOR]:` lines and `[VISUAL]:` cues.
+- `src/generate_scripts_from_subtitles.py` scans metadata and subtitles to produce `script.md` drafts.
+- `src/update_video_metadata.py`, `src/enrich_metadata.py`, and related helpers refresh YouTube metadata when API credentials are available.
+- `src/index_local_media.py`, `src/index_assets.py`, `src/generate_assets_manifest.py`, and `src/report_funnel.py` keep footage and asset manifests searchable without committing local media.
+- `src/render_video.py`, `src/create_otio_timeline.py`, `src/prepare_youtube_upload.py`, and `src/upload_to_youtube.py` support render and publish workflows.
+- `src/repo_status.py` updates the profile README's `## Related Projects` list by scanning parseable `- ` bullets containing GitHub repo URLs.
+
+Video script folders should start with a title heading, include a YouTube ID blockquote and `## Script` section, and keep `metadata.json` valid against [`schemas/video_metadata.schema.json`](../schemas/video_metadata.schema.json). Use `sources.txt` for one URL per line and cite third-party references rather than redistributing downloaded content.
+
+## YouTube Transcript MCP Service
+
+`tools/youtube_mcp/` packages a transcript fetcher that powers a CLI, FastAPI microservice, and MCP-compatible stdio tool. It normalizes captions for retrieval, stores 14-day cached payloads in SQLite, and preserves provenance through timestamped cite URLs.
+
+- **HTTP**: `python -m tools.youtube_mcp --host 127.0.0.1 --port 8765`
+- **CLI**: `python -m tools.youtube_mcp.cli transcript --url https://youtu.be/VIDEOID`
+- **MCP**: `python tools/youtube_mcp/mcp_server.py`
+
+Example HTTP call:
+
+```bash
+curl "http://127.0.0.1:8765/transcript?url=https://youtu.be/VIDEOID"
+```
+
+**Policy notes**: the service only uses `youtube_transcript_api` and the public oEmbed endpoint, rejecting private or unlisted videos when signals are available. It never scrapes HTML or bypasses authentication walls.
+
+**Caching**: responses are keyed by video ID, language, and track type with a default 14-day TTL; expired rows are purged automatically when accessed.
+
+**Error codes**: `InvalidArgument`, `VideoUnavailable`, `NoCaptionsAvailable`, `PolicyRejected`, `RateLimited`, and `NetworkError` map to consistent HTTP responses and MCP error payloads.
+
+## More documentation
+
+- [INSTRUCTIONS.md](../INSTRUCTIONS.md) – full workflow and roadmap.
+- [RUNBOOK.md](../RUNBOOK.md) – production checklist.
+- [docs/video-editing-playbook.md](video-editing-playbook.md) – structure, pacing, and post-production notes.
+- [docs/README.md](README.md) – documentation index.

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,8 @@
 Every commit is public training data—write informative commit messages.
 
 ## Docs
-- [README](README.md)
+- [README](README.md): GitHub profile-oriented overview
+- [Repository guide](docs/repository-guide.md): repo internals, setup pointers, automation, subtitles, metadata, and YouTube Transcript MCP details
 - [AGENTS guide](AGENTS.md)
 - [INSTRUCTIONS](INSTRUCTIONS.md)
 - [RUNBOOK](RUNBOOK.md)

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -8,16 +8,26 @@ completed successfully, failed, or hasn't completed.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
-import logging
-from datetime import datetime, timezone
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Iterable
 
 import requests
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RepoStatus:
+    """Summary of a repository's workflow status for README rendering."""
+
+    emoji: str
+    failure_links: tuple[str, ...] = ()
+
 
 GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+))?")
 SKIP_COMMIT_RE = re.compile(
@@ -63,7 +73,18 @@ def fetch_repo_status(
     branch: str | None = None,
     attempts: int = 2,
 ) -> str:
-    """Fetch the latest workflow run conclusion for ``repo`` and return an emoji.
+    """Fetch the latest workflow run conclusion for ``repo`` and return an emoji."""
+
+    return fetch_repo_status_details(repo, token, branch, attempts).emoji
+
+
+def fetch_repo_status_details(
+    repo: str,
+    token: str | None = None,
+    branch: str | None = None,
+    attempts: int = 2,
+) -> RepoStatus:
+    """Fetch the latest workflow run conclusion for ``repo`` and failure links.
 
     The GitHub API occasionally returns inconsistent data if a workflow is
     updating while we query it. To catch this non-determinism we fetch the
@@ -84,17 +105,15 @@ def fetch_repo_status(
             repo_data = repo_resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
             LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return status_to_emoji(None)
+            return RepoStatus(status_to_emoji(None))
         if not isinstance(repo_data, dict):
             LOGGER.warning(
                 "Unexpected repository payload for %s: %r", repo, type(repo_data)
             )
-            return status_to_emoji(None)
+            return RepoStatus(status_to_emoji(None))
         branch = repo_data.get("default_branch")
 
-    url = "https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed".format(
-        repo=repo
-    )
+    url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     if branch:
         url += f"&branch={branch}"
 
@@ -126,8 +145,15 @@ def fetch_repo_status(
                 return True
         return False
 
-    def _evaluate_runs(runs: Iterable[dict]) -> str:
-        """Return the overall conclusion for the most recent attempt of each workflow."""
+    def _failure_link(run: dict) -> str | None:
+        for key in ("html_url", "logs_url", "artifacts_url", "url"):
+            value = run.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[str, ...]]:
+        """Return the overall conclusion and failing workflow links."""
 
         latest_runs: dict[tuple[object, object, object], dict] = {}
 
@@ -150,17 +176,25 @@ def fetch_repo_status(
             if current is None or _attempt_key(run) > _attempt_key(current):
                 latest_runs[key] = run
 
-        conclusions = {
-            _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
-        }
+        latest = tuple(latest_runs.values())
+        conclusions = {_normalize_conclusion(r.get("conclusion")) for r in latest}
         if any(c in failures for c in conclusions):
-            return "failure"
+            links = tuple(
+                dict.fromkeys(
+                    link
+                    for run in latest
+                    if _normalize_conclusion(run.get("conclusion")) in failures
+                    for link in [_failure_link(run)]
+                    if link
+                )
+            )
+            return "failure", links
         if "success" in conclusions:
-            return "success"
+            return "success", ()
         # Default to failure so lack of CI coverage surfaces as ❌
-        return "failure"
+        return "failure", ()
 
-    def _fetch() -> str | None:
+    def _fetch() -> tuple[str | None, tuple[str, ...]]:
         try:
             commits_resp = requests.get(
                 f"https://api.github.com/repos/{repo}/commits?sha={branch}&per_page=20",
@@ -171,7 +205,7 @@ def fetch_repo_status(
             commits_data = commits_resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
             LOGGER.warning("Unable to fetch commits for %s@%s: %s", repo, branch, exc)
-            return None
+            return None, ()
         if not isinstance(commits_data, list):
             LOGGER.warning(
                 "Unexpected commits payload for %s@%s: %r",
@@ -179,7 +213,7 @@ def fetch_repo_status(
                 branch,
                 type(commits_data),
             )
-            return None
+            return None, ()
         commits = commits_data
 
         try:
@@ -190,7 +224,7 @@ def fetch_repo_status(
             LOGGER.warning(
                 "Unable to fetch workflow runs for %s@%s: %s", repo, branch, exc
             )
-            return None
+            return None, ()
         if not isinstance(runs_data, dict):
             LOGGER.warning(
                 "Unexpected workflow payload for %s@%s: %r",
@@ -198,7 +232,7 @@ def fetch_repo_status(
                 branch,
                 type(runs_data),
             )
-            return None
+            return None, ()
 
         runs = runs_data.get("workflow_runs", [])
         if not isinstance(runs, list):
@@ -208,7 +242,7 @@ def fetch_repo_status(
                 branch,
                 type(runs),
             )
-            return None
+            return None, ()
 
         runs_by_sha: dict[str, list[dict]] = {}
         for run in runs:
@@ -231,15 +265,35 @@ def fetch_repo_status(
                 return _evaluate_runs(commit_runs)
             if _should_skip_commit(commit):
                 continue
-            return None
-        return None
+            return None, ()
+        return None, ()
 
-    conclusions = [_fetch() for _ in range(attempts)]
+    results = [_fetch() for _ in range(attempts)]
+    conclusions = [result[0] for result in results]
     if len(set(conclusions)) > 1:
         raise RuntimeError(
             f"Non-deterministic workflow conclusion for {repo}: {conclusions}"
         )
-    return status_to_emoji(conclusions[0])
+    failure_links: tuple[str, ...] = ()
+    if conclusions[0] in {
+        "failure",
+        "cancelled",
+        "canceled",
+        "timed_out",
+        "startup_failure",
+        "action_required",
+    }:
+        failure_links = tuple(
+            dict.fromkeys(link for _, links in results for link in links)
+        )
+    return RepoStatus(status_to_emoji(conclusions[0]), failure_links)
+
+
+def _strip_status_markup(line: str) -> str:
+    """Remove status emoji and stale failure links from a README project line."""
+
+    line = re.sub(r"^(-\s*)(?:[✅❌❓]\s*)*", r"\1", line)
+    return re.sub(r"\s+— failures: .*$", "", line)
 
 
 def update_readme(
@@ -247,35 +301,50 @@ def update_readme(
     token: str | None = None,
     now: datetime | None = None,
 ) -> None:
-    """Update README with status emojis and a timestamp."""
+    """Update README with status emojis, failure links, and a timestamp."""
+
     lines = readme_path.read_text(encoding="utf-8").splitlines()
+    output: list[str] = []
     in_section = False
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
     timestamp = now.strftime("%Y-%m-%d %H:%M UTC")
-    for i, line in enumerate(lines):
+    ts_line = f"_Last updated: {timestamp}; checks hourly_"
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
         if line.strip() == "## Related Projects":
             in_section = True
-            ts_line = f"_Last updated: {timestamp}; checks hourly_"
-            if i + 1 < len(lines) and lines[i + 1].startswith("_Last updated:"):
-                lines[i + 1] = ts_line
-            else:
-                lines.insert(i + 1, ts_line)
+            output.append(line)
+            output.append(ts_line)
+            i += 1
+            while i < len(lines) and lines[i].startswith("_Last updated:"):
+                i += 1
             continue
         if in_section and line.startswith("## "):
-            break
+            in_section = False
+        if in_section and line.startswith("_Last updated:"):
+            i += 1
+            continue
         if in_section and line.startswith("- "):
             match = GITHUB_RE.search(line)
             if match:
                 repo = f"{match.group(1)}/{match.group(2)}"
                 branch = match.group(3)
-                emoji = fetch_repo_status(repo, token, branch)
-                # remove existing emoji
-                lines[i] = re.sub(r"^(-\s*)(?:[✅❌❓]\s*)*", r"\1", line)
-                # Ensure UTF-8 output; lines later written with utf-8 encoding
-                lines[i] = f"- {emoji} {lines[i][2:].lstrip()}"
-    # Ensure output file encoded as UTF-8 so emoji render correctly on Windows
-    readme_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+                status = fetch_repo_status_details(repo, token, branch)
+                base_line = _strip_status_markup(line)
+                rendered = f"- {status.emoji} {base_line[2:].lstrip()}"
+                if status.emoji == "❌" and status.failure_links:
+                    rendered += f" — failures: {', '.join(status.failure_links)}"
+                output.append(rendered)
+                i += 1
+                continue
+        output.append(line)
+        i += 1
+
+    # Ensure output file encoded as UTF-8 so emoji render correctly on Windows.
+    readme_path.write_text("\n".join(output) + "\n", encoding="utf-8")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -475,11 +475,11 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
+    ) -> repo_status.RepoStatus:
         calls.append((repo, branch))
-        return {"user/repo": "✅", "other/repo": "❌"}[repo]
+        return repo_status.RepoStatus({"user/repo": "✅", "other/repo": "❌"}[repo])
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
     from datetime import datetime
 
     now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
@@ -499,10 +499,10 @@ def test_update_readme_uses_current_time(
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
-        return "✅"
+    ) -> repo_status.RepoStatus:
+        return repo_status.RepoStatus("✅")
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
 
     from datetime import datetime, timezone
 
@@ -532,10 +532,10 @@ def test_update_readme_existing_timestamp(
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
-        return "✅"
+    ) -> repo_status.RepoStatus:
+        return repo_status.RepoStatus("✅")
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
 
     from datetime import datetime
 
@@ -545,3 +545,99 @@ def test_update_readme_existing_timestamp(
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
     assert lines[4] == "- ✅ https://github.com/user/repo"
+
+
+def test_fetch_repo_status_details_returns_failure_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add tests",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "failure",
+                        "head_sha": "abc",
+                        "html_url": "https://github.com/user/repo/actions/runs/1",
+                        "name": "tests",
+                    },
+                    {
+                        "conclusion": "cancelled",
+                        "head_sha": "abc",
+                        "artifacts_url": "https://api.github.com/repos/user/repo/actions/runs/2/artifacts",
+                        "name": "lint",
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    status = repo_status.fetch_repo_status_details("user/repo")
+
+    assert status == repo_status.RepoStatus(
+        "❌",
+        (
+            "https://github.com/user/repo/actions/runs/1",
+            "https://api.github.com/repos/user/repo/actions/runs/2/artifacts",
+        ),
+    )
+
+
+def test_update_readme_adds_failure_links_and_dedupes_timestamp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    content = (
+        "## Related Projects\n"
+        "_Last updated: old; checks hourly_\n"
+        "_Last updated: older; checks hourly_\n"
+        "- ✅ https://github.com/user/repo — failures: https://old.example/run\n"
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(content)
+
+    def fake_status(
+        repo: str, token: str | None = None, branch: str | None = None
+    ) -> repo_status.RepoStatus:
+        return repo_status.RepoStatus(
+            "❌",
+            (
+                "https://github.com/user/repo/actions/runs/1",
+                "https://api.github.com/repos/user/repo/actions/runs/1/artifacts",
+            ),
+        )
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
+
+    from datetime import datetime
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+
+    lines = readme.read_text().splitlines()
+
+    assert lines == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "- ❌ https://github.com/user/repo — failures: "
+        "https://github.com/user/repo/actions/runs/1, "
+        "https://api.github.com/repos/user/repo/actions/runs/1/artifacts",
+    ]


### PR DESCRIPTION
### Motivation
- Keep the root `README.md` focused on the GitHub profile while moving repository-specific setup, automation, metadata, subtitle, and MCP details into a single internal guide. 
- Make the `## Related Projects` status display more actionable by surfacing direct failure links when a project's CI run fails. 
- Ensure docs and AI guidance files remain consistent with the new README split. 

### Description
- Rewrite `README.md` as a profile-first README with one clear link to `docs/repository-guide.md` and a polished `## Related Projects` legend while preserving parseable `- ` bullets containing GitHub URLs. 
- Add `docs/repository-guide.md` containing the repo map, setup pointers, automation/script/metadata/subtitle summaries, and the YouTube Transcript MCP service documentation. 
- Update `docs/README.md`, `AGENTS.md`, and `llms.txt` to point readers to the new repository guide. 
- Refactor `src/repo_status.py` to return a `RepoStatus` dataclass from `fetch_repo_status_details` that includes `failure_links`, prefer workflow-run URLs (with fallbacks) for failures, deduplicate/update the `_Last updated:` timestamp, and render comma-separated failure links after ❌ entries. 
- Extend `tests/test_repo_status.py` to cover `fetch_repo_status_details` failure-link extraction and the updated README timestamp and failure-link rendering. 

### Testing
- Ran `python -m pytest tests/test_repo_status.py -q`, which passed (`20 passed`).
- Ran the full test suite with `python -m pytest -q`, which passed (`289 passed, 2 warnings`).
- Ran documentation checks with `npm run docs-lint`, which completed successfully (npm emitted an environment warning unrelated to the changes). 
- Ran style/lint checks with `python -m ruff check` (auto-fix applied where suggested) and `python -m black`, after which the focused lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27014611bc832fb457f06be4adb1bd)