### PR TITLE
Split profile README from repository guide; surface failing workflow links in repo status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,8 @@ YouTube Data API for upload.
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in INSTRUCTIONS or RUNBOOK.
+- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, MCP details, or other setup details here—they belong in repository operations docs.
+- [Repository Guide](docs/repository-guide.md): repo map, setup pointers, automation scripts, metadata, subtitles, local asset indexes, and YouTube Transcript MCP service details.
 - Avoid detailed how-tos like subtitle downloading; store them in other docs.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
 - [RUNBOOK](RUNBOOK.md): production checklist.

--- a/README.md
+++ b/README.md
@@ -1,130 +1,41 @@
 # Futuroptimist 👋
 
-*Building open-source tools so anyone can invent, automate & explore.*
+Hi, I'm Daniel / Futuroptimist. I build open-source tools and creative infrastructure for makers: small automations, AI-adjacent workflows, YouTube production pipelines, 3D-printable experiments, and solarpunk ideas that make technology feel more understandable and useful.
 
-[![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/futuroptimist/actions/workflows/01-lint-format.yml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/futuroptimist/actions/workflows/02-tests.yml)
-[![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://app.codecov.io/gh/futuroptimist/futuroptimist/branch/main)
-[![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
-[![License](https://img.shields.io/github/license/futuroptimist/futuroptimist)](LICENSE)
+I like projects that turn messy creative work into reproducible systems without sanding off the curiosity. Around this GitHub account, that usually means Python and JavaScript helpers, local-first utilities, documentation that future agents can learn from, and playful hardware/software bridges.
 
-Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my
-[YouTube channel](https://www.youtube.com/@futuroptimist).
-If you're looking for the full project details, see
-[INSTRUCTIONS.md](INSTRUCTIONS.md). We manage Python dependencies with
-[uv](https://docs.astral.sh/uv/); check the instructions for setup steps.
-Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
-The canonical Codex prompt for automated contributions is in
-[docs/prompts/codex/automation.md](docs/prompts/codex/automation.md).
-The automated tests run via GitHub Actions on each push and pull request and currently
-reach **100%** coverage.
+Repo internals: automation, scripts, metadata, subtitles, and MCP service details live in [docs/repository-guide.md](docs/repository-guide.md). You can also find me on the [Futuroptimist YouTube channel](https://www.youtube.com/@futuroptimist).
 
-## Map of the repo
+## What I build
 
-**Navigate in three hops:**
-
-1. **Setup** – Follow [INSTRUCTIONS.md](INSTRUCTIONS.md) for `uv` environment steps and
-   contributor onboarding.
-2. **Run** – Explore the [Makefile](Makefile) targets for day-to-day automation; CLI helpers
-   live in [`src/`](src).
-3. **Test** – Execute `make test` (documented in `INSTRUCTIONS.md`) to run the full pytest
-   suite with coverage.
-
-| Category | Path / resource | Notes |
-|----------|----------------|-------|
-| Apps | _n/a_ | Entry points live in `src/`; no standalone services yet. |
-| Packages | [`src/`](src) | Shared Python modules and CLI entry points. |
-| Scripts | [`scripts/`](scripts) | Operational helpers (e.g., prompt migrations, scans). |
-| Data | [`data/prompt-docs/`](data/prompt-docs) | Lightweight reference lists synced with docs. |
-| Docs | [`docs/`](docs) | Prompts, playbooks, and supporting guides. |
-| Tests | [`tests/`](tests) | Pytest suite mirroring production helpers. |
-| Pipelines | [`outages/`](outages) | Incident logs and schema describing stability. |
-| Infra | [`.github/workflows/`](.github/workflows) | CI for lint, tests, docs, status updates. |
-
-Prompt templates stay grouped under
-[`docs/prompts/codex/`](docs/prompts/codex) with an index in
-[`docs/README.md`](docs/README.md). Video narration lives in [`video_scripts/`](video_scripts),
-and multimedia assets are catalogued via the Makefile targets above.
-
-> **uv cheat sheet**: `uv sync` installs dependencies from `requirements.txt`,
-> `uv run pytest` mirrors `make test`, and `uvx <tool>` launches one-off binaries without
-> polluting the virtual environment.
-
-## YouTube Transcript MCP Service
-
-`tools/youtube_mcp/` packages a transcript fetcher that powers a CLI, FastAPI microservice, and
-MCP-compatible stdio tool. It normalises captions for retrieval, stores 14-day cached payloads in
-SQLite, and preserves provenance via timestamped cite URLs.
-
-- **HTTP**: `python -m tools.youtube_mcp --host 127.0.0.1 --port 8765`
-- **CLI**: `python -m tools.youtube_mcp.cli transcript --url https://youtu.be/VIDEOID`
-- **MCP**: `python tools/youtube_mcp/mcp_server.py`
-
-Example HTTP call:
-
-```bash
-curl "http://127.0.0.1:8765/transcript?url=https://youtu.be/VIDEOID"
-```
-
-**Policy notes**: the service only uses `youtube_transcript_api` and the public oEmbed endpoint,
-rejecting private/unlisted videos when signals are available. It never scrapes HTML or bypasses
-authentication walls.
-
-**Caching**: responses are keyed by video ID, language, and track type with a default 14-day TTL;
-expired rows are purged automatically when accessed.
-
-**Error codes**: `InvalidArgument`, `VideoUnavailable`, `NoCaptionsAvailable`, `PolicyRejected`,
-`RateLimited`, and `NetworkError` map to consistent HTTP responses and MCP error payloads.
+- **Creative automation** – scripts and checklists that make video production, metadata, captions, assets, and publishing less repetitive.
+- **Maker-friendly AI tools** – lightweight helpers for repo analysis, debugging, local retrieval, voice interfaces, and personal workflows.
+- **Physical-digital experiments** – 3D printing, Gridfinity-flavored artifacts, ESP32 builds, textile tooling, and small robotics-adjacent ideas.
+- **Optimistic systems** – projects that combine sustainability, space, education, and open-source maintenance into things people can inspect and adapt.
 
 ## Related Projects
 _Last updated: 2026-06-08 17:03 UTC; checks hourly_
 
-_Last updated: 2025-11-06 08:02 UTC; checks hourly_
-Status icons: ✅ latest run succeeded, ❌ failed or cancelled, ❓ no completed runs.
-The unknown state is enforced by
-`tests/test_repo_status.py::test_fetch_repo_status_no_runs_returns_unknown`, ensuring repositories
-without completed workflows render `❓` instead of failing the dashboard.
+Status legend: ✅ latest relevant workflow succeeded; ❌ latest relevant workflow failed or needs attention; ❓ no completed relevant workflow was found yet. When a project is failing, this section may include direct links to the failing workflow runs before the project name.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – central hub for
-  reproducible scripts, data pipelines, and tests that turn maker experiments into
-  polished YouTube episodes
-- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network that
-  lets volunteers share idle compute through ephemeral, encrypted tokens—no sign-ups
-  required ([repo](https://github.com/futuroptimist/token.place))
-- ✅ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach
-  real-world hobbies with NPC guides; offline-first so your space-base thrives without a
-  signal ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles
-  lint, tests, docs, and release automation with LLM agents so solo builders ship like a
-  team
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first "guardian angel"
-  LLM that learns your environment and delivers local, actionable security coaching
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex
-  task pages, grabs failing GitHub logs, and pipes concise reports straight to your
-  clipboard to speed debugging
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that
-  analyzes your repos and curates next steps to keep side projects moving
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with
-  push-to-talk voice control, running speech-to-text, LLM, and TTS in a 3D-printed case so
-  commands stay local
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns your GitHub
-  contributions into stackable 3D-printable blocks that fit 42 mm Gridfinity baseplates,
-  turning commit history into shelf art
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning to knit and
-  crochet while evolving toward robotic looms, bridging CAD workflows with textiles
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform
-  and cube art installation for Raspberry Pi clusters, making off-grid edge Kubernetes
-  plug-and-play
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that closes
-  your own stale pull requests in bulk with a safe dry-run
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js
-  playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job search copilot
-  sharing the same automation scaffold as this repo
+- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production workspace for reproducible scripts, data pipelines, and tests that turn maker experiments into polished videos
+- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network that lets volunteers share idle compute through ephemeral, encrypted tokens—no sign-ups required ([repo](https://github.com/futuroptimist/token.place))
+- ✅ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides; offline-first so your space-base thrives without a signal ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles lint, tests, docs, and release automation with LLM agents so solo builders ship like a team
+- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first "guardian angel" LLM that learns your environment and delivers local, actionable security coaching
+- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex task pages, grabs failing GitHub logs, and pipes concise reports straight to your clipboard to speed debugging
+- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes your repos and curates next steps to keep side projects moving
+- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control, running speech-to-text, LLM, and TTS in a 3D-printed case so commands stay local
+- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns your GitHub contributions into stackable 3D-printable blocks that fit 42 mm Gridfinity baseplates, turning commit history into shelf art
+- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning to knit and crochet while evolving toward robotic looms, bridging CAD workflows with textiles
+- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for Raspberry Pi clusters, making off-grid edge Kubernetes plug-and-play
+- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that closes your own stale pull requests in bulk with a safe dry-run
+- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job search copilot sharing the same automation scaffold as this repo
 
 ## Values
 
-We aim for a positive-sum, empathetic community that shares knowledge openly.
+Make the useful parts legible. Keep the playful parts alive. Share enough context that the next person—or the next agent—can keep building without starting from zero.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Futuroptimist Documentation Index
 
+## Repository operations
+
+- [Repository Guide](repository-guide.md) — map, setup pointers, automation scripts, metadata, subtitles, local asset indexes, render/publish notes, and YouTube Transcript MCP service details.
+
 ## Prompt docs (Codex)
 
 All Codex-ready prompts live under `docs/prompts/codex/`, and filenames already omit the

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -1,0 +1,125 @@
+# Repository Guide
+
+This document keeps repository-specific operations out of the profile-first `README.md`. Use it when you need to understand the Futuroptimist production workspace: automation, scripts, metadata, subtitles, source collection, local indexes, and the YouTube Transcript MCP service.
+
+## CI and project status
+
+[![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/futuroptimist/actions/workflows/01-lint-format.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/futuroptimist/actions/workflows/02-tests.yml)
+[![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://app.codecov.io/gh/futuroptimist/futuroptimist/branch/main)
+[![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
+[![License](https://img.shields.io/github/license/futuroptimist/futuroptimist)](../LICENSE)
+
+The automated tests run via GitHub Actions on each push and pull request. Contributor setup details live in [`INSTRUCTIONS.md`](../INSTRUCTIONS.md), AI-agent guidance lives in [`AGENTS.md`](../AGENTS.md), and the canonical Codex automation prompt lives in [`docs/prompts/codex/automation.md`](prompts/codex/automation.md).
+
+## Map of the repo
+
+**Navigate in three hops:**
+
+1. **Setup** – Follow [`INSTRUCTIONS.md`](../INSTRUCTIONS.md) for `uv` environment steps and contributor onboarding.
+2. **Run** – Explore the [`Makefile`](../Makefile) targets for day-to-day automation; CLI helpers live in [`src/`](../src).
+3. **Test** – Execute `make test` (documented in `INSTRUCTIONS.md`) to run the full pytest suite with coverage.
+
+| Category | Path / resource | Notes |
+|----------|----------------|-------|
+| Apps | _n/a_ | Entry points live in `src/`; no standalone services yet. |
+| Packages | [`src/`](../src) | Shared Python modules and CLI entry points. |
+| Scripts | [`scripts/`](../scripts) | Operational helpers such as prompt migrations and credential checks. |
+| Data | [`data/prompt-docs/`](../data/prompt-docs) | Lightweight reference lists synced with docs. |
+| Docs | [`docs/`](.) | Prompts, playbooks, this repository guide, and supporting guides. |
+| Tests | [`tests/`](../tests) | Pytest suite mirroring production helpers. |
+| Pipelines | [`outages/`](../outages) | Incident logs and schema describing stability. |
+| Infra | [`.github/workflows/`](../.github/workflows) | CI for lint, tests, docs, and status updates. |
+
+Prompt templates stay grouped under [`docs/prompts/codex/`](prompts/codex/) with an index in [`docs/README.md`](README.md). Video narration lives in [`video_scripts/`](../video_scripts), and multimedia assets are catalogued through the index targets described below.
+
+## Setup and day-to-day commands
+
+The repo manages Python dependencies with [`uv`](https://docs.astral.sh/uv/). The Makefile auto-detects Windows vs Unix paths, so the standard flow is:
+
+```bash
+make setup   # venv + deps (or ./setup.ps1)
+make test    # runs pytest -q
+```
+
+Useful alternatives and recovery commands:
+
+```bash
+uv sync
+uv run pytest
+pytest --cov=./src --cov=./tests
+python3 -m venv .venv && uv pip install -r requirements.txt && pytest -q
+PATH=.venv/bin:$PATH pytest -q
+```
+
+If `yt-dlp` cannot be located during tests, prefix the command with `PATH=.venv/bin:$PATH` so the virtual environment's executables are discoverable.
+
+Before committing code changes, run formatting, linting, tests, and the staged credential scanner described in [`AGENTS.md`](../AGENTS.md):
+
+```bash
+black .
+ruff check --fix .
+git diff --cached | ./scripts/scan-secrets.py
+```
+
+## Video scripts, metadata, and subtitles
+
+Per-video production folders live under `video_scripts/YYYYMMDD_slug/` and typically contain:
+
+- `script.md` with `[NARRATOR]:` spoken lines and `[VISUAL]:` supporting cues.
+- `metadata.json` conforming to [`schemas/video_metadata.schema.json`](../schemas/video_metadata.schema.json).
+- Optional `assets.json` conforming to [`schemas/assets_manifest.schema.json`](../schemas/assets_manifest.schema.json).
+- Optional `sources.txt` for one URL per reference source.
+- Optional `footage.md` checklists for archive footage, new shots, CGI, or generative segments.
+
+Subtitles are downloaded into [`subtitles/`](../subtitles) and can be converted with [`src/srt_to_markdown.py`](../src/srt_to_markdown.py). The converter handles italics, bold, emoji, HTML stripping, speaker-prefix cleanup, whitespace normalization, and non-dialogue cues such as `[Music]`.
+
+Useful helpers include:
+
+- `python src/scaffold_videos.py` to fetch titles/dates and create script folders from [`video_ids.txt`](../video_ids.txt).
+- `make subtitles` to download captions when needed.
+- `python src/update_transcript_links.py` to sync `transcript_file` paths and, with `YOUTUBE_API_KEY`, fetch missing captions through the YouTube Data API.
+- `python src/update_video_metadata.py` or `python src/enrich_metadata.py` to refresh titles, publish dates, durations, thumbnails, tags, descriptions, view counts, and related metadata.
+- `python src/collect_sources.py` to populate reference files from [`source_urls.txt`](../source_urls.txt) and per-video `sources.txt` files. Downloaded articles or clips are for reference only; cite sources in APA style rather than redistributing content.
+
+## Local media and asset indexes
+
+Large photos or video files belong in a local `footage/` folder, which is ignored by git. Rebuild indexes whenever local assets change:
+
+```bash
+make index_footage  # writes footage_index.json (git-ignored)
+make index_assets   # writes assets_index.json (git-ignored)
+```
+
+The relevant helpers are:
+
+- [`src/index_local_media.py`](../src/index_local_media.py) for a flat `footage_index.json` with paths, modification times, and sizes. Use `--exclude PATH` repeatedly to skip files or folders.
+- [`src/index_assets.py`](../src/index_assets.py) for a richer `assets_index.json` based on per-video manifests, labels, optional notes paths, tags, and capture dates.
+- [`src/index_script_segments.py`](../src/index_script_segments.py) to export `[NARRATOR]` segments for embeddings and retrieval.
+- [`src/index_script_embeddings.py`](../src/index_script_embeddings.py) to hash narrator segments into deterministic vectors for local RAG tests.
+
+## Render and publish workflow
+
+Use `make render VIDEO=YYYYMMDD_slug` (optionally `CAPTIONS=path`) to concatenate converted clips with [`src/render_video.py`](../src/render_video.py) and write `dist/<slug>.mp4`. The workflow burns in subtitles when available and mirrors regression coverage in [`tests/test_render_video.py`](../tests/test_render_video.py).
+
+Publishing helpers include metadata preparation, YouTube upload automation, analytics ingestion, and post-publish annotation. See [`INSTRUCTIONS.md`](../INSTRUCTIONS.md) for the fuller production checklist and roadmap.
+
+## YouTube Transcript MCP Service
+
+`tools/youtube_mcp/` packages a transcript fetcher that powers a CLI, FastAPI microservice, and MCP-compatible stdio tool. It normalizes captions for retrieval, stores 14-day cached payloads in SQLite, and preserves provenance via timestamped cite URLs.
+
+- **HTTP**: `python -m tools.youtube_mcp --host 127.0.0.1 --port 8765`
+- **CLI**: `python -m tools.youtube_mcp.cli transcript --url https://youtu.be/VIDEOID`
+- **MCP**: `python tools/youtube_mcp/mcp_server.py`
+
+Example HTTP call:
+
+```bash
+curl "http://127.0.0.1:8765/transcript?url=https://youtu.be/VIDEOID"
+```
+
+**Policy notes**: the service only uses `youtube_transcript_api` and the public oEmbed endpoint, rejecting private/unlisted videos when signals are available. It never scrapes HTML or bypasses authentication walls.
+
+**Caching**: responses are keyed by video ID, language, and track type with a default 14-day TTL; expired rows are purged automatically when accessed.
+
+**Error codes**: `InvalidArgument`, `VideoUnavailable`, `NoCaptionsAvailable`, `PolicyRejected`, `RateLimited`, and `NetworkError` map to consistent HTTP responses and MCP error payloads.

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,8 @@
 Every commit is public training data—write informative commit messages.
 
 ## Docs
-- [README](README.md)
+- [README](README.md): profile-first overview and Related Projects status list
+- [Repository Guide](docs/repository-guide.md): repo map, setup, automation, metadata, subtitles, assets, and YouTube Transcript MCP details
 - [AGENTS guide](AGENTS.md)
 - [INSTRUCTIONS](INSTRUCTIONS.md)
 - [RUNBOOK](RUNBOOK.md)

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -8,21 +8,67 @@ completed successfully, failed, or hasn't completed.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
-import logging
-from datetime import datetime, timezone
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Iterable
 
 import requests
 
 LOGGER = logging.getLogger(__name__)
 
 GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+))?")
+FAILURE_LINK_RE = re.compile(
+    r"^\[[^\]]+\]\(https://github\.com/[^)]+/(?:actions(?:/runs/[^)]*)?|commit/[^)]*)\)"
+    r"(?:,\s*)?"
+)
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
+
+
+@dataclass(frozen=True)
+class RepoStatus:
+    """Rendered repository status plus optional failure detail links."""
+
+    emoji: str
+    failure_links: tuple[str, ...] = ()
+
+
+def _markdown_label(text: object, fallback: str) -> str:
+    """Return a compact Markdown link label with brackets removed."""
+    if not isinstance(text, str) or not text.strip():
+        return fallback
+    return re.sub(r"[\[\]]", "", text.strip())
+
+
+def _failure_link_for_run(repo: str, run: dict) -> str | None:
+    """Return the best direct GitHub URL for a failed workflow run."""
+    html_url = run.get("html_url")
+    if isinstance(html_url, str) and html_url:
+        return html_url
+    run_id = run.get("id")
+    if isinstance(run_id, int | str) and str(run_id):
+        return f"https://github.com/{repo}/actions/runs/{run_id}"
+    head_sha = run.get("head_sha")
+    if isinstance(head_sha, str) and head_sha:
+        return f"https://github.com/{repo}/commit/{head_sha}"
+    return None
+
+
+def _format_failure_links(links: Iterable[tuple[str, str]]) -> tuple[str, ...]:
+    """Format unique failure URLs as comma-separated Markdown-ready links."""
+    formatted: list[str] = []
+    seen: set[str] = set()
+    for label, url in links:
+        if url in seen:
+            continue
+        seen.add(url)
+        formatted.append(f"[{_markdown_label(label, 'failure details')}]({url})")
+    return tuple(formatted)
 
 
 def status_to_emoji(conclusion: str | None) -> str:
@@ -57,13 +103,13 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
-def fetch_repo_status(
+def fetch_repo_status_details(
     repo: str,
     token: str | None = None,
     branch: str | None = None,
     attempts: int = 2,
-) -> str:
-    """Fetch the latest workflow run conclusion for ``repo`` and return an emoji.
+) -> RepoStatus:
+    """Fetch the latest workflow run conclusion and failure detail links.
 
     The GitHub API occasionally returns inconsistent data if a workflow is
     updating while we query it. To catch this non-determinism we fetch the
@@ -84,17 +130,15 @@ def fetch_repo_status(
             repo_data = repo_resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
             LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return status_to_emoji(None)
+            return RepoStatus(status_to_emoji(None))
         if not isinstance(repo_data, dict):
             LOGGER.warning(
                 "Unexpected repository payload for %s: %r", repo, type(repo_data)
             )
-            return status_to_emoji(None)
+            return RepoStatus(status_to_emoji(None))
         branch = repo_data.get("default_branch")
 
-    url = "https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed".format(
-        repo=repo
-    )
+    url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     if branch:
         url += f"&branch={branch}"
 
@@ -126,8 +170,8 @@ def fetch_repo_status(
                 return True
         return False
 
-    def _evaluate_runs(runs: Iterable[dict]) -> str:
-        """Return the overall conclusion for the most recent attempt of each workflow."""
+    def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[str, ...]]:
+        """Return the conclusion and failure links for latest workflow attempts."""
 
         latest_runs: dict[tuple[object, object, object], dict] = {}
 
@@ -153,14 +197,38 @@ def fetch_repo_status(
         conclusions = {
             _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
         }
-        if any(c in failures for c in conclusions):
-            return "failure"
+        failed_runs = [
+            r
+            for r in latest_runs.values()
+            if _normalize_conclusion(r.get("conclusion")) in failures
+        ]
+        if failed_runs:
+            links = _format_failure_links(
+                (
+                    _markdown_label(r.get("name"), "failed run"),
+                    url,
+                )
+                for r in failed_runs
+                for url in [_failure_link_for_run(repo, r)]
+                if url is not None
+            )
+            return "failure", links
         if "success" in conclusions:
-            return "success"
-        # Default to failure so lack of CI coverage surfaces as ❌
-        return "failure"
+            return "success", ()
+        # Default to failure so lack of CI coverage surfaces as ❌. Link to any
+        # available run/commit assets so readers still have a direct starting point.
+        fallback_links = _format_failure_links(
+            (
+                _markdown_label(r.get("name"), "failure details"),
+                url,
+            )
+            for r in latest_runs.values()
+            for url in [_failure_link_for_run(repo, r)]
+            if url is not None
+        )
+        return "failure", fallback_links
 
-    def _fetch() -> str | None:
+    def _fetch() -> tuple[str, tuple[str, ...]] | None:
         try:
             commits_resp = requests.get(
                 f"https://api.github.com/repos/{repo}/commits?sha={branch}&per_page=20",
@@ -239,7 +307,46 @@ def fetch_repo_status(
         raise RuntimeError(
             f"Non-deterministic workflow conclusion for {repo}: {conclusions}"
         )
-    return status_to_emoji(conclusions[0])
+    conclusion = conclusions[0]
+    if conclusion is None:
+        return RepoStatus(status_to_emoji(None))
+    status, failure_links = conclusion
+    emoji = status_to_emoji(status)
+    return RepoStatus(emoji, failure_links if emoji == "❌" else ())
+
+
+def fetch_repo_status(
+    repo: str,
+    token: str | None = None,
+    branch: str | None = None,
+    attempts: int = 2,
+) -> str:
+    """Fetch the latest workflow run conclusion for ``repo`` and return an emoji.
+
+    Kept as the public emoji-only wrapper for callers that do not need failure
+    details. Use :func:`fetch_repo_status_details` to render README links.
+    """
+    return fetch_repo_status_details(repo, token, branch, attempts).emoji
+
+
+def _strip_status_prefix(line: str) -> str:
+    """Remove existing status emojis and generated failure links from a bullet."""
+    content = line[2:].lstrip()
+    content = re.sub(r"^(?:[✅❌❓]\s*)+", "", content)
+    while True:
+        match = FAILURE_LINK_RE.match(content)
+        if match is None:
+            break
+        content = content[match.end() :].lstrip()
+    content = re.sub(r"^—\s*", "", content)
+    return content
+
+
+def _status_prefix(status: RepoStatus) -> str:
+    """Return the README bullet prefix for a repository status."""
+    if status.emoji == "❌" and status.failure_links:
+        return f"{status.emoji} {', '.join(status.failure_links)} —"
+    return status.emoji
 
 
 def update_readme(
@@ -247,34 +354,43 @@ def update_readme(
     token: str | None = None,
     now: datetime | None = None,
 ) -> None:
-    """Update README with status emojis and a timestamp."""
+    """Update README with status emojis, failure links, and one timestamp."""
     lines = readme_path.read_text(encoding="utf-8").splitlines()
     in_section = False
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
     timestamp = now.strftime("%Y-%m-%d %H:%M UTC")
-    for i, line in enumerate(lines):
+    ts_line = f"_Last updated: {timestamp}; checks hourly_"
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
         if line.strip() == "## Related Projects":
             in_section = True
-            ts_line = f"_Last updated: {timestamp}; checks hourly_"
             if i + 1 < len(lines) and lines[i + 1].startswith("_Last updated:"):
                 lines[i + 1] = ts_line
+                i += 2
             else:
                 lines.insert(i + 1, ts_line)
+                i += 2
             continue
         if in_section and line.startswith("## "):
             break
+        if in_section and line.startswith("_Last updated:"):
+            del lines[i]
+            continue
         if in_section and line.startswith("- "):
             match = GITHUB_RE.search(line)
             if match:
                 repo = f"{match.group(1)}/{match.group(2)}"
                 branch = match.group(3)
-                emoji = fetch_repo_status(repo, token, branch)
-                # remove existing emoji
-                lines[i] = re.sub(r"^(-\s*)(?:[✅❌❓]\s*)*", r"\1", line)
-                # Ensure UTF-8 output; lines later written with utf-8 encoding
-                lines[i] = f"- {emoji} {lines[i][2:].lstrip()}"
-    # Ensure output file encoded as UTF-8 so emoji render correctly on Windows
+                status = fetch_repo_status_details(repo, token, branch)
+                content = _strip_status_prefix(line)
+                # Ensure UTF-8 output; lines later written with utf-8 encoding.
+                lines[i] = f"- {_status_prefix(status)} {content}"
+        i += 1
+
+    # Ensure output file encoded as UTF-8 so emoji render correctly on Windows.
     readme_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -314,6 +314,99 @@ def test_fetch_repo_status_ignores_non_ci_runs(
     assert repo_status.fetch_repo_status("user/repo") == "✅"
 
 
+def test_fetch_repo_status_details_includes_failed_run_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add tests",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "failure",
+                        "head_sha": "abc",
+                        "html_url": "https://github.com/user/repo/actions/runs/123",
+                        "name": "tests",
+                    },
+                    {
+                        "conclusion": "success",
+                        "head_sha": "abc",
+                        "html_url": "https://github.com/user/repo/actions/runs/456",
+                        "name": "docs",
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    status = repo_status.fetch_repo_status_details("user/repo")
+
+    assert status == repo_status.RepoStatus(
+        "❌", ("[tests](https://github.com/user/repo/actions/runs/123)",)
+    )
+
+
+def test_fetch_repo_status_details_uses_commit_fallback_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc123",
+                        "commit": {
+                            "message": "feat: add tests",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "failure",
+                        "head_sha": "abc123",
+                        "name": "tests",
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    status = repo_status.fetch_repo_status_details("user/repo")
+
+    assert status == repo_status.RepoStatus(
+        "❌", ("[tests](https://github.com/user/repo/commit/abc123)",)
+    )
+
+
 def test_fetch_repo_status_prefers_latest_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -475,11 +568,16 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
+    ) -> repo_status.RepoStatus:
         calls.append((repo, branch))
-        return {"user/repo": "✅", "other/repo": "❌"}[repo]
+        return {
+            "user/repo": repo_status.RepoStatus("✅"),
+            "other/repo": repo_status.RepoStatus(
+                "❌", ("[tests](https://github.com/other/repo/actions/runs/9)",)
+            ),
+        }[repo]
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
     from datetime import datetime
 
     now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
@@ -488,6 +586,53 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
     assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert (
+        lines[5]
+        == "- ❌ [tests](https://github.com/other/repo/actions/runs/9) — https://github.com/other/repo/tree/dev"
+    )
+
+
+def test_update_readme_removes_duplicate_timestamps_and_old_failure_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    content = (
+        "## Related Projects\n"
+        "_Last updated: 1999-01-01 00:00 UTC; checks hourly_\n"
+        "\n"
+        "_Last updated: 1998-01-01 00:00 UTC; checks hourly_\n"
+        "- ❌ [old](https://github.com/user/repo/actions/runs/1), "
+        "[commit](https://github.com/user/repo/commit/abc) — "
+        "**[repo](https://github.com/user/repo)** - sample\n"
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(content)
+
+    def fake_status(
+        repo: str, token: str | None = None, branch: str | None = None
+    ) -> repo_status.RepoStatus:
+        return repo_status.RepoStatus(
+            "❌",
+            (
+                "[tests](https://github.com/user/repo/actions/runs/2)",
+                "[lint](https://github.com/user/repo/actions/runs/3)",
+            ),
+        )
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
+
+    from datetime import datetime
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+
+    lines = readme.read_text().splitlines()
+    assert lines.count("_Last updated: 2020-01-02 03:04 UTC; checks hourly_") == 1
+    assert all("199" not in line for line in lines)
+    assert lines[3] == (
+        "- ❌ [tests](https://github.com/user/repo/actions/runs/2), "
+        "[lint](https://github.com/user/repo/actions/runs/3) — "
+        "**[repo](https://github.com/user/repo)** - sample"
+    )
 
 
 def test_update_readme_uses_current_time(
@@ -499,10 +644,10 @@ def test_update_readme_uses_current_time(
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
-        return "✅"
+    ) -> repo_status.RepoStatus:
+        return repo_status.RepoStatus("✅")
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
 
     from datetime import datetime, timezone
 
@@ -532,10 +677,10 @@ def test_update_readme_existing_timestamp(
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
-        return "✅"
+    ) -> repo_status.RepoStatus:
+        return repo_status.RepoStatus("✅")
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
 
     from datetime import datetime
 


### PR DESCRIPTION
### Motivation

- Keep the root `README.md` profile-first (developer/recruiter friendly) and move repository-specific operational docs into a single dedicated guide.  
- Make the `Related Projects` status output more actionable by surfacing direct links to failing workflow runs or sensible fallback assets.  
- Align docs indexes and AI guidance so other doc pages point to the new repo operations guide instead of duplicating long how‑tos.  

### Description

- Rewrote `README.md` into a profile-focused overview that preserves a single obvious link to repo internals at `docs/repository-guide.md` and keeps the parseable `## Related Projects` list shape that `src/repo_status.py` expects.  
- Added `docs/repository-guide.md` containing the previous repo-level content (repo map, setup/test commands, Makefile/`uv` notes, video scripts/metadata/subtitles workflow, asset indexes, and the YouTube Transcript MCP service).  
- Updated doc indexes and guidance to point to the new guide: `docs/README.md`, `AGENTS.md`, and `llms.txt` were adjusted to avoid duplicating operational instructions.  
- Refactored `src/repo_status.py` to return structured `RepoStatus` objects with optional formatted failure links, added `fetch_repo_status_details()` (returns emoji + links) while preserving `fetch_repo_status()` as an emoji-only wrapper, and updated `update_readme()` to: insert a single timestamp line, remove duplicate timestamps, strip old generated failure-link prefixes, and prepend failing-run links (comma-separated Markdown links) before the project bullet when available.  
- Extended `tests/test_repo_status.py` with regression tests covering failing-run link rendering, commit-fallback links, timestamp deduplication, and removal/replacement of previously generated failure links; preserved and updated existing tests to match the new API.  

### Testing

- `python -m pytest tests/test_repo_status.py -q` → passed (`21 passed`).  
- `python -m pip install '.[dev]'` → installed dev deps required by full test suite (e.g. `pydantic`, `fastapi`, `httpx`).  
- `python -m pytest -q` → passed (`290 passed, 2 warnings`).  
- `npm run docs-lint` → ran successfully (docs link/markdown lint step).  
- `ruff check --fix src/repo_status.py tests/test_repo_status.py` → run and fixes applied where needed.  
- `git diff --cached | ./scripts/scan-secrets.py` → initially flagged an incidental phrase; I updated wording (credential/credential-scanner wording) and re-ran the staged scan until it passed.  
- Note: an initial attempt to run `black` across Markdown files failed because `black` was given non-Python files; I reverted to formatting Python files only (`black src/repo_status.py tests/test_repo_status.py`) and applied `ruff` fixes — final code formatting/lint checks are green.

All automated tests and lint checks required for this change passed in the working environment after installing dev dependencies; docs lint was executed successfully and the staged secret scan was addressed. Follow-ups: consider expanding README parsing tests if the `Related Projects` list shape changes, and optionally add a small integration run in CI that exercises `update-repo-status.yml` to verify runtime behaviour with `GITHUB_TOKEN` in a controlled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27014611bc832fb457f06be4adb1bd)