### PR TITLE
docs: split profile README from repo guide; surface failing-run links in repo_status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Every commit here doubles as both version control and long-term training data. K
 Keep `llms.txt` synchronized with changes to this guide so LLMs stay current.
 
 The main `README.md` is intentionally minimal to maintain a clean GitHub profile.
-Avoid adding setup or asset instructions there; link to INSTRUCTIONS instead.
+Avoid adding setup or asset instructions there; link to `docs/repository-guide.md` or INSTRUCTIONS instead.
 
 ## Key Information
 
@@ -129,7 +129,8 @@ YouTube Data API for upload.
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in INSTRUCTIONS or RUNBOOK.
+- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in `docs/repository-guide.md`, INSTRUCTIONS, or RUNBOOK.
+- [Repository guide](docs/repository-guide.md): repo-internal map, setup pointers, automation, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
 - Avoid detailed how-tos like subtitle downloading; store them in other docs.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
 - [RUNBOOK](RUNBOOK.md): production checklist.

--- a/README.md
+++ b/README.md
@@ -1,130 +1,41 @@
 # Futuroptimist 👋
 
-*Building open-source tools so anyone can invent, automate & explore.*
+I’m Daniel/Futuroptimist: a developer and maker building open-source tools for creative infrastructure, AI-adjacent workflows, and hands-on experiments that make the future feel more repairable, playful, and shared.
 
-[![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/futuroptimist/actions/workflows/01-lint-format.yml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/futuroptimist/actions/workflows/02-tests.yml)
-[![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://app.codecov.io/gh/futuroptimist/futuroptimist/branch/main)
-[![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
-[![License](https://img.shields.io/github/license/futuroptimist/futuroptimist)](LICENSE)
+I like projects where code meets the physical world: reproducible automation, YouTube production pipelines, 3D-printable artifacts, small ML utilities, solar/space/sustainability ideas, and maker-friendly systems that help people learn by building.
 
-Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my
-[YouTube channel](https://www.youtube.com/@futuroptimist).
-If you're looking for the full project details, see
-[INSTRUCTIONS.md](INSTRUCTIONS.md). We manage Python dependencies with
-[uv](https://docs.astral.sh/uv/); check the instructions for setup steps.
-Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
-The canonical Codex prompt for automated contributions is in
-[docs/prompts/codex/automation.md](docs/prompts/codex/automation.md).
-The automated tests run via GitHub Actions on each push and pull request and currently
-reach **100%** coverage.
+Repo internals: automation, scripts, metadata, subtitles, and MCP service details live in the [repository guide](docs/repository-guide.md). You can also find the channel at [youtube.com/@futuroptimist](https://www.youtube.com/@futuroptimist).
 
-## Map of the repo
+## What I build
 
-**Navigate in three hops:**
-
-1. **Setup** – Follow [INSTRUCTIONS.md](INSTRUCTIONS.md) for `uv` environment steps and
-   contributor onboarding.
-2. **Run** – Explore the [Makefile](Makefile) targets for day-to-day automation; CLI helpers
-   live in [`src/`](src).
-3. **Test** – Execute `make test` (documented in `INSTRUCTIONS.md`) to run the full pytest
-   suite with coverage.
-
-| Category | Path / resource | Notes |
-|----------|----------------|-------|
-| Apps | _n/a_ | Entry points live in `src/`; no standalone services yet. |
-| Packages | [`src/`](src) | Shared Python modules and CLI entry points. |
-| Scripts | [`scripts/`](scripts) | Operational helpers (e.g., prompt migrations, scans). |
-| Data | [`data/prompt-docs/`](data/prompt-docs) | Lightweight reference lists synced with docs. |
-| Docs | [`docs/`](docs) | Prompts, playbooks, and supporting guides. |
-| Tests | [`tests/`](tests) | Pytest suite mirroring production helpers. |
-| Pipelines | [`outages/`](outages) | Incident logs and schema describing stability. |
-| Infra | [`.github/workflows/`](.github/workflows) | CI for lint, tests, docs, status updates. |
-
-Prompt templates stay grouped under
-[`docs/prompts/codex/`](docs/prompts/codex) with an index in
-[`docs/README.md`](docs/README.md). Video narration lives in [`video_scripts/`](video_scripts),
-and multimedia assets are catalogued via the Makefile targets above.
-
-> **uv cheat sheet**: `uv sync` installs dependencies from `requirements.txt`,
-> `uv run pytest` mirrors `make test`, and `uvx <tool>` launches one-off binaries without
-> polluting the virtual environment.
-
-## YouTube Transcript MCP Service
-
-`tools/youtube_mcp/` packages a transcript fetcher that powers a CLI, FastAPI microservice, and
-MCP-compatible stdio tool. It normalises captions for retrieval, stores 14-day cached payloads in
-SQLite, and preserves provenance via timestamped cite URLs.
-
-- **HTTP**: `python -m tools.youtube_mcp --host 127.0.0.1 --port 8765`
-- **CLI**: `python -m tools.youtube_mcp.cli transcript --url https://youtu.be/VIDEOID`
-- **MCP**: `python tools/youtube_mcp/mcp_server.py`
-
-Example HTTP call:
-
-```bash
-curl "http://127.0.0.1:8765/transcript?url=https://youtu.be/VIDEOID"
-```
-
-**Policy notes**: the service only uses `youtube_transcript_api` and the public oEmbed endpoint,
-rejecting private/unlisted videos when signals are available. It never scrapes HTML or bypasses
-authentication walls.
-
-**Caching**: responses are keyed by video ID, language, and track type with a default 14-day TTL;
-expired rows are purged automatically when accessed.
-
-**Error codes**: `InvalidArgument`, `VideoUnavailable`, `NoCaptionsAvailable`, `PolicyRejected`,
-`RateLimited`, and `NetworkError` map to consistent HTTP responses and MCP error payloads.
+- **Creative automation** that turns repeatable production work into tested scripts and checklists.
+- **Maker tools** for 3D printing, electronics, textiles, off-grid computing, and physical interfaces.
+- **AI-adjacent workflows** that keep humans in the loop while making research, writing, and debugging easier.
+- **Open learning systems** that document the path from rough idea to reusable project.
 
 ## Related Projects
 _Last updated: 2026-06-08 17:03 UTC; checks hourly_
 
-_Last updated: 2025-11-06 08:02 UTC; checks hourly_
-Status icons: ✅ latest run succeeded, ❌ failed or cancelled, ❓ no completed runs.
-The unknown state is enforced by
-`tests/test_repo_status.py::test_fetch_repo_status_no_runs_returns_unknown`, ensuring repositories
-without completed workflows render `❓` instead of failing the dashboard.
+Status legend: ✅ latest completed checks passed, ❌ latest completed checks failed or were cancelled, ❓ no completed checks were found yet.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – central hub for
-  reproducible scripts, data pipelines, and tests that turn maker experiments into
-  polished YouTube episodes
-- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network that
-  lets volunteers share idle compute through ephemeral, encrypted tokens—no sign-ups
-  required ([repo](https://github.com/futuroptimist/token.place))
-- ✅ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach
-  real-world hobbies with NPC guides; offline-first so your space-base thrives without a
-  signal ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles
-  lint, tests, docs, and release automation with LLM agents so solo builders ship like a
-  team
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first "guardian angel"
-  LLM that learns your environment and delivers local, actionable security coaching
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex
-  task pages, grabs failing GitHub logs, and pipes concise reports straight to your
-  clipboard to speed debugging
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that
-  analyzes your repos and curates next steps to keep side projects moving
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with
-  push-to-talk voice control, running speech-to-text, LLM, and TTS in a 3D-printed case so
-  commands stay local
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns your GitHub
-  contributions into stackable 3D-printable blocks that fit 42 mm Gridfinity baseplates,
-  turning commit history into shelf art
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning to knit and
-  crochet while evolving toward robotic looms, bridging CAD workflows with textiles
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform
-  and cube art installation for Raspberry Pi clusters, making off-grid edge Kubernetes
-  plug-and-play
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that closes
-  your own stale pull requests in bulk with a safe dry-run
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js
-  playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job search copilot
-  sharing the same automation scaffold as this repo
+- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for turning maker experiments into reproducible scripts, metadata, and polished Futuroptimist episodes
+- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network for sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+- ✅ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles lint, tests, docs, release automation, and LLM-agent workflows for solo builders
+- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex task pages, grabs failing GitHub logs, and copies concise debugging reports
+- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repos and curates next steps to keep side projects moving
+- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control in a 3D-printed case
+- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns GitHub contributions into stackable 3D-printable Gridfinity blocks
+- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning knitting and crochet while exploring CAD-to-textile workflows
+- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that safely closes stale pull requests in bulk with dry-run support
+- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot sharing the same automation scaffold as this repo
 
 ## Values
 
-We aim for a positive-sum, empathetic community that shares knowledge openly.
+I’m drawn to tools that are open, inspectable, optimistic without being naive, and useful to people who want to understand the systems they depend on. If a project helps someone build, repair, teach, or explore with more confidence, it belongs in this orbit.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Futuroptimist Documentation Index
 
+## Repository guide
+
+- [repository-guide.md](repository-guide.md) — Repo-internal map, setup pointers, automation, scripts, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
+
 ## Prompt docs (Codex)
 
 All Codex-ready prompts live under `docs/prompts/codex/`, and filenames already omit the

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -1,0 +1,169 @@
+# Futuroptimist Repository Guide
+
+This repository is the working production hub for the Futuroptimist YouTube/GitHub project. The public `README.md` stays profile-first; this guide collects the repo-internal map, setup pointers, automation notes, metadata workflow, subtitle tooling, and YouTube Transcript MCP service details.
+
+## Repository purpose
+
+The repo hosts scripts, metadata, prompt docs, test fixtures, and production checklists for turning maker experiments into repeatable Futuroptimist episodes. It supports:
+
+- drafting and validating per-video scripts;
+- collecting YouTube metadata, transcripts, captions, and source references;
+- indexing local media and per-video assets;
+- rendering rough cuts and exportable editing timelines;
+- maintaining Codex prompt docs and cross-repo automation; and
+- exposing a local YouTube transcript CLI/API/MCP service for retrieval workflows.
+
+For the full contributor workflow and roadmap, see [`INSTRUCTIONS.md`](../INSTRUCTIONS.md). For the production checklist, see [`RUNBOOK.md`](../RUNBOOK.md). AI-agent guidance lives in [`AGENTS.md`](../AGENTS.md), with creative context mirrored in [`llms.txt`](../llms.txt).
+
+## Map of the repo
+
+**Navigate in three hops:**
+
+1. **Setup** – Follow [`INSTRUCTIONS.md`](../INSTRUCTIONS.md) for `uv` environment steps and contributor onboarding.
+2. **Run** – Explore the [`Makefile`](../Makefile) targets for day-to-day automation; CLI helpers live in [`src/`](../src).
+3. **Test** – Execute `make test` or `python -m pytest -q` to run the pytest suite.
+
+| Category | Path / resource | Notes |
+|----------|----------------|-------|
+| Apps | _n/a_ | Entry points live in `src/` and `tools/`; there is no standalone product app in this repo. |
+| Packages | [`src/`](../src) | Shared Python modules and CLI entry points for subtitles, scripts, metadata, assets, rendering, status updates, and reports. |
+| Transcript service | [`tools/youtube_mcp/`](../tools/youtube_mcp) | CLI, FastAPI microservice, and MCP-compatible stdio server for YouTube transcripts. |
+| Scripts | [`scripts/`](../scripts) | Operational helpers, prompt migrations, npm check wrappers, and credential-leak scans. |
+| Video scripts | [`video_scripts/`](../video_scripts) | Per-video folders with `script.md`, `metadata.json`, and optional sources/assets/footage notes. |
+| Subtitles | [`subtitles/`](../subtitles) | Downloaded `.srt` caption files populated by subtitle helpers. |
+| Sources | [`sources/`](../sources) | Reference files fetched by source collection tooling. |
+| Data | [`data/`](../data) | Lightweight generated/reference data for prompt docs and retrieval workflows. |
+| Docs | [`docs/`](../docs) | Prompt docs, playbooks, this guide, and supporting documentation. |
+| Schemas | [`schemas/`](../schemas) | JSON Schemas for video metadata, asset manifests, outage records, and related structured files. |
+| Tests | [`tests/`](../tests) | Pytest suite mirroring production helpers. |
+| Pipelines | [`outages/`](../outages) | Incident logs and schema-backed records for CI/workflow failures. |
+| Infra | [`.github/workflows/`](../.github/workflows) | CI for lint, tests, docs, and scheduled Related Projects status updates. |
+
+Prompt templates stay grouped under [`docs/prompts/codex/`](prompts/codex/) with an index in [`docs/README.md`](README.md). Video narration lives in [`video_scripts/`](../video_scripts), while local media and generated indexes are intentionally kept out of git when large or machine-specific.
+
+## Setup and package notes
+
+Python dependencies are managed with [`uv`](https://docs.astral.sh/uv/) and traditional requirement files.
+
+Common setup and verification commands:
+
+```bash
+make setup      # create/sync the virtual environment
+make test       # run pytest through the Makefile
+make fmt        # black + ruff check --fix
+python -m pytest -q
+```
+
+If `make setup` fails on your platform, use the fallback described in [`INSTRUCTIONS.md`](../INSTRUCTIONS.md): create a Python 3.11+ virtual environment, install `requirements.txt`, then run pytest. The Makefile includes Windows/Unix path detection; if pytest cannot locate venv scripts, prefix commands with the venv `bin`/`Scripts` directory as documented in the instructions.
+
+Node is only used for repository hygiene scripts such as docs linting. The package manager is npm, with scripts defined in [`package.json`](../package.json):
+
+```bash
+npm run lint
+npm run format:check
+npm run test:ci
+npm run docs-lint
+```
+
+## Automation and helper scripts
+
+The repository aims to make video creation as repeatable as software delivery. Key helper workflows include:
+
+- `python src/scaffold_videos.py` – create dated `video_scripts/YYYYMMDD_slug` folders from `video_ids.txt`.
+- `python src/update_video_metadata.py` – refresh titles, publish dates, durations, thumbnails, descriptions, tags, and view counts via the YouTube Data API when `YOUTUBE_API_KEY` is available.
+- `python src/update_transcript_links.py` – sync `transcript_file` paths and optionally fetch missing captions when API access is configured.
+- `python src/collect_sources.py` – download reference files from configured source URL lists for citation/research workflows.
+- `python src/newsletter_builder.py` or `make newsletter` – assemble Markdown digests of recent videos.
+- `python src/fact_check_discussions.py` – export Futuroptimist GitHub Discussions fact-check threads to JSON.
+- `python src/repo_status.py` – update the parseable `README.md` Related Projects dashboard with check-status emoji, timestamps, and direct failed-run links.
+
+Run `make help` to see the current target list.
+
+## Script, metadata, subtitle, and asset workflow
+
+Video folders under `video_scripts/` use `metadata.json` plus Markdown script files to keep drafts structured and retrievable.
+
+- Scripts begin with a title heading, a YouTube ID blockquote, and a `## Script` section.
+- Spoken lines use `[NARRATOR]:`; b-roll and graphics cues use `[VISUAL]:` directly after the dialogue they support.
+- `metadata.json` files are validated against [`schemas/video_metadata.schema.json`](../schemas/video_metadata.schema.json).
+- Optional `assets.json` manifests are validated against [`schemas/assets_manifest.schema.json`](../schemas/assets_manifest.schema.json).
+- Optional `sources.txt` files list one URL per line for reference collection; downloaded materials are for citation/reference only.
+- Optional `footage.md` files track archive clips, new footage, CGI, and generative AI shots.
+
+Subtitle and transcript helpers:
+
+- `make subtitles` / `python src/fetch_subtitles.py` downloads captions into `subtitles/`.
+- `python src/srt_to_markdown.py` converts `.srt` captions into `[NARRATOR]` lines while stripping non-dialog cues and HTML noise.
+- `python src/generate_scripts_from_subtitles.py` converts resolved subtitle files into `script.md` drafts.
+- `python src/index_script_segments.py` exports narrator segments for retrieval.
+- `python src/index_script_embeddings.py` hashes narrator segments into deterministic local test vectors.
+
+Asset and render helpers:
+
+- `python src/index_local_media.py` builds `footage_index.json` for local media under ignored `footage/` directories.
+- `make index_assets` builds `assets_index.json` from per-video manifests.
+- `python src/generate_assets_manifest.py --slug SLUG --overwrite` scaffolds `assets.json` from footage directories.
+- `make convert_assets`, `make verify_assets`, and related conversion targets prepare footage for editing.
+- `python src/render_video.py --slug SLUG` or `make render VIDEO=SLUG` builds rough-cut videos under `dist/`.
+- `python src/create_otio_timeline.py --slug SLUG` emits portable OpenTimelineIO timelines for editing suites.
+
+Generated indexes, large media, render outputs, and downloaded per-video reference files should stay out of commits unless the repo explicitly tracks them.
+
+## YouTube Transcript MCP Service
+
+[`tools/youtube_mcp/`](../tools/youtube_mcp) packages a transcript fetcher that powers a CLI, FastAPI microservice, and MCP-compatible stdio tool. It normalizes captions for retrieval, stores cached payloads in SQLite, and preserves provenance with timestamped cite URLs.
+
+Entrypoints:
+
+```bash
+# HTTP service
+python -m tools.youtube_mcp --host 127.0.0.1 --port 8765
+
+# CLI transcript fetch
+python -m tools.youtube_mcp.cli transcript --url https://youtu.be/VIDEOID
+
+# MCP stdio server
+python tools/youtube_mcp/mcp_server.py
+```
+
+Example HTTP call:
+
+```bash
+curl "http://127.0.0.1:8765/transcript?url=https://youtu.be/VIDEOID"
+```
+
+Policy notes:
+
+- The service uses `youtube_transcript_api` and YouTube’s public oEmbed endpoint.
+- It rejects private or unlisted videos when those signals are available.
+- It does not scrape YouTube HTML or bypass authentication walls.
+
+Caching and errors:
+
+- Cache keys include video ID, language, and track type.
+- Cached transcript payloads default to a 14-day TTL.
+- Expired rows are purged automatically when accessed.
+- Error codes such as `InvalidArgument`, `VideoUnavailable`, `NoCaptionsAvailable`, `PolicyRejected`, `RateLimited`, and `NetworkError` map to consistent HTTP responses and MCP error payloads.
+
+## CI badges and workflows
+
+Repo-level health is tracked by GitHub Actions rather than displayed at the top of the profile README:
+
+[![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/futuroptimist/actions/workflows/01-lint-format.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/futuroptimist/actions/workflows/02-tests.yml)
+[![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://app.codecov.io/gh/futuroptimist/futuroptimist/branch/main)
+[![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
+
+Primary workflows:
+
+- `.github/workflows/01-lint-format.yml` – Python and JavaScript lint/format checks.
+- `.github/workflows/02-tests.yml` – pytest with coverage on push and pull requests targeting `main`.
+- `.github/workflows/03-docs.yml` – docs spellcheck and linkcheck.
+- `.github/workflows/update-repo-status.yml` – scheduled hourly Related Projects status refresh.
+- `.github/workflows/ci.yml` – focused YouTube MCP lint/test coverage for service-related paths.
+
+Before committing, format code, run focused tests, and scan staged changes for credential leaks with:
+
+```bash
+git diff --cached | ./scripts/scan-secrets.py
+```

--- a/llms.txt
+++ b/llms.txt
@@ -7,6 +7,7 @@ Every commit is public training data—write informative commit messages.
 ## Docs
 - [README](README.md)
 - [AGENTS guide](AGENTS.md)
+- [Repository guide](docs/repository-guide.md)
 - [INSTRUCTIONS](INSTRUCTIONS.md)
 - [RUNBOOK](RUNBOOK.md)
 - [Contributing guide](CONTRIBUTING.md)

--- a/scripts/precommit_heatmap.py
+++ b/scripts/precommit_heatmap.py
@@ -7,7 +7,6 @@ import runpy
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -7,6 +7,7 @@ assignments, GitHub tokens (``ghp_…`` or ``github_pat_…``), and Slack tokens
 (``xoxb-…``). The scan is intentionally lightweight and should be supplemented
 with dedicated tools for thorough auditing.
 """
+
 from __future__ import annotations
 
 import re

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Generate docs/prompt-docs-summary.md from prompt docs."""
+
 import argparse
 import pathlib
 import urllib.request

--- a/src/analytics_dashboard.py
+++ b/src/analytics_dashboard.py
@@ -16,7 +16,6 @@ from typing import Iterable
 
 import pandas as pd
 
-
 VIDEO_ROOT = pathlib.Path("video_scripts")
 ANALYTICS_FIELDS = [
     "views",

--- a/src/analytics_ingester.py
+++ b/src/analytics_ingester.py
@@ -11,7 +11,6 @@ import urllib.request
 from datetime import datetime, timezone
 from typing import Iterable
 
-
 DEFAULT_METRICS = (
     "views",
     "estimatedMinutesWatched",

--- a/src/annotate_publish.py
+++ b/src/annotate_publish.py
@@ -14,7 +14,6 @@ from datetime import datetime, timezone
 import pathlib
 from typing import Iterable
 
-
 VIDEO_ROOT = pathlib.Path("video_scripts")
 METADATA_NAME = "metadata.json"
 

--- a/src/convert_assets.py
+++ b/src/convert_assets.py
@@ -26,7 +26,6 @@ from dataclasses import dataclass
 from typing import Iterable
 import shutil
 
-
 # Image conversions (library-first)
 EXTENSION_RULES: dict[str, tuple[str, list[str]]] = {
     # Save camera-originated stills as high-quality JPEGs for NLE compatibility

--- a/src/create_otio_timeline.py
+++ b/src/create_otio_timeline.py
@@ -18,7 +18,6 @@ from typing import Iterable
 
 import opentimelineio as otio
 
-
 VIDEO_EXTENSIONS = {".mp4", ".mov", ".m4v"}
 DEFAULT_FRAME_RATE = 24.0
 DEFAULT_DURATION_SECONDS = 1.0

--- a/src/describe_images.py
+++ b/src/describe_images.py
@@ -17,7 +17,6 @@ from datetime import datetime, timezone
 
 from PIL import Image, ImageStat
 
-
 IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".heic", ".dng", ".webp"}
 
 

--- a/src/fact_check_discussions.py
+++ b/src/fact_check_discussions.py
@@ -11,7 +11,6 @@ import requests
 
 from . import github_auth
 
-
 API_URL = "https://api.github.com/repos/{repo}/discussions"
 DEFAULT_CATEGORY = "Fact Check"
 DEFAULT_OUTPUT = pathlib.Path("data/fact_check_discussions.json")

--- a/src/index_assets.py
+++ b/src/index_assets.py
@@ -18,7 +18,6 @@ from PIL import Image
 
 from jsonschema import Draft7Validator
 
-
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 

--- a/src/index_local_media.py
+++ b/src/index_local_media.py
@@ -12,7 +12,6 @@ import pathlib
 from collections.abc import Iterable
 from datetime import datetime, timezone
 
-
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
 

--- a/src/index_script_hooks.py
+++ b/src/index_script_hooks.py
@@ -15,7 +15,6 @@ import pathlib
 import re
 from typing import Iterable
 
-
 SCRIPT_NAME = "script.md"
 METADATA_NAME = "metadata.json"
 DEFAULT_OUTPUT = pathlib.Path("data/script_hooks.json")

--- a/src/rename_video_slug.py
+++ b/src/rename_video_slug.py
@@ -16,7 +16,6 @@ import pathlib
 import re
 from typing import Any
 
-
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -8,18 +8,29 @@ completed successfully, failed, or hasn't completed.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
-import logging
-from datetime import datetime, timezone
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Iterable
 
 import requests
 
 LOGGER = logging.getLogger(__name__)
 
+
+@dataclass(frozen=True)
+class RepoStatusReport:
+    """Rendered status plus optional direct links for failed checks."""
+
+    emoji: str
+    failure_links: tuple[str, ...] = field(default_factory=tuple)
+
+
 GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+))?")
+FAILURE_LINKS_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
@@ -57,13 +68,13 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
-def fetch_repo_status(
+def fetch_repo_status_report(
     repo: str,
     token: str | None = None,
     branch: str | None = None,
     attempts: int = 2,
-) -> str:
-    """Fetch the latest workflow run conclusion for ``repo`` and return an emoji.
+) -> RepoStatusReport:
+    """Fetch the latest workflow run conclusion and failure links for ``repo``.
 
     The GitHub API occasionally returns inconsistent data if a workflow is
     updating while we query it. To catch this non-determinism we fetch the
@@ -84,17 +95,15 @@ def fetch_repo_status(
             repo_data = repo_resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
             LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return status_to_emoji(None)
+            return RepoStatusReport(status_to_emoji(None))
         if not isinstance(repo_data, dict):
             LOGGER.warning(
                 "Unexpected repository payload for %s: %r", repo, type(repo_data)
             )
-            return status_to_emoji(None)
+            return RepoStatusReport(status_to_emoji(None))
         branch = repo_data.get("default_branch")
 
-    url = "https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed".format(
-        repo=repo
-    )
+    url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     if branch:
         url += f"&branch={branch}"
 
@@ -126,8 +135,21 @@ def fetch_repo_status(
                 return True
         return False
 
-    def _evaluate_runs(runs: Iterable[dict]) -> str:
-        """Return the overall conclusion for the most recent attempt of each workflow."""
+    def _failure_link(run: dict) -> str | None:
+        html_url = run.get("html_url")
+        if isinstance(html_url, str) and html_url:
+            return html_url
+        run_id = run.get("id")
+        if run_id is not None:
+            return f"https://github.com/{repo}/actions/runs/{run_id}"
+        for key in ("logs_url", "artifacts_url", "check_suite_url"):
+            url_value = run.get(key)
+            if isinstance(url_value, str) and url_value:
+                return url_value
+        return None
+
+    def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[str, ...]]:
+        """Return conclusion and failure links for each workflow latest attempt."""
 
         latest_runs: dict[tuple[object, object, object], dict] = {}
 
@@ -150,17 +172,24 @@ def fetch_repo_status(
             if current is None or _attempt_key(run) > _attempt_key(current):
                 latest_runs[key] = run
 
+        failed_links = tuple(
+            link
+            for run in latest_runs.values()
+            if _normalize_conclusion(run.get("conclusion")) in failures
+            for link in [_failure_link(run)]
+            if link
+        )
         conclusions = {
             _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
         }
         if any(c in failures for c in conclusions):
-            return "failure"
+            return "failure", failed_links
         if "success" in conclusions:
-            return "success"
+            return "success", ()
         # Default to failure so lack of CI coverage surfaces as ❌
-        return "failure"
+        return "failure", failed_links
 
-    def _fetch() -> str | None:
+    def _fetch() -> tuple[str | None, tuple[str, ...]]:
         try:
             commits_resp = requests.get(
                 f"https://api.github.com/repos/{repo}/commits?sha={branch}&per_page=20",
@@ -171,7 +200,7 @@ def fetch_repo_status(
             commits_data = commits_resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
             LOGGER.warning("Unable to fetch commits for %s@%s: %s", repo, branch, exc)
-            return None
+            return None, ()
         if not isinstance(commits_data, list):
             LOGGER.warning(
                 "Unexpected commits payload for %s@%s: %r",
@@ -179,7 +208,7 @@ def fetch_repo_status(
                 branch,
                 type(commits_data),
             )
-            return None
+            return None, ()
         commits = commits_data
 
         try:
@@ -190,7 +219,7 @@ def fetch_repo_status(
             LOGGER.warning(
                 "Unable to fetch workflow runs for %s@%s: %s", repo, branch, exc
             )
-            return None
+            return None, ()
         if not isinstance(runs_data, dict):
             LOGGER.warning(
                 "Unexpected workflow payload for %s@%s: %r",
@@ -198,7 +227,7 @@ def fetch_repo_status(
                 branch,
                 type(runs_data),
             )
-            return None
+            return None, ()
 
         runs = runs_data.get("workflow_runs", [])
         if not isinstance(runs, list):
@@ -208,7 +237,7 @@ def fetch_repo_status(
                 branch,
                 type(runs),
             )
-            return None
+            return None, ()
 
         runs_by_sha: dict[str, list[dict]] = {}
         for run in runs:
@@ -231,15 +260,40 @@ def fetch_repo_status(
                 return _evaluate_runs(commit_runs)
             if _should_skip_commit(commit):
                 continue
-            return None
-        return None
+            return None, ()
+        return None, ()
 
-    conclusions = [_fetch() for _ in range(attempts)]
+    reports = [_fetch() for _ in range(attempts)]
+    conclusions = [report[0] for report in reports]
     if len(set(conclusions)) > 1:
         raise RuntimeError(
             f"Non-deterministic workflow conclusion for {repo}: {conclusions}"
         )
-    return status_to_emoji(conclusions[0])
+    failure_links: list[str] = []
+    for _, links in reports:
+        for link in links:
+            if link not in failure_links:
+                failure_links.append(link)
+    return RepoStatusReport(status_to_emoji(conclusions[0]), tuple(failure_links))
+
+
+def fetch_repo_status(
+    repo: str,
+    token: str | None = None,
+    branch: str | None = None,
+    attempts: int = 2,
+) -> str:
+    """Fetch the latest workflow run conclusion for ``repo`` and return an emoji."""
+
+    return fetch_repo_status_report(repo, token, branch, attempts).emoji
+
+
+def _format_failure_links(links: tuple[str, ...]) -> str:
+    """Format direct failure URLs for README bullets."""
+
+    if not links:
+        return ""
+    return f" (failing runs: {', '.join(links)})"
 
 
 def update_readme(
@@ -247,35 +301,40 @@ def update_readme(
     token: str | None = None,
     now: datetime | None = None,
 ) -> None:
-    """Update README with status emojis and a timestamp."""
+    """Update README with status emojis, failure links, and a timestamp."""
     lines = readme_path.read_text(encoding="utf-8").splitlines()
     in_section = False
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
     timestamp = now.strftime("%Y-%m-%d %H:%M UTC")
-    for i, line in enumerate(lines):
+    ts_line = f"_Last updated: {timestamp}; checks hourly_"
+    output: list[str] = []
+    for line in lines:
         if line.strip() == "## Related Projects":
             in_section = True
-            ts_line = f"_Last updated: {timestamp}; checks hourly_"
-            if i + 1 < len(lines) and lines[i + 1].startswith("_Last updated:"):
-                lines[i + 1] = ts_line
-            else:
-                lines.insert(i + 1, ts_line)
+            output.append(line)
+            output.append(ts_line)
             continue
         if in_section and line.startswith("## "):
-            break
+            in_section = False
+        if in_section and line.startswith("_Last updated:"):
+            continue
         if in_section and line.startswith("- "):
             match = GITHUB_RE.search(line)
             if match:
                 repo = f"{match.group(1)}/{match.group(2)}"
                 branch = match.group(3)
-                emoji = fetch_repo_status(repo, token, branch)
-                # remove existing emoji
-                lines[i] = re.sub(r"^(-\s*)(?:[✅❌❓]\s*)*", r"\1", line)
+                report = fetch_repo_status_report(repo, token, branch)
+                # remove existing emoji and generated failure links
+                cleaned = re.sub(r"^(-\s*)(?:[✅❌❓]\s*)*", r"\1", line)
+                cleaned = FAILURE_LINKS_RE.sub("", cleaned)
                 # Ensure UTF-8 output; lines later written with utf-8 encoding
-                lines[i] = f"- {emoji} {lines[i][2:].lstrip()}"
+                link_suffix = _format_failure_links(report.failure_links)
+                line = f"- {report.emoji} {cleaned[2:].lstrip()}{link_suffix}"
+        output.append(line)
+
     # Ensure output file encoded as UTF-8 so emoji render correctly on Windows
-    readme_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    readme_path.write_text("\n".join(output) + "\n", encoding="utf-8")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -139,13 +139,13 @@ def fetch_repo_status_report(
         html_url = run.get("html_url")
         if isinstance(html_url, str) and html_url:
             return html_url
-        run_id = run.get("id")
-        if run_id is not None:
-            return f"https://github.com/{repo}/actions/runs/{run_id}"
         for key in ("logs_url", "artifacts_url", "check_suite_url"):
             url_value = run.get(key)
             if isinstance(url_value, str) and url_value:
                 return url_value
+        run_id = run.get("id")
+        if run_id is not None:
+            return f"https://github.com/{repo}/actions/runs/{run_id}"
         return None
 
     def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[str, ...]]:

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -34,6 +34,7 @@ FAILURE_LINKS_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
+FAILURE_LINK_FALLBACK_KEYS = ("logs_url", "artifacts_url", "check_suite_url")
 
 
 def status_to_emoji(conclusion: str | None) -> str:
@@ -139,7 +140,7 @@ def fetch_repo_status_report(
         html_url = run.get("html_url")
         if isinstance(html_url, str) and html_url:
             return html_url
-        for key in ("logs_url", "artifacts_url", "check_suite_url"):
+        for key in FAILURE_LINK_FALLBACK_KEYS:
             url_value = run.get(key)
             if isinstance(url_value, str) and url_value:
                 return url_value

--- a/src/report_funnel.py
+++ b/src/report_funnel.py
@@ -23,7 +23,6 @@ from datetime import datetime, timezone
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Iterable
 
-
 IMAGE_EXTS = {".png", ".jpg", ".jpeg"}
 VIDEO_EXTS = {".mp4"}
 AUDIO_EXTS = {".wav", ".mp3", ".aac", ".m4a", ".flac", ".ogg"}

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -5,7 +5,6 @@ import pathlib
 import re
 from typing import List, Tuple
 
-
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 

--- a/src/thumbnail_text_predictor.py
+++ b/src/thumbnail_text_predictor.py
@@ -23,7 +23,6 @@ from typing import Any, Dict, List
 
 from PIL import Image, ImageFilter, ImageStat
 
-
 ACTION_WORDS = {
     "build",
     "make",

--- a/src/upload_to_youtube.py
+++ b/src/upload_to_youtube.py
@@ -22,7 +22,6 @@ from googleapiclient.http import MediaFileUpload
 
 from src import prepare_youtube_upload
 
-
 SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -565,8 +565,22 @@ def test_update_readme_existing_timestamp(
     assert lines[4] == "- ✅ https://github.com/user/repo"
 
 
+@pytest.mark.parametrize(
+    ("fallback_key", "fallback_url"),
+    [
+        ("logs_url", "https://api.github.com/repos/user/repo/actions/runs/2/logs"),
+        (
+            "artifacts_url",
+            "https://api.github.com/repos/user/repo/actions/runs/2/artifacts",
+        ),
+        (
+            "check_suite_url",
+            "https://api.github.com/repos/user/repo/check-suites/2",
+        ),
+    ],
+)
 def test_fetch_repo_status_report_includes_failed_run_links(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, fallback_key: str, fallback_url: str
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         if url == "https://api.github.com/repos/user/repo":
@@ -601,7 +615,7 @@ def test_fetch_repo_status_report_includes_failed_run_links(
                         "conclusion": "cancelled",
                         "head_sha": "abc",
                         "id": 2,
-                        "logs_url": "https://api.github.com/repos/user/repo/actions/runs/2/logs",
+                        fallback_key: fallback_url,
                         "name": "lint",
                     },
                     {
@@ -627,7 +641,7 @@ def test_fetch_repo_status_report_includes_failed_run_links(
         "❌",
         (
             "https://github.com/user/repo/actions/runs/1",
-            "https://api.github.com/repos/user/repo/actions/runs/2/logs",
+            fallback_url,
             "https://github.com/user/repo/actions/runs/4",
         ),
     )

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -601,7 +601,14 @@ def test_fetch_repo_status_report_includes_failed_run_links(
                         "conclusion": "cancelled",
                         "head_sha": "abc",
                         "id": 2,
+                        "logs_url": "https://api.github.com/repos/user/repo/actions/runs/2/logs",
                         "name": "lint",
+                    },
+                    {
+                        "conclusion": "timed_out",
+                        "head_sha": "abc",
+                        "id": 4,
+                        "name": "ci",
                     },
                     {
                         "conclusion": "success",
@@ -620,7 +627,8 @@ def test_fetch_repo_status_report_includes_failed_run_links(
         "❌",
         (
             "https://github.com/user/repo/actions/runs/1",
-            "https://github.com/user/repo/actions/runs/2",
+            "https://api.github.com/repos/user/repo/actions/runs/2/logs",
+            "https://github.com/user/repo/actions/runs/4",
         ),
     )
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -479,7 +479,13 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         calls.append((repo, branch))
         return {"user/repo": "✅", "other/repo": "❌"}[repo]
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_report",
+        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
+            fake_status(repo, token, branch)
+        ),
+    )
     from datetime import datetime
 
     now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
@@ -502,7 +508,13 @@ def test_update_readme_uses_current_time(
     ) -> str:
         return "✅"
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_report",
+        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
+            fake_status(repo, token, branch)
+        ),
+    )
 
     from datetime import datetime, timezone
 
@@ -535,7 +547,13 @@ def test_update_readme_existing_timestamp(
     ) -> str:
         return "✅"
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_report",
+        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
+            fake_status(repo, token, branch)
+        ),
+    )
 
     from datetime import datetime
 
@@ -545,3 +563,103 @@ def test_update_readme_existing_timestamp(
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
     assert lines[4] == "- ✅ https://github.com/user/repo"
+
+
+def test_fetch_repo_status_report_includes_failed_run_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add failing tests",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "failure",
+                        "head_sha": "abc",
+                        "html_url": "https://github.com/user/repo/actions/runs/1",
+                        "name": "tests",
+                    },
+                    {
+                        "conclusion": "cancelled",
+                        "head_sha": "abc",
+                        "id": 2,
+                        "name": "lint",
+                    },
+                    {
+                        "conclusion": "success",
+                        "head_sha": "abc",
+                        "html_url": "https://github.com/user/repo/actions/runs/3",
+                        "name": "build",
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    report = repo_status.fetch_repo_status_report("user/repo")
+
+    assert report == repo_status.RepoStatusReport(
+        "❌",
+        (
+            "https://github.com/user/repo/actions/runs/1",
+            "https://github.com/user/repo/actions/runs/2",
+        ),
+    )
+
+
+def test_update_readme_includes_failure_links_and_removes_duplicates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    content = (
+        "## Related Projects\n"
+        "_Last updated: 1999-01-01 00:00 UTC; checks hourly_\n"
+        "_Last updated: 1998-01-01 00:00 UTC; checks hourly_\n"
+        "- ✅ https://github.com/user/repo (failing runs: https://old.example/run)\n"
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(content)
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_report",
+        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
+            "❌",
+            (
+                "https://github.com/user/repo/actions/runs/1",
+                "https://github.com/user/repo/actions/runs/2",
+            ),
+        ),
+    )
+    from datetime import datetime
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+
+    lines = readme.read_text().splitlines()
+    assert lines == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        (
+            "- ❌ https://github.com/user/repo (failing runs: "
+            "https://github.com/user/repo/actions/runs/1, "
+            "https://github.com/user/repo/actions/runs/2)"
+        ),
+    ]

--- a/tools/youtube_mcp/cache.py
+++ b/tools/youtube_mcp/cache.py
@@ -26,16 +26,14 @@ class TranscriptCache:
 
     def _initialise(self) -> None:
         with self._conn:
-            self._conn.execute(
-                """
+            self._conn.execute("""
                 CREATE TABLE IF NOT EXISTS cache_entries (
                     cache_key TEXT PRIMARY KEY,
                     value TEXT NOT NULL,
                     expires_at REAL NOT NULL,
                     schema_version INTEGER NOT NULL
                 )
-                """
-            )
+                """)
 
     def close(self) -> None:
         with self._lock:


### PR DESCRIPTION
### Motivation
- Keep the root `README.md` profile-first while moving repository-internal setup, automation, scripts, metadata, subtitles, and YouTube MCP details into a dedicated doc so the profile stays compact and machine-parseable. 
- Preserve the `## Related Projects` bullet shape (lines starting with `- ` and GitHub URLs) so `src/repo_status.py` can continue to update statuses. 
- Make failing project statuses more actionable by including direct links to failing workflow runs or fallback assets in the Related Projects list.

### Description
- Rewrote `README.md` as a profile-oriented page with one clear link to the new repository internals doc (`docs/repository-guide.md`) and a polished `Related Projects` legend while preserving parseable `- ` bullets. 
- Added `docs/repository-guide.md` containing the repo map, setup & package notes, helper workflows, script/metadata/subtitle/asset guidance, CI badges, and the YouTube Transcript MCP service details. 
- Updated `docs/README.md`, `AGENTS.md`, and `llms.txt` to reference `docs/repository-guide.md` so docs and AI guidance stay consistent. 
- Refactored `src/repo_status.py` to introduce `RepoStatusReport` (dataclass) and a new `fetch_repo_status_report()` that returns an emoji plus a tuple of failure links; preserved `fetch_repo_status()` to keep the emoji-only API for callers. 
- Enhanced `update_readme()` to insert a single `_Last updated: ...; checks hourly_` line, strip duplicate timestamps, and append comma-separated `(failing runs: <url>, ...)` suffixes on failing bullets; kept output UTF-8. 
- Extended `tests/test_repo_status.py` to mock and assert returned failure links and to verify duplicate timestamp cleanup and README formatting.

### Testing
- Installed dev extras with `python -m pip install -e '.[dev]'` which completed successfully and provided `pydantic`, `fastapi`, and other service deps. (passed)
- Ran focused repo-status tests with `python -m pytest tests/test_repo_status.py -q` which returned `20 passed`. (passed)
- Ran the full test suite with `python -m pytest -q` which returned `289 passed, 2 warnings`. (passed; warnings reported by FastAPI/TestClient and a runtime import warning). 
- Ran docs checks with `npm run docs-lint` which completed (no blocking errors). (ran)
- Ran linters/formatters: `ruff check src/repo_status.py tests/test_repo_status.py` and `black src/repo_status.py tests/test_repo_status.py` were executed and issues were fixed; note Black emitted a Python version safety warning about formatting targeting a newer Python. (fixed; warning recorded)
- Scanned staged diffs for secrets via `git diff --cached | ./scripts/scan-secrets.py` and adjusted wording where the scan flagged a doc phrase, then re-ran the scan; no secrets remained in staged changes. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27014611bc832fb457f06be4adb1bd)