### PR TITLE
Split profile README into repository guide; surface failing-run links in repo status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,8 +129,9 @@ YouTube Data API for upload.
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in INSTRUCTIONS or RUNBOOK.
-- Avoid detailed how-tos like subtitle downloading; store them in other docs.
+- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in INSTRUCTIONS, RUNBOOK, or the repository guide.
+- [Repository guide](docs/repository-guide.md): repo-specific map, setup pointers, automation/script/metadata/subtitle summary, and YouTube Transcript MCP service details.
+- Avoid detailed how-tos like subtitle downloading in the profile README; store them in other docs.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
 - [RUNBOOK](RUNBOOK.md): production checklist.
 - [Video Editing Playbook](docs/video-editing-playbook.md): concise guide to structure, pacing, and post steps.

--- a/README.md
+++ b/README.md
@@ -1,130 +1,55 @@
 # Futuroptimist 👋
 
-*Building open-source tools so anyone can invent, automate & explore.*
+Hi, I'm Daniel — Futuroptimist on GitHub and YouTube. I build open-source tools
+and creative infrastructure for maker projects, AI-adjacent workflows, and
+repeatable video production pipelines.
 
-[![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/futuroptimist/actions/workflows/01-lint-format.yml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/futuroptimist/actions/workflows/02-tests.yml)
-[![Coverage](https://codecov.io/gh/futuroptimist/futuroptimist/branch/main/graph/badge.svg)](https://app.codecov.io/gh/futuroptimist/futuroptimist/branch/main)
-[![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/futuroptimist/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/futuroptimist/actions/workflows/03-docs.yml)
-[![License](https://img.shields.io/github/license/futuroptimist/futuroptimist)](LICENSE)
+I like small systems that make ambitious ideas easier to finish: scripts that
+turn raw captions into structured episodes, automation that keeps repos healthy,
+and playful hardware/software projects around 3D printing, space, sustainability,
+and local-first tools.
 
-Hi, I'm Futuroptimist. This repository hosts scripts and metadata for my
-[YouTube channel](https://www.youtube.com/@futuroptimist).
-If you're looking for the full project details, see
-[INSTRUCTIONS.md](INSTRUCTIONS.md). We manage Python dependencies with
-[uv](https://docs.astral.sh/uv/); check the instructions for setup steps.
-Guidelines for AI tools live in [AGENTS.md](AGENTS.md).
-The canonical Codex prompt for automated contributions is in
-[docs/prompts/codex/automation.md](docs/prompts/codex/automation.md).
-The automated tests run via GitHub Actions on each push and pull request and currently
-reach **100%** coverage.
+[YouTube channel](https://www.youtube.com/@futuroptimist) · Repo internals:
+automation, scripts, metadata, subtitles, and MCP service details live in
+[repository guide](docs/repository-guide.md).
 
-## Map of the repo
+## What I build
 
-**Navigate in three hops:**
-
-1. **Setup** – Follow [INSTRUCTIONS.md](INSTRUCTIONS.md) for `uv` environment steps and
-   contributor onboarding.
-2. **Run** – Explore the [Makefile](Makefile) targets for day-to-day automation; CLI helpers
-   live in [`src/`](src).
-3. **Test** – Execute `make test` (documented in `INSTRUCTIONS.md`) to run the full pytest
-   suite with coverage.
-
-| Category | Path / resource | Notes |
-|----------|----------------|-------|
-| Apps | _n/a_ | Entry points live in `src/`; no standalone services yet. |
-| Packages | [`src/`](src) | Shared Python modules and CLI entry points. |
-| Scripts | [`scripts/`](scripts) | Operational helpers (e.g., prompt migrations, scans). |
-| Data | [`data/prompt-docs/`](data/prompt-docs) | Lightweight reference lists synced with docs. |
-| Docs | [`docs/`](docs) | Prompts, playbooks, and supporting guides. |
-| Tests | [`tests/`](tests) | Pytest suite mirroring production helpers. |
-| Pipelines | [`outages/`](outages) | Incident logs and schema describing stability. |
-| Infra | [`.github/workflows/`](.github/workflows) | CI for lint, tests, docs, status updates. |
-
-Prompt templates stay grouped under
-[`docs/prompts/codex/`](docs/prompts/codex) with an index in
-[`docs/README.md`](docs/README.md). Video narration lives in [`video_scripts/`](video_scripts),
-and multimedia assets are catalogued via the Makefile targets above.
-
-> **uv cheat sheet**: `uv sync` installs dependencies from `requirements.txt`,
-> `uv run pytest` mirrors `make test`, and `uvx <tool>` launches one-off binaries without
-> polluting the virtual environment.
-
-## YouTube Transcript MCP Service
-
-`tools/youtube_mcp/` packages a transcript fetcher that powers a CLI, FastAPI microservice, and
-MCP-compatible stdio tool. It normalises captions for retrieval, stores 14-day cached payloads in
-SQLite, and preserves provenance via timestamped cite URLs.
-
-- **HTTP**: `python -m tools.youtube_mcp --host 127.0.0.1 --port 8765`
-- **CLI**: `python -m tools.youtube_mcp.cli transcript --url https://youtu.be/VIDEOID`
-- **MCP**: `python tools/youtube_mcp/mcp_server.py`
-
-Example HTTP call:
-
-```bash
-curl "http://127.0.0.1:8765/transcript?url=https://youtu.be/VIDEOID"
-```
-
-**Policy notes**: the service only uses `youtube_transcript_api` and the public oEmbed endpoint,
-rejecting private/unlisted videos when signals are available. It never scrapes HTML or bypasses
-authentication walls.
-
-**Caching**: responses are keyed by video ID, language, and track type with a default 14-day TTL;
-expired rows are purged automatically when accessed.
-
-**Error codes**: `InvalidArgument`, `VideoUnavailable`, `NoCaptionsAvailable`, `PolicyRejected`,
-`RateLimited`, and `NetworkError` map to consistent HTTP responses and MCP error payloads.
+- **Creative automation** for turning research, transcripts, footage notes, and
+  metadata into repeatable publishing workflows.
+- **Maker-friendly tools** that bridge code, physical builds, 3D printing,
+  education, and sustainable infrastructure.
+- **AI-adjacent experiments** that keep provenance, privacy, and local control in
+  view instead of treating automation as magic.
+- **Open-source scaffolding** for side projects: tests, docs, CI, prompts, and
+  small utilities that help future contributors understand the why.
 
 ## Related Projects
-_Last updated: 2026-06-08 17:03 UTC; checks hourly_
+_Last updated: 2026-06-08 17:57 UTC; checks hourly_
 
-_Last updated: 2025-11-06 08:02 UTC; checks hourly_
-Status icons: ✅ latest run succeeded, ❌ failed or cancelled, ❓ no completed runs.
-The unknown state is enforced by
-`tests/test_repo_status.py::test_fetch_repo_status_no_runs_returns_unknown`, ensuring repositories
-without completed workflows render `❓` instead of failing the dashboard.
+Status legend: ✅ latest relevant workflow succeeded, ❌ one or more relevant workflows failed or were cancelled, ❓ no completed run was available yet. Failed entries may include direct links to the failing workflow runs or fallback failure assets.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – central hub for
-  reproducible scripts, data pipelines, and tests that turn maker experiments into
-  polished YouTube episodes
-- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network that
-  lets volunteers share idle compute through ephemeral, encrypted tokens—no sign-ups
-  required ([repo](https://github.com/futuroptimist/token.place))
-- ✅ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach
-  real-world hobbies with NPC guides; offline-first so your space-base thrives without a
-  signal ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles
-  lint, tests, docs, and release automation with LLM agents so solo builders ship like a
-  team
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first "guardian angel"
-  LLM that learns your environment and delivers local, actionable security coaching
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex
-  task pages, grabs failing GitHub logs, and pipes concise reports straight to your
-  clipboard to speed debugging
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that
-  analyzes your repos and curates next steps to keep side projects moving
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with
-  push-to-talk voice control, running speech-to-text, LLM, and TTS in a 3D-printed case so
-  commands stay local
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns your GitHub
-  contributions into stackable 3D-printable blocks that fit 42 mm Gridfinity baseplates,
-  turning commit history into shelf art
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning to knit and
-  crochet while evolving toward robotic looms, bridging CAD workflows with textiles
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform
-  and cube art installation for Raspberry Pi clusters, making off-grid edge Kubernetes
-  plug-and-play
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that closes
-  your own stale pull requests in bulk with a safe dry-run
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js
-  playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job search copilot
-  sharing the same automation scaffold as this repo
+- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production pipeline for turning maker experiments, captions, metadata, and scripts into polished Futuroptimist episodes
+- ❌ **[token.place](https://token.place)** – secure peer-to-peer generative AI network that lets volunteers share idle compute through ephemeral, encrypted tokens—no sign-ups required ([repo](https://github.com/futuroptimist/token.place)) — failing checks: [failure 1](https://github.com/futuroptimist/token.place/actions/runs/27156720917)
+- ❓ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides, built offline-first so a space-base can keep thriving without a signal ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template bundling lint, tests, docs, release automation, and LLM-agent handoffs so solo builders can ship with team-grade guardrails — failing checks: [failure 1](https://github.com/futuroptimist/flywheel/actions/runs/27123196602)
+- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for learning your environment and delivering local, actionable security coaching — failing checks: [failure 1](https://github.com/futuroptimist/gabriel/actions/runs/21579647496), [failure 2](https://github.com/futuroptimist/gabriel/actions/runs/21348015488), [failure 3](https://github.com/futuroptimist/gabriel/actions/runs/21127165452), [failure 4](https://github.com/futuroptimist/gabriel/actions/runs/20909714496), [failure 5](https://github.com/futuroptimist/gabriel/actions/runs/20706713112), [failure 6](https://github.com/futuroptimist/gabriel/actions/runs/20566165837), [failure 7](https://github.com/futuroptimist/gabriel/actions/runs/20423408130), [failure 8](https://github.com/futuroptimist/gabriel/actions/runs/20222249132), [failure 9](https://github.com/futuroptimist/gabriel/actions/runs/20018430344), [failure 10](https://github.com/futuroptimist/gabriel/actions/runs/19421904742)
+- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex task pages, grabs failing GitHub logs, and pipes concise reports straight to your clipboard for faster debugging
+- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repos and curates next steps to keep side projects moving
+- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control in a 3D-printed case, aimed at keeping speech-to-text, LLM, and TTS workflows local
+- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns GitHub contributions into stackable 3D-printable blocks that fit 42 mm Gridfinity baseplates, making commit history tangible
+- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning knitting and crochet while exploring robotic looms, textile CAD, and craft-friendly automation
+- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for Raspberry Pi clusters, making off-grid edge Kubernetes more approachable — failing checks: [failure 1](https://github.com/futuroptimist/sugarkube/actions/runs/27055466699)
+- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that closes your own stale pull requests in bulk with a safe dry-run
+- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job search copilot sharing the same automation scaffold as this repo
 
 ## Values
 
-We aim for a positive-sum, empathetic community that shares knowledge openly.
+- Make useful things easier to inspect, remix, and repair.
+- Keep automation understandable enough that humans can safely steer it.
+- Treat creative infrastructure as part of the project, not an afterthought.
+- Aim for hopeful, practical, positive-sum technology.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Futuroptimist Documentation Index
 
+## Repository guide
+
+- [repository-guide.md](repository-guide.md) — Repo-specific map, setup pointers, automation notes, script/metadata/subtitle flow, and YouTube Transcript MCP service details.
+
 ## Prompt docs (Codex)
 
 All Codex-ready prompts live under `docs/prompts/codex/`, and filenames already omit the

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -1,0 +1,148 @@
+# Futuroptimist Repository Guide
+
+This repository is the working hub behind the Futuroptimist YouTube/GitHub
+project. The profile README stays intentionally lightweight; this guide collects
+the repo-specific map, setup pointers, automation notes, and local service
+details for contributors and AI tools.
+
+## What lives here
+
+The repo hosts scripts, metadata, captions, references, and helper automation for
+turning maker experiments and forward-looking tech essays into repeatable video
+production workflows. The long-form workflow and roadmap remain in
+[`INSTRUCTIONS.md`](../INSTRUCTIONS.md), while day-to-day commands are exposed
+through the [`Makefile`](../Makefile).
+
+## Map of the repo
+
+**Navigate in three hops:**
+
+1. **Setup** – Follow [`INSTRUCTIONS.md`](../INSTRUCTIONS.md) for `uv`
+   environment steps and contributor onboarding.
+2. **Run** – Explore the [`Makefile`](../Makefile) targets for day-to-day
+   automation; CLI helpers live in [`src/`](../src).
+3. **Test** – Execute `make test` (documented in `INSTRUCTIONS.md`) to run the
+   full pytest suite with coverage.
+
+| Category | Path / resource | Notes |
+|----------|----------------|-------|
+| Apps | _n/a_ | Entry points live in `src/`; no standalone app ships from this repo. |
+| Packages | [`src/`](../src) | Shared Python modules and CLI entry points. |
+| Scripts | [`scripts/`](../scripts) | Operational helpers such as prompt migrations and safety checks. |
+| Data | [`data/prompt-docs/`](../data/prompt-docs) | Lightweight reference lists synced with docs. |
+| Docs | [`docs/`](.) | Prompts, playbooks, and supporting guides. |
+| Tests | [`tests/`](../tests) | Pytest suite mirroring production helpers. |
+| Pipelines | [`outages/`](../outages) | Incident logs and schema describing stability. |
+| Infra | [`.github/workflows/`](../.github/workflows) | CI for lint, tests, docs, and status updates. |
+
+Prompt templates stay grouped under
+[`docs/prompts/codex/`](prompts/codex/) with an index in
+[`docs/README.md`](README.md). Video narration lives in
+[`video_scripts/`](../video_scripts), and multimedia assets are catalogued with
+local indexers rather than committed media files.
+
+## Setup and automation pointers
+
+This repo manages Python dependencies with
+[`uv`](https://docs.astral.sh/uv/). Use the detailed setup flow in
+[`INSTRUCTIONS.md`](../INSTRUCTIONS.md); the short version is:
+
+```bash
+make setup   # venv + deps (or ./setup.ps1 on Windows)
+make test    # runs pytest -q
+make fmt     # black + ruff check --fix
+```
+
+The Makefile auto-detects Windows vs. Unix virtualenv paths. If `make setup`
+fails on your platform, run `python3 -m venv .venv && uv pip install -r
+requirements.txt`, then `pytest -q`. If tests cannot locate `yt-dlp`, prefix the
+command with `PATH=.venv/bin:$PATH` so venv executables are visible.
+
+Useful automation families include:
+
+- `make subtitles` to populate downloaded `.srt` captions when needed.
+- `python src/collect_sources.py` to fetch reference URLs into `sources/`.
+- `make index_footage` to rebuild the gitignored `footage_index.json` from local
+  media under `footage/`.
+- `make index_assets` to rebuild the gitignored `assets_index.json` from
+  per-video manifests.
+- `make render VIDEO=YYYYMMDD_slug` to concatenate converted clips and optional
+  captions into `dist/<slug>.mp4`.
+
+## Scripts, metadata, subtitles, and assets
+
+Video scripts live under `video_scripts/YYYYMMDD_slug/`. Each folder should
+include a `metadata.json` file that conforms to
+[`schemas/video_metadata.schema.json`](../schemas/video_metadata.schema.json).
+Optional files such as `sources.txt`, `footage.md`, and `assets.json` enrich the
+production pipeline without forcing large media into git.
+
+Important helpers include:
+
+- [`src/srt_to_markdown.py`](../src/srt_to_markdown.py) converts `.srt` captions
+  into the Futuroptimist script format, using `[NARRATOR]:` for spoken lines and
+  `[VISUAL]:` for supporting b-roll or graphics cues.
+- [`src/generate_scripts_from_subtitles.py`](../src/generate_scripts_from_subtitles.py)
+  resolves subtitle files from video metadata and produces `script.md` files.
+- [`src/update_transcript_links.py`](../src/update_transcript_links.py) syncs
+  `transcript_file` paths and can fetch missing captions when `YOUTUBE_API_KEY`
+  is set.
+- [`src/update_video_metadata.py`](../src/update_video_metadata.py) refreshes
+  title, date, duration, tags, descriptions, thumbnails, and view counts via the
+  YouTube Data API.
+- [`src/index_script_segments.py`](../src/index_script_segments.py) exports
+  `[NARRATOR]` segments for retrieval workflows.
+- [`src/index_script_embeddings.py`](../src/index_script_embeddings.py) hashes
+  script segments into deterministic local vectors for RAG tests.
+- [`src/index_local_media.py`](../src/index_local_media.py) and
+  [`src/index_assets.py`](../src/index_assets.py) build local media indexes from
+  `footage/` and per-video manifests.
+
+Large photos and videos belong in a local `footage/` directory, which is ignored
+by git. Reference files downloaded by `collect_sources.py` are for citation and
+review only; check rights before reuse and cite sources in APA style rather than
+redistributing third-party material.
+
+## YouTube Transcript MCP Service
+
+`tools/youtube_mcp/` packages a transcript fetcher that powers a CLI, FastAPI
+microservice, and MCP-compatible stdio tool. It normalizes captions for
+retrieval, stores 14-day cached payloads in SQLite, and preserves provenance via
+timestamped cite URLs.
+
+- **HTTP**: `python -m tools.youtube_mcp --host 127.0.0.1 --port 8765`
+- **CLI**: `python -m tools.youtube_mcp.cli transcript --url https://youtu.be/VIDEOID`
+- **MCP**: `python tools/youtube_mcp/mcp_server.py`
+
+Example HTTP call:
+
+```bash
+curl "http://127.0.0.1:8765/transcript?url=https://youtu.be/VIDEOID"
+```
+
+**Policy notes**: the service only uses `youtube_transcript_api` and the public
+oEmbed endpoint, rejecting private or unlisted videos when signals are available.
+It never scrapes HTML or bypasses authentication walls.
+
+**Caching**: responses are keyed by video ID, language, and track type with a
+default 14-day TTL; expired rows are purged automatically when accessed.
+
+**Error codes**: `InvalidArgument`, `VideoUnavailable`, `NoCaptionsAvailable`,
+`PolicyRejected`, `RateLimited`, and `NetworkError` map to consistent HTTP
+responses and MCP error payloads.
+
+## Testing and CI
+
+GitHub Actions installs dependencies and runs lint, tests, docs checks, and
+status updates. Locally, prefer focused checks first and then the repo-standard
+suite:
+
+```bash
+python -m pytest tests/test_repo_status.py -q
+python -m pytest -q
+npm run docs-lint
+```
+
+If `npm run docs-lint` is unavailable because Node dependencies are not
+installed, report that environment limit rather than treating the check as
+passed.

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,8 @@
 Every commit is public training data—write informative commit messages.
 
 ## Docs
-- [README](README.md)
+- [README](README.md) — profile-first GitHub account README
+- [Repository guide](docs/repository-guide.md) — repo map, setup, automation, metadata, subtitles, and MCP details
 - [AGENTS guide](AGENTS.md)
 - [INSTRUCTIONS](INSTRUCTIONS.md)
 - [RUNBOOK](RUNBOOK.md)

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -8,12 +8,13 @@ completed successfully, failed, or hasn't completed.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
-import logging
-from datetime import datetime, timezone
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Iterable
 
 import requests
 
@@ -23,6 +24,38 @@ GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
+
+
+@dataclass(frozen=True)
+class RepoStatusDetails:
+    """Resolved status plus direct links to failing workflow evidence."""
+
+    emoji: str
+    failure_links: tuple[str, ...] = ()
+
+
+def _failure_link_for_run(run: dict) -> str | None:
+    """Return the best direct URL for a failed run or its fallback assets."""
+
+    for key in ("html_url", "artifacts_url", "url"):
+        value = run.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def format_failure_links(links: Iterable[str]) -> str:
+    """Format failure evidence URLs as a comma-separated Markdown link list."""
+
+    return ", ".join(
+        f"[failure {index}]({link})" for index, link in enumerate(links, 1)
+    )
+
+
+def _strip_failure_details(line: str) -> str:
+    """Remove stale failure evidence appended by this updater."""
+
+    return re.sub(r"\s+— failing checks: .*$", "", line)
 
 
 def status_to_emoji(conclusion: str | None) -> str:
@@ -57,13 +90,13 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
-def fetch_repo_status(
+def fetch_repo_status_details(
     repo: str,
     token: str | None = None,
     branch: str | None = None,
     attempts: int = 2,
-) -> str:
-    """Fetch the latest workflow run conclusion for ``repo`` and return an emoji.
+) -> RepoStatusDetails:
+    """Fetch latest workflow status and failure evidence links for ``repo``.
 
     The GitHub API occasionally returns inconsistent data if a workflow is
     updating while we query it. To catch this non-determinism we fetch the
@@ -84,17 +117,15 @@ def fetch_repo_status(
             repo_data = repo_resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
             LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return status_to_emoji(None)
+            return RepoStatusDetails(status_to_emoji(None))
         if not isinstance(repo_data, dict):
             LOGGER.warning(
                 "Unexpected repository payload for %s: %r", repo, type(repo_data)
             )
-            return status_to_emoji(None)
+            return RepoStatusDetails(status_to_emoji(None))
         branch = repo_data.get("default_branch")
 
-    url = "https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed".format(
-        repo=repo
-    )
+    url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     if branch:
         url += f"&branch={branch}"
 
@@ -126,7 +157,7 @@ def fetch_repo_status(
                 return True
         return False
 
-    def _evaluate_runs(runs: Iterable[dict]) -> str:
+    def _evaluate_runs(runs: Iterable[dict]) -> RepoStatusDetails:
         """Return the overall conclusion for the most recent attempt of each workflow."""
 
         latest_runs: dict[tuple[object, object, object], dict] = {}
@@ -153,14 +184,21 @@ def fetch_repo_status(
         conclusions = {
             _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
         }
+        failing_links = tuple(
+            link
+            for run in latest_runs.values()
+            if _normalize_conclusion(run.get("conclusion")) in failures
+            for link in [_failure_link_for_run(run)]
+            if link is not None
+        )
         if any(c in failures for c in conclusions):
-            return "failure"
+            return RepoStatusDetails("❌", failing_links)
         if "success" in conclusions:
-            return "success"
+            return RepoStatusDetails("✅")
         # Default to failure so lack of CI coverage surfaces as ❌
-        return "failure"
+        return RepoStatusDetails("❌", failing_links)
 
-    def _fetch() -> str | None:
+    def _fetch() -> RepoStatusDetails:
         try:
             commits_resp = requests.get(
                 f"https://api.github.com/repos/{repo}/commits?sha={branch}&per_page=20",
@@ -171,7 +209,7 @@ def fetch_repo_status(
             commits_data = commits_resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
             LOGGER.warning("Unable to fetch commits for %s@%s: %s", repo, branch, exc)
-            return None
+            return RepoStatusDetails(status_to_emoji(None))
         if not isinstance(commits_data, list):
             LOGGER.warning(
                 "Unexpected commits payload for %s@%s: %r",
@@ -179,7 +217,7 @@ def fetch_repo_status(
                 branch,
                 type(commits_data),
             )
-            return None
+            return RepoStatusDetails(status_to_emoji(None))
         commits = commits_data
 
         try:
@@ -190,7 +228,7 @@ def fetch_repo_status(
             LOGGER.warning(
                 "Unable to fetch workflow runs for %s@%s: %s", repo, branch, exc
             )
-            return None
+            return RepoStatusDetails(status_to_emoji(None))
         if not isinstance(runs_data, dict):
             LOGGER.warning(
                 "Unexpected workflow payload for %s@%s: %r",
@@ -198,7 +236,7 @@ def fetch_repo_status(
                 branch,
                 type(runs_data),
             )
-            return None
+            return RepoStatusDetails(status_to_emoji(None))
 
         runs = runs_data.get("workflow_runs", [])
         if not isinstance(runs, list):
@@ -208,7 +246,7 @@ def fetch_repo_status(
                 branch,
                 type(runs),
             )
-            return None
+            return RepoStatusDetails(status_to_emoji(None))
 
         runs_by_sha: dict[str, list[dict]] = {}
         for run in runs:
@@ -231,15 +269,26 @@ def fetch_repo_status(
                 return _evaluate_runs(commit_runs)
             if _should_skip_commit(commit):
                 continue
-            return None
-        return None
+            return RepoStatusDetails(status_to_emoji(None))
+        return RepoStatusDetails(status_to_emoji(None))
 
-    conclusions = [_fetch() for _ in range(attempts)]
-    if len(set(conclusions)) > 1:
+    results = [_fetch() for _ in range(attempts)]
+    if len(set(results)) > 1:
         raise RuntimeError(
-            f"Non-deterministic workflow conclusion for {repo}: {conclusions}"
+            f"Non-deterministic workflow conclusion for {repo}: {results}"
         )
-    return status_to_emoji(conclusions[0])
+    return results[0]
+
+
+def fetch_repo_status(
+    repo: str,
+    token: str | None = None,
+    branch: str | None = None,
+    attempts: int = 2,
+) -> str:
+    """Fetch the latest workflow run conclusion for ``repo`` and return an emoji."""
+
+    return fetch_repo_status_details(repo, token, branch, attempts).emoji
 
 
 def update_readme(
@@ -251,7 +300,7 @@ def update_readme(
     lines = readme_path.read_text(encoding="utf-8").splitlines()
     in_section = False
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
     timestamp = now.strftime("%Y-%m-%d %H:%M UTC")
     for i, line in enumerate(lines):
         if line.strip() == "## Related Projects":
@@ -269,11 +318,16 @@ def update_readme(
             if match:
                 repo = f"{match.group(1)}/{match.group(2)}"
                 branch = match.group(3)
-                emoji = fetch_repo_status(repo, token, branch)
-                # remove existing emoji
+                status = fetch_repo_status_details(repo, token, branch)
+                # remove existing emoji and stale failure links
                 lines[i] = re.sub(r"^(-\s*)(?:[✅❌❓]\s*)*", r"\1", line)
+                lines[i] = _strip_failure_details(lines[i])
                 # Ensure UTF-8 output; lines later written with utf-8 encoding
-                lines[i] = f"- {emoji} {lines[i][2:].lstrip()}"
+                lines[i] = f"- {status.emoji} {lines[i][2:].lstrip()}"
+                if status.emoji == "❌" and status.failure_links:
+                    lines[
+                        i
+                    ] += f" — failing checks: {format_failure_links(status.failure_links)}"
     # Ensure output file encoded as UTF-8 so emoji render correctly on Windows
     readme_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -475,11 +475,13 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
+    ) -> repo_status.RepoStatusDetails:
         calls.append((repo, branch))
-        return {"user/repo": "✅", "other/repo": "❌"}[repo]
+        return repo_status.RepoStatusDetails(
+            {"user/repo": "✅", "other/repo": "❌"}[repo]
+        )
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
     from datetime import datetime
 
     now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
@@ -499,10 +501,10 @@ def test_update_readme_uses_current_time(
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
-        return "✅"
+    ) -> repo_status.RepoStatusDetails:
+        return repo_status.RepoStatusDetails("✅")
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
 
     from datetime import datetime, timezone
 
@@ -532,10 +534,10 @@ def test_update_readme_existing_timestamp(
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
-        return "✅"
+    ) -> repo_status.RepoStatusDetails:
+        return repo_status.RepoStatusDetails("✅")
 
-    monkeypatch.setattr(repo_status, "fetch_repo_status", fake_status)
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
 
     from datetime import datetime
 
@@ -545,3 +547,93 @@ def test_update_readme_existing_timestamp(
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
     assert lines[4] == "- ✅ https://github.com/user/repo"
+
+
+def test_fetch_repo_status_details_includes_failure_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add tests",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "failure",
+                        "head_sha": "abc",
+                        "name": "tests",
+                        "html_url": "https://github.com/user/repo/actions/runs/1",
+                    },
+                    {
+                        "conclusion": "cancelled",
+                        "head_sha": "abc",
+                        "name": "lint",
+                        "artifacts_url": "https://api.github.com/repos/user/repo/actions/runs/2/artifacts",
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details(
+        "user/repo"
+    ) == repo_status.RepoStatusDetails(
+        "❌",
+        (
+            "https://github.com/user/repo/actions/runs/1",
+            "https://api.github.com/repos/user/repo/actions/runs/2/artifacts",
+        ),
+    )
+
+
+def test_update_readme_appends_and_replaces_failure_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    content = (
+        "## Related Projects\n"
+        "_Last updated: 1999-01-01 00:00 UTC; checks hourly_\n"
+        "- ❌ https://github.com/user/repo — failing checks: [failure 1](old)\n"
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(content)
+
+    def fake_status(
+        repo: str, token: str | None = None, branch: str | None = None
+    ) -> repo_status.RepoStatusDetails:
+        return repo_status.RepoStatusDetails(
+            "❌",
+            (
+                "https://github.com/user/repo/actions/runs/1",
+                "https://api.github.com/repos/user/repo/actions/runs/1/artifacts",
+            ),
+        )
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
+
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text().splitlines()[2] == (
+        "- ❌ https://github.com/user/repo — failing checks: "
+        "[failure 1](https://github.com/user/repo/actions/runs/1), "
+        "[failure 2](https://api.github.com/repos/user/repo/actions/runs/1/artifacts)"
+    )


### PR DESCRIPTION
### Motivation
- Keep the top-level `README.md` account/profile-focused while moving repo-specific setup and automation details into a dedicated guide. 
- Preserve the parseable `## Related Projects` block so `src/repo_status.py` can continue to discover project URLs. 
- Make failed Related Projects easier to investigate by surfacing direct links to failing workflow runs or fallback failure assets.

### Description
- Rewrote `README.md` as a profile-first page with a single obvious link to `docs/repository-guide.md`, a compact elevator pitch, `## Related Projects` kept in the parseable `- ` bullet form, and a polished status legend. 
- Added `docs/repository-guide.md` containing the repo map, setup pointers, Makefile/`uv` guidance, scripts/metadata/subtitle summaries, and YouTube Transcript MCP service details. 
- Updated `docs/README.md`, `AGENTS.md`, and `llms.txt` to point to the new repository guide and keep docs indexes consistent. 
- Refactored `src/repo_status.py` to introduce `RepoStatusDetails` (dataclass), added `fetch_repo_status_details()` returning emoji plus failure-evidence links, kept `fetch_repo_status()` as a compatibility wrapper returning only the emoji, and updated `update_readme()` to append comma-separated failing-run links when present; tests were extended to cover the new behavior.

### Testing
- Ran the focused unit tests for the status updater: `python -m pytest tests/test_repo_status.py -q` — result: passed (20 passed). 
- Ran the full test suite: `python -m pytest -q` — initial run failed due to missing MCP dependencies; after installing the package editable dependencies with `python -m pip install -e .` the run passed: `289 passed, 2 warnings`. 
- Docs/markdown checks: `npm run docs-lint` — result: passed. 
- Lint/format checks: `ruff check --fix src/repo_status.py tests/test_repo_status.py` and `black` on Python targets — result: auto-fixed then passed; Python compile checks `python -m py_compile src/repo_status.py tests/test_repo_status.py` also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27014611bc832fb457f06be4adb1bd)