### PR TITLE
Add failure-run links to Related Projects statuses

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -22,19 +22,39 @@ LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class RepoStatusReport:
-    """Rendered status plus optional direct links for failed checks."""
+class StatusLink:
+    """A human-readable Markdown link target for an actionable status detail."""
+
+    label: str
+    url: str
+
+
+@dataclass(frozen=True)
+class RepoStatus:
+    """Repository status details suitable for README rendering."""
 
     emoji: str
-    failure_links: tuple[str, ...] = field(default_factory=tuple)
+    failure_links: tuple[StatusLink, ...] = field(default_factory=tuple)
+
+
+# Backward-compatible name used by older tests/callers while P2 transitions to
+# the clearer RepoStatus type.
+RepoStatusReport = RepoStatus
 
 
 GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+))?")
-FAILURE_LINKS_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
+OLD_FAILURE_LINKS_SUFFIX_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
-FAILURE_LINK_FALLBACK_KEYS = ("logs_url", "artifacts_url", "check_suite_url")
+FAILURE_CONCLUSIONS = {
+    "failure",
+    "cancelled",
+    "canceled",
+    "timed_out",
+    "startup_failure",
+    "action_required",
+}
 
 
 def status_to_emoji(conclusion: str | None) -> str:
@@ -51,30 +71,130 @@ def status_to_emoji(conclusion: str | None) -> str:
       ``"startup_failure"``, ``"action_required"`` → ❌
     - anything else (including ``None`` or non-strings) → ❓
     """
-    if not isinstance(conclusion, str) or not conclusion:
-        normalized = ""
-    else:
-        normalized = re.sub(r"[\s-]+", "_", conclusion.strip().lower())
+    normalized = _normalize_conclusion(conclusion)
     if normalized == "success":
         return "✅"
-    if normalized in {
-        "failure",
-        "cancelled",
-        "canceled",
-        "timed_out",
-        "startup_failure",
-        "action_required",
-    }:
+    if normalized in FAILURE_CONCLUSIONS:
         return "❌"
     return "❓"
 
 
-def fetch_repo_status_report(
+def _normalize_conclusion(value: str | None) -> str:
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"[\s-]+", "_", value.strip().lower())
+
+
+def _run_attempt_key(run: dict) -> tuple[int, str]:
+    raw_attempt = run.get("run_attempt")
+    try:
+        attempt = int(raw_attempt)
+    except (TypeError, ValueError):
+        attempt = 0
+    updated = run.get("updated_at")
+    return (attempt, str(updated) if updated is not None else "")
+
+
+def _run_identity(run: dict) -> tuple[object, object, object]:
+    return (run.get("workflow_id"), run.get("run_number"), run.get("name"))
+
+
+def _run_url(repo: str, run: dict) -> str | None:
+    html_url = run.get("html_url")
+    if isinstance(html_url, str) and html_url:
+        return html_url
+    run_id = run.get("id")
+    if run_id is not None:
+        return f"https://github.com/{repo}/actions/runs/{run_id}"
+    return None
+
+
+def _run_label(run: dict, repeated_labels: set[str]) -> str:
+    raw_label = run.get("name") or run.get("display_title") or "workflow run"
+    label = str(raw_label).strip() or "workflow run"
+    if label not in repeated_labels:
+        return label
+    run_number = run.get("run_number")
+    if run_number is not None:
+        return f"{label} #{run_number}"
+    run_attempt = run.get("run_attempt")
+    if run_attempt is not None:
+        return f"{label} attempt {run_attempt}"
+    return label
+
+
+def _failure_links(repo: str, failed_runs: list[dict]) -> tuple[StatusLink, ...]:
+    labels = [
+        str(run.get("name") or run.get("display_title") or "workflow run")
+        for run in failed_runs
+    ]
+    repeated_labels = {label for label in labels if labels.count(label) > 1}
+    links: list[StatusLink] = []
+    for run in sorted(
+        failed_runs,
+        key=lambda item: (
+            str(
+                item.get("name") or item.get("display_title") or "workflow run"
+            ).lower(),
+            str(item.get("run_number") or ""),
+            str(item.get("workflow_id") or ""),
+            str(item.get("id") or ""),
+        ),
+    ):
+        url = _run_url(repo, run)
+        if url:
+            links.append(StatusLink(_run_label(run, repeated_labels), url))
+    return tuple(links)
+
+
+def _evaluate_runs(
+    repo: str, runs: Iterable[dict]
+) -> tuple[str, tuple[StatusLink, ...]]:
+    """Return conclusion and failure links for each workflow latest attempt."""
+
+    latest_runs: dict[tuple[object, object, object], dict] = {}
+    for run in runs:
+        key = _run_identity(run)
+        current = latest_runs.get(key)
+        if current is None or _run_attempt_key(run) > _run_attempt_key(current):
+            latest_runs[key] = run
+
+    conclusions = {
+        _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
+    }
+    failed_runs = [
+        run
+        for run in latest_runs.values()
+        if _normalize_conclusion(run.get("conclusion")) in FAILURE_CONCLUSIONS
+    ]
+    if failed_runs:
+        return "failure", _failure_links(repo, failed_runs)
+    if "success" in conclusions:
+        return "success", ()
+    # Default to failure so lack of CI coverage surfaces as ❌
+    return "failure", ()
+
+
+def _should_skip_commit(commit: dict) -> bool:
+    message = commit.get("commit", {}).get("message", "")
+    if SKIP_COMMIT_RE.search(message):
+        return True
+    for key in ("author", "committer"):
+        login = (commit.get(key) or {}).get("login")
+        name = commit.get("commit", {}).get(key, {}).get("name")
+        if isinstance(login, str) and login.endswith("[bot]"):
+            return True
+        if isinstance(name, str) and name.endswith("[bot]"):
+            return True
+    return False
+
+
+def fetch_repo_status_details(
     repo: str,
     token: str | None = None,
     branch: str | None = None,
     attempts: int = 2,
-) -> RepoStatusReport:
+) -> RepoStatus:
     """Fetch the latest workflow run conclusion and failure links for ``repo``.
 
     The GitHub API occasionally returns inconsistent data if a workflow is
@@ -96,12 +216,12 @@ def fetch_repo_status_report(
             repo_data = repo_resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
             LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return RepoStatusReport(status_to_emoji(None))
+            return RepoStatus(status_to_emoji(None))
         if not isinstance(repo_data, dict):
             LOGGER.warning(
                 "Unexpected repository payload for %s: %r", repo, type(repo_data)
             )
-            return RepoStatusReport(status_to_emoji(None))
+            return RepoStatus(status_to_emoji(None))
         branch = repo_data.get("default_branch")
 
     url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
@@ -109,88 +229,8 @@ def fetch_repo_status_report(
         url += f"&branch={branch}"
 
     keywords = re.compile(r"(test|lint|build|ci)", re.I)
-    failures = {
-        "failure",
-        "cancelled",
-        "canceled",
-        "timed_out",
-        "startup_failure",
-        "action_required",
-    }
 
-    def _normalize_conclusion(value: str | None) -> str:
-        if not isinstance(value, str):
-            return ""
-        return re.sub(r"[\s-]+", "_", value.strip().lower())
-
-    def _should_skip_commit(commit: dict) -> bool:
-        message = commit.get("commit", {}).get("message", "")
-        if SKIP_COMMIT_RE.search(message):
-            return True
-        for key in ("author", "committer"):
-            login = (commit.get(key) or {}).get("login")
-            name = commit.get("commit", {}).get(key, {}).get("name")
-            if isinstance(login, str) and login.endswith("[bot]"):
-                return True
-            if isinstance(name, str) and name.endswith("[bot]"):
-                return True
-        return False
-
-    def _failure_link(run: dict) -> str | None:
-        html_url = run.get("html_url")
-        if isinstance(html_url, str) and html_url:
-            return html_url
-        for key in FAILURE_LINK_FALLBACK_KEYS:
-            url_value = run.get(key)
-            if isinstance(url_value, str) and url_value:
-                return url_value
-        run_id = run.get("id")
-        if run_id is not None:
-            return f"https://github.com/{repo}/actions/runs/{run_id}"
-        return None
-
-    def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[str, ...]]:
-        """Return conclusion and failure links for each workflow latest attempt."""
-
-        latest_runs: dict[tuple[object, object, object], dict] = {}
-
-        def _attempt_key(run: dict) -> tuple[int, str]:
-            raw_attempt = run.get("run_attempt")
-            try:
-                attempt = int(raw_attempt)
-            except (TypeError, ValueError):
-                attempt = 0
-            updated = run.get("updated_at")
-            return (attempt, str(updated) if updated is not None else "")
-
-        for run in runs:
-            key = (
-                run.get("workflow_id"),
-                run.get("run_number"),
-                run.get("name"),
-            )
-            current = latest_runs.get(key)
-            if current is None or _attempt_key(run) > _attempt_key(current):
-                latest_runs[key] = run
-
-        failed_links = tuple(
-            link
-            for run in latest_runs.values()
-            if _normalize_conclusion(run.get("conclusion")) in failures
-            for link in [_failure_link(run)]
-            if link
-        )
-        conclusions = {
-            _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
-        }
-        if any(c in failures for c in conclusions):
-            return "failure", failed_links
-        if "success" in conclusions:
-            return "success", ()
-        # Default to failure so lack of CI coverage surfaces as ❌
-        return "failure", failed_links
-
-    def _fetch() -> tuple[str | None, tuple[str, ...]]:
+    def _fetch() -> tuple[str | None, tuple[StatusLink, ...]]:
         try:
             commits_resp = requests.get(
                 f"https://api.github.com/repos/{repo}/commits?sha={branch}&per_page=20",
@@ -210,7 +250,6 @@ def fetch_repo_status_report(
                 type(commits_data),
             )
             return None, ()
-        commits = commits_data
 
         try:
             resp = requests.get(url, headers=headers, timeout=10)
@@ -247,18 +286,18 @@ def fetch_repo_status_report(
                 continue
             runs_by_sha.setdefault(sha, []).append(run)
 
-        for commit in commits:
+        for commit in commits_data:
             sha = commit.get("sha")
             if not isinstance(sha, str):
                 continue
             commit_runs = runs_by_sha.get(sha, [])
             if commit_runs:
                 important = [
-                    r for r in commit_runs if keywords.search(r.get("name", ""))
+                    run for run in commit_runs if keywords.search(run.get("name", ""))
                 ]
                 if important:
                     commit_runs = important
-                return _evaluate_runs(commit_runs)
+                return _evaluate_runs(repo, commit_runs)
             if _should_skip_commit(commit):
                 continue
             return None, ()
@@ -270,12 +309,23 @@ def fetch_repo_status_report(
         raise RuntimeError(
             f"Non-deterministic workflow conclusion for {repo}: {conclusions}"
         )
-    failure_links: list[str] = []
+    failure_links: list[StatusLink] = []
     for _, links in reports:
         for link in links:
             if link not in failure_links:
                 failure_links.append(link)
-    return RepoStatusReport(status_to_emoji(conclusions[0]), tuple(failure_links))
+    return RepoStatus(status_to_emoji(conclusions[0]), tuple(failure_links))
+
+
+def fetch_repo_status_report(
+    repo: str,
+    token: str | None = None,
+    branch: str | None = None,
+    attempts: int = 2,
+) -> RepoStatus:
+    """Backward-compatible alias for :func:`fetch_repo_status_details`."""
+
+    return fetch_repo_status_details(repo, token, branch, attempts)
 
 
 def fetch_repo_status(
@@ -286,15 +336,56 @@ def fetch_repo_status(
 ) -> str:
     """Fetch the latest workflow run conclusion for ``repo`` and return an emoji."""
 
-    return fetch_repo_status_report(repo, token, branch, attempts).emoji
+    return fetch_repo_status_details(repo, token, branch, attempts).emoji
 
 
-def _format_failure_links(links: tuple[str, ...]) -> str:
-    """Format direct failure URLs for README bullets."""
+def _format_markdown_link(link: StatusLink) -> str:
+    label = link.label.replace("[", "\\[").replace("]", "\\]")
+    return f"[{label}]({link.url})"
+
+
+def _format_failure_links(links: tuple[StatusLink, ...]) -> str:
+    """Format direct failure links for README bullets."""
 
     if not links:
         return ""
-    return f" (failing runs: {', '.join(links)})"
+    return f" ({', '.join(_format_markdown_link(link) for link in links)})"
+
+
+def _matching_parenthesis(text: str) -> int | None:
+    """Return the matching close-paren index when ``text`` starts with ``(``."""
+
+    depth = 0
+    for index, char in enumerate(text):
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _strip_status_prefix(line: str) -> str:
+    """Remove previously generated status prefixes while preserving the bullet."""
+
+    if not line.startswith("- "):
+        return OLD_FAILURE_LINKS_SUFFIX_RE.sub("", line)
+
+    rest = line[2:].lstrip()
+    changed = True
+    while changed:
+        changed = False
+        while rest.startswith(("✅", "❌", "❓")):
+            rest = rest[1:].lstrip()
+            changed = True
+        if rest.startswith("(") and "](" in rest:
+            close = _matching_parenthesis(rest)
+            if close is not None:
+                rest = rest[close + 1 :].lstrip()
+                changed = True
+
+    return OLD_FAILURE_LINKS_SUFFIX_RE.sub("", f"- {rest}")
 
 
 def update_readme(
@@ -325,13 +416,12 @@ def update_readme(
             if match:
                 repo = f"{match.group(1)}/{match.group(2)}"
                 branch = match.group(3)
-                report = fetch_repo_status_report(repo, token, branch)
-                # remove existing emoji and generated failure links
-                cleaned = re.sub(r"^(-\s*)(?:[✅❌❓]\s*)*", r"\1", line)
-                cleaned = FAILURE_LINKS_RE.sub("", cleaned)
-                # Ensure UTF-8 output; lines later written with utf-8 encoding
-                link_suffix = _format_failure_links(report.failure_links)
-                line = f"- {report.emoji} {cleaned[2:].lstrip()}{link_suffix}"
+                status = fetch_repo_status_details(repo, token, branch)
+                cleaned = _strip_status_prefix(line)
+                line = (
+                    f"- {status.emoji}{_format_failure_links(status.failure_links)} "
+                    f"{cleaned[2:].lstrip()}"
+                )
         output.append(line)
 
     # Ensure output file encoded as UTF-8 so emoji render correctly on Windows

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -475,17 +475,11 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_status(
         repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
+    ) -> repo_status.RepoStatus:
         calls.append((repo, branch))
-        return {"user/repo": "✅", "other/repo": "❌"}[repo]
+        return repo_status.RepoStatus({"user/repo": "✅", "other/repo": "❌"}[repo])
 
-    monkeypatch.setattr(
-        repo_status,
-        "fetch_repo_status_report",
-        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
-            fake_status(repo, token, branch)
-        ),
-    )
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
     from datetime import datetime
 
     now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
@@ -494,6 +488,8 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
     assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert lines[5] == "- ❌ https://github.com/other/repo/tree/dev"
+    assert calls == [("user/repo", None), ("other/repo", "dev")]
 
 
 def test_update_readme_uses_current_time(
@@ -503,17 +499,10 @@ def test_update_readme_uses_current_time(
     readme = tmp_path / "README.md"
     readme.write_text(content)
 
-    def fake_status(
-        repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
-        return "✅"
-
     monkeypatch.setattr(
         repo_status,
-        "fetch_repo_status_report",
-        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
-            fake_status(repo, token, branch)
-        ),
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus("✅"),
     )
 
     from datetime import datetime, timezone
@@ -542,17 +531,10 @@ def test_update_readme_existing_timestamp(
     readme = tmp_path / "README.md"
     readme.write_text(content)
 
-    def fake_status(
-        repo: str, token: str | None = None, branch: str | None = None
-    ) -> str:
-        return "✅"
-
     monkeypatch.setattr(
         repo_status,
-        "fetch_repo_status_report",
-        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
-            fake_status(repo, token, branch)
-        ),
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus("✅"),
     )
 
     from datetime import datetime
@@ -565,23 +547,7 @@ def test_update_readme_existing_timestamp(
     assert lines[4] == "- ✅ https://github.com/user/repo"
 
 
-@pytest.mark.parametrize(
-    ("fallback_key", "fallback_url"),
-    [
-        ("logs_url", "https://api.github.com/repos/user/repo/actions/runs/2/logs"),
-        (
-            "artifacts_url",
-            "https://api.github.com/repos/user/repo/actions/runs/2/artifacts",
-        ),
-        (
-            "check_suite_url",
-            "https://api.github.com/repos/user/repo/check-suites/2",
-        ),
-    ],
-)
-def test_fetch_repo_status_report_includes_failed_run_links(
-    monkeypatch: pytest.MonkeyPatch, fallback_key: str, fallback_url: str
-) -> None:
+def _mock_repo_status_api(monkeypatch: pytest.MonkeyPatch, runs: list[dict]) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
@@ -593,7 +559,7 @@ def test_fetch_repo_status_report_includes_failed_run_links(
                     {
                         "sha": "abc",
                         "commit": {
-                            "message": "feat: add failing tests",
+                            "message": "feat: update checks",
                             "author": {"name": "Alice"},
                             "committer": {"name": "Alice"},
                         },
@@ -602,86 +568,264 @@ def test_fetch_repo_status_report_includes_failed_run_links(
                     }
                 ]
             )
-        return DummyResp(
-            {
-                "workflow_runs": [
-                    {
-                        "conclusion": "failure",
-                        "head_sha": "abc",
-                        "html_url": "https://github.com/user/repo/actions/runs/1",
-                        "name": "tests",
-                    },
-                    {
-                        "conclusion": "cancelled",
-                        "head_sha": "abc",
-                        "id": 2,
-                        fallback_key: fallback_url,
-                        "name": "lint",
-                    },
-                    {
-                        "conclusion": "timed_out",
-                        "head_sha": "abc",
-                        "id": 4,
-                        "name": "ci",
-                    },
-                    {
-                        "conclusion": "success",
-                        "head_sha": "abc",
-                        "html_url": "https://github.com/user/repo/actions/runs/3",
-                        "name": "build",
-                    },
-                ]
-            }
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main"
         )
+        return DummyResp({"workflow_runs": runs})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
-    report = repo_status.fetch_repo_status_report("user/repo")
 
-    assert report == repo_status.RepoStatusReport(
+
+def test_fetch_repo_status_details_returns_failed_run_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            {
+                "conclusion": "failure",
+                "head_sha": "abc",
+                "html_url": "https://github.com/user/repo/actions/runs/1",
+                "name": "tests",
+            }
+        ],
+    )
+
+    status = repo_status.fetch_repo_status_details("user/repo")
+
+    assert status == repo_status.RepoStatus(
         "❌",
         (
-            "https://github.com/user/repo/actions/runs/1",
-            fallback_url,
-            "https://github.com/user/repo/actions/runs/4",
+            repo_status.StatusLink(
+                "tests", "https://github.com/user/repo/actions/runs/1"
+            ),
+        ),
+    )
+    assert repo_status.fetch_repo_status("user/repo", attempts=1) == "❌"
+
+
+def test_fetch_repo_status_details_multiple_failures_are_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            {
+                "conclusion": "failure",
+                "head_sha": "abc",
+                "html_url": "https://github.com/user/repo/actions/runs/2",
+                "name": "tests",
+                "run_number": 2,
+                "workflow_id": 20,
+            },
+            {
+                "conclusion": "cancelled",
+                "head_sha": "abc",
+                "html_url": "https://github.com/user/repo/actions/runs/1",
+                "name": "lint",
+                "run_number": 1,
+                "workflow_id": 10,
+            },
+        ],
+    )
+
+    status = repo_status.fetch_repo_status_details("user/repo")
+
+    assert status == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "lint", "https://github.com/user/repo/actions/runs/1"
+            ),
+            repo_status.StatusLink(
+                "tests", "https://github.com/user/repo/actions/runs/2"
+            ),
+        ),
+    )
+    assert repo_status._format_failure_links(status.failure_links) == (
+        " ([lint](https://github.com/user/repo/actions/runs/1), "
+        "[tests](https://github.com/user/repo/actions/runs/2))"
+    )
+
+
+def test_fetch_repo_status_details_falls_back_to_actions_run_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            {
+                "conclusion": "startup_failure",
+                "head_sha": "abc",
+                "id": 123,
+                "name": "build",
+            }
+        ],
+    )
+
+    status = repo_status.fetch_repo_status_details("user/repo")
+
+    assert status == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "build", "https://github.com/user/repo/actions/runs/123"
+            ),
         ),
     )
 
 
-def test_update_readme_includes_failure_links_and_removes_duplicates(
+def test_fetch_repo_status_details_failure_without_url_has_no_empty_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [{"conclusion": "timed_out", "head_sha": "abc", "name": "ci"}],
+    )
+
+    status = repo_status.fetch_repo_status_details("user/repo")
+
+    assert status == repo_status.RepoStatus("❌")
+    assert repo_status._format_failure_links(status.failure_links) == ""
+
+
+def test_fetch_repo_status_details_success_and_unknown_have_no_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [{"conclusion": "success", "head_sha": "abc", "name": "tests"}],
+    )
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "✅"
+    )
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        raise repo_status.requests.exceptions.ConnectionError("boom")
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❓"
+    )
+
+
+def test_fetch_repo_status_details_latest_attempt_clears_stale_failure_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            {
+                "conclusion": "failure",
+                "head_sha": "abc",
+                "html_url": "https://github.com/user/repo/actions/runs/42/attempts/1",
+                "name": "tests",
+                "run_attempt": 1,
+                "run_number": 42,
+                "workflow_id": 123,
+                "updated_at": "2025-09-25T12:00:00Z",
+            },
+            {
+                "conclusion": "success",
+                "head_sha": "abc",
+                "html_url": "https://github.com/user/repo/actions/runs/42/attempts/2",
+                "name": "tests",
+                "run_attempt": 2,
+                "run_number": 42,
+                "workflow_id": 123,
+                "updated_at": "2025-09-25T12:05:00Z",
+            },
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "✅"
+    )
+
+
+def test_fetch_repo_status_details_links_only_failed_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            {
+                "conclusion": "success",
+                "head_sha": "abc",
+                "html_url": "https://github.com/user/repo/actions/runs/1",
+                "name": "tests",
+                "run_number": 1,
+                "workflow_id": 10,
+            },
+            {
+                "conclusion": "action_required",
+                "head_sha": "abc",
+                "html_url": "https://github.com/user/repo/actions/runs/2",
+                "name": "lint",
+                "run_number": 2,
+                "workflow_id": 20,
+            },
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "lint", "https://github.com/user/repo/actions/runs/2"
+            ),
+        ),
+    )
+
+
+def test_update_readme_renders_failure_links_and_is_idempotent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     content = (
         "## Related Projects\n"
         "_Last updated: 1999-01-01 00:00 UTC; checks hourly_\n"
         "_Last updated: 1998-01-01 00:00 UTC; checks hourly_\n"
-        "- ✅ https://github.com/user/repo (failing runs: https://old.example/run)\n"
+        "- ❌ ([old tests](https://old.example/run), [old lint](https://old.example/lint)) "
+        "❌ **[repo](https://github.com/user/repo)** \u2013 description\n"
+        "- ❌ **[other](https://github.com/user/other)** \u2013 description\n"
     )
     readme = tmp_path / "README.md"
     readme.write_text(content)
 
-    monkeypatch.setattr(
-        repo_status,
-        "fetch_repo_status_report",
-        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
-            "❌",
-            (
-                "https://github.com/user/repo/actions/runs/1",
-                "https://github.com/user/repo/actions/runs/2",
-            ),
-        ),
-    )
+    def fake_status(
+        repo: str, token: str | None = None, branch: str | None = None
+    ) -> repo_status.RepoStatus:
+        if repo == "user/repo":
+            return repo_status.RepoStatus(
+                "❌",
+                (
+                    repo_status.StatusLink(
+                        "tests", "https://github.com/user/repo/actions/runs/1"
+                    ),
+                    repo_status.StatusLink(
+                        "lint", "https://github.com/user/repo/actions/runs/2"
+                    ),
+                ),
+            )
+        return repo_status.RepoStatus("✅")
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
     from datetime import datetime
 
     now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
     repo_status.update_readme(readme, now=now)
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=now)
+    second = readme.read_text()
 
-    lines = readme.read_text().splitlines()
-    assert lines == [
+    assert second == first
+    assert second.splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         (
-            "- ❌ https://github.com/user/repo (failing runs: "
-            "https://github.com/user/repo/actions/runs/1, "
-            "https://github.com/user/repo/actions/runs/2)"
+            "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
+            "[lint](https://github.com/user/repo/actions/runs/2)) "
+            "**[repo](https://github.com/user/repo)** \u2013 description"
         ),
+        "- ✅ **[other](https://github.com/user/other)** \u2013 description",
     ]


### PR DESCRIPTION
### Motivation
- Make Related Projects ❌ statuses immediately actionable by linking directly to failing workflow runs or fallback run URLs so maintainers can jump to the precise failure.
- Preserve the existing emoji-only API so older callers and CI remain compatible while adding structured details for README rendering and future metadata (e.g. star counts).

### Description
- Introduced small structured types `StatusLink(label: str, url: str)` and `RepoStatus(emoji: str, failure_links: tuple[StatusLink, ...])` (kept `RepoStatusReport` as a compatibility alias) and a new detailed fetcher `fetch_repo_status_details(...)` while leaving `fetch_repo_status(...)` as an emoji-only wrapper.
- Updated failure extraction to prefer each run's `html_url`, fall back to `https://github.com/{repo}/actions/runs/{id}` when `id` exists, skip runs with no usable URL, and collect only the latest attempt per workflow/run identity.
- Render README bullets as `- ❌ ([tests](...), [lint](...)) **[repo](...)** – description` when failures exist and produce comma-separated Markdown links; added robust prefix stripping that removes previous generated emojis/linked groups idempotently and collapses duplicate `_Last updated:` lines under `## Related Projects`.
- Added deterministic ordering and labeling logic for repeated workflow names so multiple failure links render consistently and are human-readable.

### Testing
- Ran focused checks: `python -m ruff check tests/test_repo_status.py` — succeeded.
- Ran unit tests for the modified module: `python -m pytest tests/test_repo_status.py -q` — all tests passed (26 passed).
- Ran full test suite: `python -m pytest -q` — succeeded (295 passed, 2 warnings).
- Formatting/lint helpers were run: `python -m black src/repo_status.py` and project install for dev deps `python -m pip install -e '.[dev]'` — both completed successfully.
- No network calls were made during tests; GitHub API interactions are fully mocked in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a270caa9a94832fb6bb27929da09a34)