### PR TITLE
feat: link failing Related Projects checks

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -12,7 +12,7 @@ import logging
 import os
 import re
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -22,15 +22,30 @@ LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class RepoStatusReport:
-    """Rendered status plus optional direct links for failed checks."""
+class StatusLink:
+    """A direct Markdown-ready link target for a failed check."""
+
+    label: str
+    url: str
+
+
+@dataclass(frozen=True)
+class RepoStatus:
+    """Structured repo status, designed to grow with future repo metadata."""
 
     emoji: str
-    failure_links: tuple[str, ...] = field(default_factory=tuple)
+    failure_links: tuple[StatusLink, ...] = ()
+
+
+# Backwards-compatible name for older callers/tests.
+RepoStatusReport = RepoStatus
 
 
 GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+))?")
-FAILURE_LINKS_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
+GENERATED_FAILURE_SUFFIX_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
+GENERATED_STATUS_PREFIX_RE = re.compile(
+    r"^(-\s*)(?:(?:[✅❌❓]\s*)+(?:\((?:\[[^\]]+\]\([^)]*\),?\s*)+\)\s*)?)+"
+)
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
@@ -69,12 +84,12 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
-def fetch_repo_status_report(
+def fetch_repo_status_details(
     repo: str,
     token: str | None = None,
     branch: str | None = None,
     attempts: int = 2,
-) -> RepoStatusReport:
+) -> RepoStatus:
     """Fetch the latest workflow run conclusion and failure links for ``repo``.
 
     The GitHub API occasionally returns inconsistent data if a workflow is
@@ -96,12 +111,12 @@ def fetch_repo_status_report(
             repo_data = repo_resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
             LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return RepoStatusReport(status_to_emoji(None))
+            return RepoStatus(status_to_emoji(None))
         if not isinstance(repo_data, dict):
             LOGGER.warning(
                 "Unexpected repository payload for %s: %r", repo, type(repo_data)
             )
-            return RepoStatusReport(status_to_emoji(None))
+            return RepoStatus(status_to_emoji(None))
         branch = repo_data.get("default_branch")
 
     url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
@@ -136,20 +151,55 @@ def fetch_repo_status_report(
                 return True
         return False
 
-    def _failure_link(run: dict) -> str | None:
+    def _failure_url(run: dict) -> str | None:
         html_url = run.get("html_url")
         if isinstance(html_url, str) and html_url:
             return html_url
+        run_id = run.get("id")
+        if run_id is not None:
+            return f"https://github.com/{repo}/actions/runs/{run_id}"
         for key in FAILURE_LINK_FALLBACK_KEYS:
             url_value = run.get(key)
             if isinstance(url_value, str) and url_value:
                 return url_value
-        run_id = run.get("id")
-        if run_id is not None:
-            return f"https://github.com/{repo}/actions/runs/{run_id}"
         return None
 
-    def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[str, ...]]:
+    def _run_label(run: dict) -> str:
+        name = run.get("display_title") or run.get("name") or run.get("workflow_name")
+        return str(name).strip() if name else "workflow run"
+
+    def _failure_status_links(runs: Iterable[dict]) -> tuple[StatusLink, ...]:
+        failed_runs = [
+            run
+            for run in runs
+            if _normalize_conclusion(run.get("conclusion")) in failures
+            and _failure_url(run)
+        ]
+        base_labels = [_run_label(run) for run in failed_runs]
+        duplicate_labels = {
+            label for label in base_labels if base_labels.count(label) > 1
+        }
+        links: list[StatusLink] = []
+        for run, base_label in zip(failed_runs, base_labels, strict=True):
+            label = base_label
+            if base_label in duplicate_labels:
+                run_number = run.get("run_number")
+                if run_number is not None:
+                    label = f"{base_label} #{run_number}"
+                run_attempt = run.get("run_attempt")
+                if run_attempt not in (None, 1, "1"):
+                    label = f"{label} attempt {run_attempt}"
+            url = _failure_url(run)
+            if url:
+                links.append(StatusLink(label, url))
+        return tuple(
+            sorted(
+                links,
+                key=lambda link: (link.label.casefold(), link.url),
+            )
+        )
+
+    def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[StatusLink, ...]]:
         """Return conclusion and failure links for each workflow latest attempt."""
 
         latest_runs: dict[tuple[object, object, object], dict] = {}
@@ -173,15 +223,10 @@ def fetch_repo_status_report(
             if current is None or _attempt_key(run) > _attempt_key(current):
                 latest_runs[key] = run
 
-        failed_links = tuple(
-            link
-            for run in latest_runs.values()
-            if _normalize_conclusion(run.get("conclusion")) in failures
-            for link in [_failure_link(run)]
-            if link
-        )
+        latest_run_values = tuple(latest_runs.values())
+        failed_links = _failure_status_links(latest_run_values)
         conclusions = {
-            _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
+            _normalize_conclusion(r.get("conclusion")) for r in latest_run_values
         }
         if any(c in failures for c in conclusions):
             return "failure", failed_links
@@ -190,7 +235,7 @@ def fetch_repo_status_report(
         # Default to failure so lack of CI coverage surfaces as ❌
         return "failure", failed_links
 
-    def _fetch() -> tuple[str | None, tuple[str, ...]]:
+    def _fetch() -> tuple[str | None, tuple[StatusLink, ...]]:
         try:
             commits_resp = requests.get(
                 f"https://api.github.com/repos/{repo}/commits?sha={branch}&per_page=20",
@@ -270,12 +315,23 @@ def fetch_repo_status_report(
         raise RuntimeError(
             f"Non-deterministic workflow conclusion for {repo}: {conclusions}"
         )
-    failure_links: list[str] = []
+    failure_links: list[StatusLink] = []
     for _, links in reports:
         for link in links:
             if link not in failure_links:
                 failure_links.append(link)
-    return RepoStatusReport(status_to_emoji(conclusions[0]), tuple(failure_links))
+    return RepoStatus(status_to_emoji(conclusions[0]), tuple(failure_links))
+
+
+def fetch_repo_status_report(
+    repo: str,
+    token: str | None = None,
+    branch: str | None = None,
+    attempts: int = 2,
+) -> RepoStatus:
+    """Backward-compatible alias for ``fetch_repo_status_details``."""
+
+    return fetch_repo_status_details(repo, token, branch, attempts)
 
 
 def fetch_repo_status(
@@ -286,15 +342,35 @@ def fetch_repo_status(
 ) -> str:
     """Fetch the latest workflow run conclusion for ``repo`` and return an emoji."""
 
-    return fetch_repo_status_report(repo, token, branch, attempts).emoji
+    return fetch_repo_status_details(repo, token, branch, attempts).emoji
 
 
-def _format_failure_links(links: tuple[str, ...]) -> str:
-    """Format direct failure URLs for README bullets."""
+def _escape_markdown_link_label(label: str) -> str:
+    """Escape the small subset needed for generated Markdown link labels."""
+
+    return label.replace("\\", "\\\\").replace("]", "\\]")
+
+
+def _format_failure_links(links: tuple[StatusLink, ...]) -> str:
+    """Format direct failure links for README bullets."""
 
     if not links:
         return ""
-    return f" (failing runs: {', '.join(links)})"
+    rendered = ", ".join(
+        f"[{_escape_markdown_link_label(link.label)}]({link.url})" for link in links
+    )
+    return f" ({rendered})"
+
+
+def _strip_generated_status_prefix(line: str) -> str:
+    """Remove previously generated status emoji and failure-link prefixes."""
+
+    previous = None
+    cleaned = line
+    while cleaned != previous:
+        previous = cleaned
+        cleaned = GENERATED_STATUS_PREFIX_RE.sub(r"\1", cleaned)
+    return GENERATED_FAILURE_SUFFIX_RE.sub("", cleaned)
 
 
 def update_readme(
@@ -325,13 +401,11 @@ def update_readme(
             if match:
                 repo = f"{match.group(1)}/{match.group(2)}"
                 branch = match.group(3)
-                report = fetch_repo_status_report(repo, token, branch)
-                # remove existing emoji and generated failure links
-                cleaned = re.sub(r"^(-\s*)(?:[✅❌❓]\s*)*", r"\1", line)
-                cleaned = FAILURE_LINKS_RE.sub("", cleaned)
-                # Ensure UTF-8 output; lines later written with utf-8 encoding
-                link_suffix = _format_failure_links(report.failure_links)
-                line = f"- {report.emoji} {cleaned[2:].lstrip()}{link_suffix}"
+                report = fetch_repo_status_details(repo, token, branch)
+                # Remove existing generated emoji/link prefixes before rendering.
+                cleaned = _strip_generated_status_prefix(line)
+                failure_prefix = _format_failure_links(report.failure_links)
+                line = f"- {report.emoji}{failure_prefix} {cleaned[2:].lstrip()}"
         output.append(line)
 
     # Ensure output file encoded as UTF-8 so emoji render correctly on Windows

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -481,8 +481,8 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(
         repo_status,
-        "fetch_repo_status_report",
-        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
             fake_status(repo, token, branch)
         ),
     )
@@ -510,8 +510,8 @@ def test_update_readme_uses_current_time(
 
     monkeypatch.setattr(
         repo_status,
-        "fetch_repo_status_report",
-        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
             fake_status(repo, token, branch)
         ),
     )
@@ -549,8 +549,8 @@ def test_update_readme_existing_timestamp(
 
     monkeypatch.setattr(
         repo_status,
-        "fetch_repo_status_report",
-        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
             fake_status(repo, token, branch)
         ),
     )
@@ -565,22 +565,8 @@ def test_update_readme_existing_timestamp(
     assert lines[4] == "- ✅ https://github.com/user/repo"
 
 
-@pytest.mark.parametrize(
-    ("fallback_key", "fallback_url"),
-    [
-        ("logs_url", "https://api.github.com/repos/user/repo/actions/runs/2/logs"),
-        (
-            "artifacts_url",
-            "https://api.github.com/repos/user/repo/actions/runs/2/artifacts",
-        ),
-        (
-            "check_suite_url",
-            "https://api.github.com/repos/user/repo/check-suites/2",
-        ),
-    ],
-)
-def test_fetch_repo_status_report_includes_failed_run_links(
-    monkeypatch: pytest.MonkeyPatch, fallback_key: str, fallback_url: str
+def test_fetch_repo_status_details_includes_failed_run_html_url(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         if url == "https://api.github.com/repos/user/repo":
@@ -611,62 +597,353 @@ def test_fetch_repo_status_report_includes_failed_run_links(
                         "html_url": "https://github.com/user/repo/actions/runs/1",
                         "name": "tests",
                     },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "tests", "https://github.com/user/repo/actions/runs/1"
+            ),
+        ),
+    )
+
+
+def test_fetch_repo_status_details_multiple_failed_runs_are_sorted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
                     {
-                        "conclusion": "cancelled",
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add failing checks",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "failure",
                         "head_sha": "abc",
-                        "id": 2,
-                        fallback_key: fallback_url,
-                        "name": "lint",
+                        "html_url": "https://github.com/user/repo/actions/runs/2",
+                        "name": "tests",
                     },
                     {
                         "conclusion": "timed_out",
                         "head_sha": "abc",
-                        "id": 4,
-                        "name": "ci",
-                    },
-                    {
-                        "conclusion": "success",
-                        "head_sha": "abc",
-                        "html_url": "https://github.com/user/repo/actions/runs/3",
-                        "name": "build",
+                        "id": 1,
+                        "name": "lint",
                     },
                 ]
             }
         )
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
-    report = repo_status.fetch_repo_status_report("user/repo")
 
-    assert report == repo_status.RepoStatusReport(
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
         "❌",
         (
-            "https://github.com/user/repo/actions/runs/1",
-            fallback_url,
-            "https://github.com/user/repo/actions/runs/4",
+            repo_status.StatusLink(
+                "lint", "https://github.com/user/repo/actions/runs/1"
+            ),
+            repo_status.StatusLink(
+                "tests", "https://github.com/user/repo/actions/runs/2"
+            ),
         ),
     )
 
 
-def test_update_readme_includes_failure_links_and_removes_duplicates(
+def test_fetch_repo_status_details_falls_back_to_actions_run_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add lint",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "cancelled",
+                        "head_sha": "abc",
+                        "id": 42,
+                        "name": "lint",
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "lint", "https://github.com/user/repo/actions/runs/42"
+            ),
+        ),
+    )
+
+
+def test_fetch_repo_status_details_failure_without_url_has_no_empty_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add ci",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "failure", "head_sha": "abc", "name": "ci"},
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌"
+    )
+
+
+def test_fetch_repo_status_details_success_and_unknown_have_no_failure_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = iter(
+        [
+            DummyResp({"default_branch": "main"}),
+            DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add tests",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            ),
+            DummyResp(
+                {
+                    "workflow_runs": [
+                        {
+                            "conclusion": "success",
+                            "head_sha": "abc",
+                            "html_url": "https://github.com/user/repo/actions/runs/1",
+                            "name": "tests",
+                        }
+                    ]
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        repo_status.requests, "get", lambda *args, **kwargs: next(responses)
+    )
+    assert repo_status.fetch_repo_status_details(
+        "user/repo", attempts=1
+    ) == repo_status.RepoStatus("✅")
+
+    monkeypatch.setattr(
+        repo_status.requests,
+        "get",
+        lambda *args, **kwargs: DummyResp(
+            {"default_branch": "main"}, json_error=ValueError()
+        ),
+    )
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❓"
+    )
+
+
+def test_fetch_repo_status_details_latest_retry_removes_stale_failure_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: retry tests",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "failure",
+                        "head_sha": "abc",
+                        "html_url": "https://github.com/user/repo/actions/runs/1",
+                        "name": "tests",
+                        "run_attempt": 1,
+                        "run_number": 7,
+                        "updated_at": "2026-01-01T00:00:00Z",
+                        "workflow_id": 1,
+                    },
+                    {
+                        "conclusion": "success",
+                        "head_sha": "abc",
+                        "html_url": "https://github.com/user/repo/actions/runs/1",
+                        "name": "tests",
+                        "run_attempt": 2,
+                        "run_number": 7,
+                        "updated_at": "2026-01-01T00:05:00Z",
+                        "workflow_id": 1,
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "✅"
+    )
+
+
+def test_fetch_repo_status_details_links_only_failed_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: split checks",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "success",
+                        "head_sha": "abc",
+                        "html_url": "https://github.com/user/repo/actions/runs/1",
+                        "name": "tests",
+                    },
+                    {
+                        "conclusion": "failure",
+                        "head_sha": "abc",
+                        "html_url": "https://github.com/user/repo/actions/runs/2",
+                        "name": "lint",
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "lint", "https://github.com/user/repo/actions/runs/2"
+            ),
+        ),
+    )
+
+
+def test_update_readme_includes_failure_links_and_collapses_timestamps(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     content = (
         "## Related Projects\n"
         "_Last updated: 1999-01-01 00:00 UTC; checks hourly_\n"
         "_Last updated: 1998-01-01 00:00 UTC; checks hourly_\n"
-        "- ✅ https://github.com/user/repo (failing runs: https://old.example/run)\n"
+        "- ❌ ([old](https://old.example/run)) ❌ **[repo](https://github.com/user/repo)** - desc\n"
     )
     readme = tmp_path / "README.md"
     readme.write_text(content)
 
     monkeypatch.setattr(
         repo_status,
-        "fetch_repo_status_report",
-        lambda repo, token=None, branch=None: repo_status.RepoStatusReport(
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
             "❌",
             (
-                "https://github.com/user/repo/actions/runs/1",
-                "https://github.com/user/repo/actions/runs/2",
+                repo_status.StatusLink(
+                    "tests", "https://github.com/user/repo/actions/runs/1"
+                ),
+                repo_status.StatusLink(
+                    "lint", "https://github.com/user/repo/actions/runs/2"
+                ),
             ),
         ),
     )
@@ -675,13 +952,17 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
     now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
     repo_status.update_readme(readme, now=now)
 
-    lines = readme.read_text().splitlines()
-    assert lines == [
+    expected_lines = [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         (
-            "- ❌ https://github.com/user/repo (failing runs: "
-            "https://github.com/user/repo/actions/runs/1, "
-            "https://github.com/user/repo/actions/runs/2)"
+            "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
+            "[lint](https://github.com/user/repo/actions/runs/2)) "
+            "**[repo](https://github.com/user/repo)** - desc"
         ),
     ]
+    assert readme.read_text().splitlines() == expected_lines
+
+    repo_status.update_readme(readme, now=now)
+
+    assert readme.read_text().splitlines() == expected_lines


### PR DESCRIPTION
### Motivation
- Make Related Projects failures actionable by linking directly to the failing workflow runs or reliable fallback URLs so maintainers know exactly what to inspect.  
- Preserve existing emoji-only API surface for backward compatibility while adding a structured type to support future metadata (e.g. star counts).  
- Keep README updates idempotent and robust across repeated hourly runs by collapsing old generated prefixes and duplicate timestamps.

### Description
- Add structured return types: `StatusLink(label: str, url: str)` and `RepoStatus(emoji: str, failure_links: tuple[StatusLink, ...])`, and keep `RepoStatusReport` as a compatibility alias.  
- Implement `fetch_repo_status_details(...) -> RepoStatus` that prefers `html_url`, falls back to a constructed Actions run URL from `id`, then existing fallback keys, collects all failed latest workflow attempts, deduplicates and sorts links deterministically, and preserves previous behavior for success/unknown/non-determinism.  
- Keep `fetch_repo_status(...)` as a wrapper returning only the emoji to avoid breaking callers.  
- Update `update_readme(...)` to use `fetch_repo_status_details`, render failing statuses as comma-separated Markdown links before the project entry (e.g. `- ❌ ([tests](...), [lint](...)) **[repo](...)** – description`), strip previously generated emoji/link prefixes idempotently, and collapse duplicate `_Last updated:` lines.
- Add helper rendering/cleanup: `_format_failure_links`, `_escape_markdown_link_label`, and `_strip_generated_status_prefix` to ensure generated Markdown is safe and stable.

### Testing
- Ran unit tests for the targeted module with `python -m pytest tests/test_repo_status.py -q`, which passed (`26 passed`).  
- Ran the full test suite with `python -m pytest -q`, which passed (`295 passed`).  
- Ran linting with `python -m ruff check src/repo_status.py tests/test_repo_status.py` and fixed minor Markdown punctuation per repo conventions, and ran the repo secret scan via `git diff --cached | ./scripts/scan-secrets.py` (no secrets found).  

All automated checks passed locally; the implementation preserves existing semantics and adds the requested actionable failure links while remaining network-free in tests via mocks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a270caa9a94832fb6bb27929da09a34)