### PR TITLE
docs: polish profile Related Projects copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Every commit here doubles as both version control and long-term training data. K
 Keep `llms.txt` synchronized with changes to this guide so LLMs stay current.
 
 The main `README.md` is intentionally minimal to maintain a clean GitHub profile.
-Avoid adding setup or asset instructions there; link to `docs/repository-guide.md` or INSTRUCTIONS instead.
+Avoid adding detailed setup, asset, or automation instructions there; those belong in `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md`.
 
 ## Key Information
 
@@ -129,7 +129,7 @@ YouTube Data API for upload.
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in `docs/repository-guide.md`, INSTRUCTIONS, or RUNBOOK.
+- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md`.
 - [Repository guide](docs/repository-guide.md): repo-internal map, setup pointers, automation, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
 - Avoid detailed how-tos like subtitle downloading; store them in other docs.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
@@ -145,7 +145,7 @@ Tests under `tests/` cover folder naming (`test_folder_names.py`), schema valida
 
 ### Optional
 - [Contributing guide](CONTRIBUTING.md): PR etiquette and code style details.
-- For cross-project synergy, see the README's **Other Projects** links or explore the [axel](https://github.com/futuroptimist/axel), [gitshelves](https://github.com/futuroptimist/gitshelves), [wove](https://github.com/futuroptimist/wove), and [sugarkube](https://github.com/futuroptimist/sugarkube) repos.
+- For cross-project synergy, see the README's **Related Projects** links or explore the [axel](https://github.com/futuroptimist/axel), [gitshelves](https://github.com/futuroptimist/gitshelves), [wove](https://github.com/futuroptimist/wove), and [sugarkube](https://github.com/futuroptimist/sugarkube) repos.
 
 ---
 *For creative context, tone, and thematic constraints refer to [`llms.txt`](llms.txt).* 

--- a/README.md
+++ b/README.md
@@ -16,22 +16,24 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 ## Related Projects
 _Last updated: 2026-06-08 19:41 UTC; checks hourly_
 
-Status legend: ✅ latest completed checks passed, ❌ latest completed checks failed or were cancelled, ❓ no completed checks were found yet.
+Selected projects from this GitHub account, spanning creative infrastructure, local-first tools, maker hardware, and playful learning systems. Status links appear only when a project has a recent run that needs attention, so the next maintainer has a direct place to inspect.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for turning maker experiments into reproducible scripts, metadata, and polished Futuroptimist episodes
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention, with linked failures pointing to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried.
+
+- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for turning maker videos into reusable scripts, metadata, and editing workflows
 - ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network for sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ❓ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles lint, tests, docs, release automation, and LLM-agent workflows for solo builders (failing runs: https://github.com/futuroptimist/flywheel/actions/runs/27123196602)
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching (failing runs: https://github.com/futuroptimist/gabriel/actions/runs/21579647496, https://github.com/futuroptimist/gabriel/actions/runs/21348015488, https://github.com/futuroptimist/gabriel/actions/runs/21127165452, https://github.com/futuroptimist/gabriel/actions/runs/20909714496, https://github.com/futuroptimist/gabriel/actions/runs/20706713112, https://github.com/futuroptimist/gabriel/actions/runs/20566165837, https://github.com/futuroptimist/gabriel/actions/runs/20423408130, https://github.com/futuroptimist/gabriel/actions/runs/20222249132, https://github.com/futuroptimist/gabriel/actions/runs/20018430344, https://github.com/futuroptimist/gabriel/actions/runs/19421904742)
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex task pages, grabs failing GitHub logs, and copies concise debugging reports
+- ❓ **[DSPACE](https://democratized.space)** @v3 – offline-first idle sim where quests teach real-world hobbies with NPC guides and retro-futurist worldbuilding ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, release automation, and LLM-agent workflows in one starter repo
+- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex task pages, collects failing GitHub logs, and copies concise debugging reports
 - ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repos and curates next steps to keep side projects moving
 - ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control in a 3D-printed case
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns GitHub contributions into stackable 3D-printable Gridfinity blocks
+- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – tool that turns GitHub contributions into stackable 3D-printable Gridfinity blocks
 - ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning knitting and crochet while exploring CAD-to-textile workflows
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters (failing runs: https://github.com/futuroptimist/sugarkube/actions/runs/27055466699)
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that safely closes stale pull requests in bulk with dry-run support
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot sharing the same automation scaffold as this repo
+- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
+- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite and Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built around reusable automation and application-tracking workflows
 
 ## Values
 

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -43,27 +43,11 @@ Prompt templates stay grouped under [`docs/prompts/codex/`](prompts/codex/) with
 
 ## Setup and package notes
 
-Python dependencies are managed with [`uv`](https://docs.astral.sh/uv/) and traditional requirement files.
+Python dependencies are managed with [`uv`](https://docs.astral.sh/uv/) and traditional requirement files. Treat [`INSTRUCTIONS.md`](../INSTRUCTIONS.md) as the canonical full workflow for environment setup, fallback commands, and contributor onboarding; this guide intentionally stays at overview level so the command list does not drift in multiple places.
 
-Common setup and verification commands:
+For day-to-day work, use the [`Makefile`](../Makefile) targets for setup, formatting, tests, subtitles, asset indexing, and rendering. The Makefile includes Windows/Unix path detection, while [`INSTRUCTIONS.md`](../INSTRUCTIONS.md) records platform-specific fallback steps.
 
-```bash
-make setup      # create/sync the virtual environment
-make test       # run pytest through the Makefile
-make fmt        # black + ruff check --fix
-python -m pytest -q
-```
-
-If `make setup` fails on your platform, use the fallback described in [`INSTRUCTIONS.md`](../INSTRUCTIONS.md): create a Python 3.11+ virtual environment, install `requirements.txt`, then run pytest. The Makefile includes Windows/Unix path detection; if pytest cannot locate venv scripts, prefix commands with the venv `bin`/`Scripts` directory as documented in the instructions.
-
-Node is only used for repository hygiene scripts such as docs linting. The package manager is npm, with scripts defined in [`package.json`](../package.json):
-
-```bash
-npm run lint
-npm run format:check
-npm run test:ci
-npm run docs-lint
-```
+Node is only used for repository hygiene scripts such as docs linting. The package manager is npm, with available scripts defined in [`package.json`](../package.json).
 
 ## Automation and helper scripts
 


### PR DESCRIPTION
### Motivation
- Keep the top-level `README.md` profile-first while preserving the parseable Related Projects dashboard used by `src/repo_status.py`.
- Replace implementation-heavy status legend text with user-friendly wording that explains why failure links may appear without exposing test internals.
- Sweep related docs so repo-internal setup and automation guidance lives in `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md`, not the profile README.

### Description
- Rewrote the `## Related Projects` introduction and status legend in `README.md` to read like a curated developer portfolio and to explain failure links in user-friendly terms while preserving bullet parseability (`- ` plus GitHub URL on the same line).
- Removed hard-coded failing-run URLs and test-name mentions from the README bullets while leaving the README layout compatible with generated failure links produced by `src/repo_status.py`.
- Simplified `docs/repository-guide.md` setup/package notes to treat `INSTRUCTIONS.md` as the canonical full workflow and made the guide an overview rather than duplicating platform-specific command examples.
- Updated `AGENTS.md` to explicitly direct detailed setup, asset, and automation instructions to `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md`, and adjusted a few cross-doc references (docs/README and llms.txt already reference `docs/repository-guide.md`).

### Testing
- Ran `python -m pytest tests/test_repo_status.py -q` which passed (36 passed).
- Ran the full test suite with `python -m pytest -q` which passed (`305 passed, 2 warnings`).
- Ran docs lint with `npm run docs-lint` which completed successfully.
- Ran the repo secret scan with `git diff --cached | ./scripts/scan-secrets.py` which produced no findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271b6456bc832faa780a11992be72c)