### PR TITLE
docs: polish profile Related Projects and repo-internals guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Every commit here doubles as both version control and long-term training data. K
 Keep `llms.txt` synchronized with changes to this guide so LLMs stay current.
 
 The main `README.md` is intentionally minimal to maintain a clean GitHub profile.
-Avoid adding setup or asset instructions there; link to `docs/repository-guide.md` or INSTRUCTIONS instead.
+Avoid adding setup, asset, or automation instructions there; route those details to `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md` instead.
 
 ## Key Information
 
@@ -129,7 +129,7 @@ YouTube Data API for upload.
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in `docs/repository-guide.md`, INSTRUCTIONS, or RUNBOOK.
+- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md`.
 - [Repository guide](docs/repository-guide.md): repo-internal map, setup pointers, automation, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
 - Avoid detailed how-tos like subtitle downloading; store them in other docs.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.

--- a/README.md
+++ b/README.md
@@ -16,22 +16,24 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 ## Related Projects
 _Last updated: 2026-06-08 19:41 UTC; checks hourly_
 
-Status legend: ✅ latest completed checks passed, ❌ latest completed checks failed or were cancelled, ❓ no completed checks were found yet.
+Selected projects across this GitHub account, from infrastructure experiments to maker-friendly learning tools. Each entry links to its code so you can inspect the build, reuse the patterns, or follow the next iteration.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for turning maker experiments into reproducible scripts, metadata, and polished Futuroptimist episodes
-- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network for sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention, and any linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried.
+
+- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for repeatable video scripts, metadata, captions, assets, and GitHub-status automation
+- ✅ **[token.place](https://token.place)** – peer-to-peer generative AI network for sharing idle compute with short-lived encrypted access tokens ([repo](https://github.com/futuroptimist/token.place))
 - ❓ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles lint, tests, docs, release automation, and LLM-agent workflows for solo builders (failing runs: https://github.com/futuroptimist/flywheel/actions/runs/27123196602)
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching (failing runs: https://github.com/futuroptimist/gabriel/actions/runs/21579647496, https://github.com/futuroptimist/gabriel/actions/runs/21348015488, https://github.com/futuroptimist/gabriel/actions/runs/21127165452, https://github.com/futuroptimist/gabriel/actions/runs/20909714496, https://github.com/futuroptimist/gabriel/actions/runs/20706713112, https://github.com/futuroptimist/gabriel/actions/runs/20566165837, https://github.com/futuroptimist/gabriel/actions/runs/20423408130, https://github.com/futuroptimist/gabriel/actions/runs/20222249132, https://github.com/futuroptimist/gabriel/actions/runs/20018430344, https://github.com/futuroptimist/gabriel/actions/runs/19421904742)
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex task pages, grabs failing GitHub logs, and copies concise debugging reports
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repos and curates next steps to keep side projects moving
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control in a 3D-printed case
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns GitHub contributions into stackable 3D-printable Gridfinity blocks
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning knitting and crochet while exploring CAD-to-textile workflows
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters (failing runs: https://github.com/futuroptimist/sugarkube/actions/runs/27055466699)
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that safely closes stale pull requests in bulk with dry-run support
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot sharing the same automation scaffold as this repo
+- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want lint, tests, docs, release automation, and LLM-agent workflows in one scaffold
+- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first guardian LLM concept for local, actionable security coaching
+- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-assisted quest tracker that reads repos and suggests next steps for side-project momentum
+- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – ESP32 AI pin prototype with push-to-talk voice control and a 3D-printed enclosure
+- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – tool that turns GitHub contribution history into stackable 3D-printable Gridfinity blocks
+- ✅ **[wove](https://github.com/futuroptimist/wove)** – learning toolkit for knitting, crochet, and CAD-to-textile workflows
+- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk, with dry-run support
+- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite and Three.js portfolio playground with an orthographic, keyboard-navigable scene
+- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as these maker tools
 
 ## Values
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## Repository guide
 
-- [repository-guide.md](repository-guide.md) — Repo-internal map, setup pointers, automation, scripts, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
+- [repository-guide.md](repository-guide.md) — Canonical repo-internals overview for setup pointers, automation, scripts, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
 
 ## Prompt docs (Codex)
 

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -1,6 +1,6 @@
 # Futuroptimist Repository Guide
 
-This repository is the working production hub for the Futuroptimist YouTube/GitHub project. The public `README.md` stays profile-first; this guide collects the repo-internal map, setup pointers, automation notes, metadata workflow, subtitle tooling, and YouTube Transcript MCP service details.
+This repository is the working production hub for the Futuroptimist YouTube/GitHub project. The public `README.md` stays profile-first; this guide collects the repo-internal map, setup pointers, automation notes, metadata workflow, subtitle tooling, and YouTube Transcript MCP service details at an overview level.
 
 ## Repository purpose
 
@@ -13,7 +13,7 @@ The repo hosts scripts, metadata, prompt docs, test fixtures, and production che
 - maintaining Codex prompt docs and cross-repo automation; and
 - exposing a local YouTube transcript CLI/API/MCP service for retrieval workflows.
 
-For the full contributor workflow and roadmap, see [`INSTRUCTIONS.md`](../INSTRUCTIONS.md). For the production checklist, see [`RUNBOOK.md`](../RUNBOOK.md). AI-agent guidance lives in [`AGENTS.md`](../AGENTS.md), with creative context mirrored in [`llms.txt`](../llms.txt).
+For the full contributor workflow and roadmap, see [`INSTRUCTIONS.md`](../INSTRUCTIONS.md); this guide intentionally summarizes rather than duplicating every setup and release command. For the production checklist, see [`RUNBOOK.md`](../RUNBOOK.md). AI-agent guidance lives in [`AGENTS.md`](../AGENTS.md), with creative context mirrored in [`llms.txt`](../llms.txt).
 
 ## Map of the repo
 
@@ -75,7 +75,7 @@ The repository aims to make video creation as repeatable as software delivery. K
 - `python src/collect_sources.py` – download reference files from configured source URL lists for citation/research workflows.
 - `python src/newsletter_builder.py` or `make newsletter` – assemble Markdown digests of recent videos.
 - `python src/fact_check_discussions.py` – export Futuroptimist GitHub Discussions fact-check threads to JSON.
-- `python src/repo_status.py` – update the parseable `README.md` Related Projects dashboard with check-status emoji, timestamps, and direct failed-run links.
+- `python src/repo_status.py` – update the parseable `README.md` Related Projects dashboard with check-status emoji, one timestamp, and direct failed-run links when relevant.
 
 Run `make help` to see the current target list.
 


### PR DESCRIPTION
### Motivation

- Make the top-level `README.md` feel like an account profile while keeping a single clear link to the repo-internals guide. 
- Polish the account-level Related Projects copy and status legend so it reads like a curated developer portfolio and avoids implementation-heavy details. 
- Keep the `README.md` layout parseable by `src/repo_status.py` (leading `- ` bullets with GitHub URLs on the same line) and remove ad-hoc live failure-run suffixes that the status updater will manage. 

### Description

- Rewrote the `## Related Projects` intro and status legend in `README.md` to be portfolio-oriented, user-friendly, and compatible with the status updater, while preserving `- ` bullets and same-line GitHub repo URLs. 
- Removed inline, implementation-heavy failure-run suffixes from README entries and clarified that any failure links added by automation point at the run or asset to inspect. 
- Updated `AGENTS.md` to route setup/asset/automation instructions to `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md` rather than the profile README. 
- Clarified `docs/repository-guide.md` as the canonical repo-internals overview (summarizes instead of duplicating full workflows) and noted that `src/repo_status.py` writes a single timestamp line and adds failure links when relevant; also adjusted `docs/README.md` wording to surface the repository guide. 

### Testing

- Ran `python -m pytest tests/test_repo_status.py -q` and observed `36 passed` (success). 
- Ran `python -m pytest -q` (the full suite): an initial run failed due to missing optional deps, then I installed dev requirements with `python -m pip install -e '.[dev]'` and re-ran the suite, resulting in `305 passed, 2 warnings` (success). 
- Ran `npm run docs-lint` (docs lint checks) which completed without errors (success). 
- Ran `git diff --cached | ./scripts/scan-secrets.py` on the staged changes and detected no secrets (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271b6456bc832faa780a11992be72c)