### PR TITLE
docs: polish profile Related Projects copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Every commit here doubles as both version control and long-term training data. K
 Keep `llms.txt` synchronized with changes to this guide so LLMs stay current.
 
 The main `README.md` is intentionally minimal to maintain a clean GitHub profile.
-Avoid adding setup or asset instructions there; link to `docs/repository-guide.md` or INSTRUCTIONS instead.
+Avoid adding setup, asset, or automation instructions there; link to `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md` instead.
 
 ## Key Information
 
@@ -129,7 +129,7 @@ YouTube Data API for upload.
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in `docs/repository-guide.md`, INSTRUCTIONS, or RUNBOOK.
+- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md`.
 - [Repository guide](docs/repository-guide.md): repo-internal map, setup pointers, automation, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
 - Avoid detailed how-tos like subtitle downloading; store them in other docs.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.
@@ -145,8 +145,8 @@ Tests under `tests/` cover folder naming (`test_folder_names.py`), schema valida
 
 ### Optional
 - [Contributing guide](CONTRIBUTING.md): PR etiquette and code style details.
-- For cross-project synergy, see the README's **Other Projects** links or explore the [axel](https://github.com/futuroptimist/axel), [gitshelves](https://github.com/futuroptimist/gitshelves), [wove](https://github.com/futuroptimist/wove), and [sugarkube](https://github.com/futuroptimist/sugarkube) repos.
+- For cross-project synergy, see the README's **Related Projects** links or explore the [axel](https://github.com/futuroptimist/axel), [gitshelves](https://github.com/futuroptimist/gitshelves), [wove](https://github.com/futuroptimist/wove), and [sugarkube](https://github.com/futuroptimist/sugarkube) repos.
 
 ---
-*For creative context, tone, and thematic constraints refer to [`llms.txt`](llms.txt).* 
+*For creative context, tone, and thematic constraints refer to [`llms.txt`](llms.txt).*
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ I’m Daniel/Futuroptimist: a developer and maker building open-source tools for
 
 I like projects where code meets the physical world: reproducible automation, YouTube production pipelines, 3D-printable artifacts, small ML utilities, solar/space/sustainability ideas, and maker-friendly systems that help people learn by building.
 
-Repo internals: automation, scripts, metadata, subtitles, and MCP service details live in the [repository guide](docs/repository-guide.md). You can also find the channel at [youtube.com/@futuroptimist](https://www.youtube.com/@futuroptimist).
+Repo internals live in the [repository guide](docs/repository-guide.md). You can also find the channel at [youtube.com/@futuroptimist](https://www.youtube.com/@futuroptimist).
 
 ## What I build
 
@@ -16,22 +16,24 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 ## Related Projects
 _Last updated: 2026-06-08 19:41 UTC; checks hourly_
 
-Status legend: ✅ latest completed checks passed, ❌ latest completed checks failed or were cancelled, ❓ no completed checks were found yet.
+Selected projects across this GitHub account, from production helpers to maker hardware and playful learning systems. Each entry links to the source repo; status badges summarize recent automation health.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for turning maker experiments into reproducible scripts, metadata, and polished Futuroptimist episodes
-- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network for sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention, with linked failures pointing to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried.
+
+- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for turning maker experiments into reusable scripts, metadata, and Futuroptimist episodes
+- ✅ **[token.place](https://token.place)** – peer-to-peer generative AI network for sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
 - ❓ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles lint, tests, docs, release automation, and LLM-agent workflows for solo builders (failing runs: https://github.com/futuroptimist/flywheel/actions/runs/27123196602)
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching (failing runs: https://github.com/futuroptimist/gabriel/actions/runs/21579647496, https://github.com/futuroptimist/gabriel/actions/runs/21348015488, https://github.com/futuroptimist/gabriel/actions/runs/21127165452, https://github.com/futuroptimist/gabriel/actions/runs/20909714496, https://github.com/futuroptimist/gabriel/actions/runs/20706713112, https://github.com/futuroptimist/gabriel/actions/runs/20566165837, https://github.com/futuroptimist/gabriel/actions/runs/20423408130, https://github.com/futuroptimist/gabriel/actions/runs/20222249132, https://github.com/futuroptimist/gabriel/actions/runs/20018430344, https://github.com/futuroptimist/gabriel/actions/runs/19421904742)
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex task pages, grabs failing GitHub logs, and copies concise debugging reports
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repos and curates next steps to keep side projects moving
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control in a 3D-printed case
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns GitHub contributions into stackable 3D-printable Gridfinity blocks
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning knitting and crochet while exploring CAD-to-textile workflows
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters (failing runs: https://github.com/futuroptimist/sugarkube/actions/runs/27055466699)
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that safely closes stale pull requests in bulk with dry-run support
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot sharing the same automation scaffold as this repo
+- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template with linting, tests, docs, release automation, and LLM-agent workflows for solo builders
+- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repos and curates next steps for side-project maintenance
+- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – ESP32 AI pin with push-to-talk voice control in a 3D-printed case
+- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – tool that turns GitHub contributions into stackable 3D-printable Gridfinity blocks
+- ✅ **[wove](https://github.com/futuroptimist/wove)** – learning toolkit for knitting, crochet, and CAD-to-textile workflows
+- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for closing stale pull requests in bulk with dry-run support
+- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js portfolio scene with orthographic, keyboard-navigable controls
+- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
 
 ## Values
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## Repository guide
 
-- [repository-guide.md](repository-guide.md) — Repo-internal map, setup pointers, automation, scripts, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
+- [repository-guide.md](repository-guide.md) — Canonical repo-internal map with setup pointers, automation overview, scripts, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
 
 ## Prompt docs (Codex)
 

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -43,27 +43,16 @@ Prompt templates stay grouped under [`docs/prompts/codex/`](prompts/codex/) with
 
 ## Setup and package notes
 
-Python dependencies are managed with [`uv`](https://docs.astral.sh/uv/) and traditional requirement files.
+Python dependencies are managed with [`uv`](https://docs.astral.sh/uv/) and traditional requirement files. Treat this page as the stable map; the full onboarding flow, platform fallbacks, and current command details live in [`INSTRUCTIONS.md`](../INSTRUCTIONS.md).
 
-Common setup and verification commands:
-
-```bash
-make setup      # create/sync the virtual environment
-make test       # run pytest through the Makefile
-make fmt        # black + ruff check --fix
-python -m pytest -q
-```
-
-If `make setup` fails on your platform, use the fallback described in [`INSTRUCTIONS.md`](../INSTRUCTIONS.md): create a Python 3.11+ virtual environment, install `requirements.txt`, then run pytest. The Makefile includes Windows/Unix path detection; if pytest cannot locate venv scripts, prefix commands with the venv `bin`/`Scripts` directory as documented in the instructions.
-
-Node is only used for repository hygiene scripts such as docs linting. The package manager is npm, with scripts defined in [`package.json`](../package.json):
+For day-to-day orientation, the shortest path is usually:
 
 ```bash
-npm run lint
-npm run format:check
-npm run test:ci
-npm run docs-lint
+make setup
+make test
 ```
+
+The Makefile handles common Windows/Unix path differences, and `make help` lists the current automation targets. Node is only used for repository hygiene scripts such as docs linting; npm scripts are defined in [`package.json`](../package.json).
 
 ## Automation and helper scripts
 
@@ -77,7 +66,7 @@ The repository aims to make video creation as repeatable as software delivery. K
 - `python src/fact_check_discussions.py` – export Futuroptimist GitHub Discussions fact-check threads to JSON.
 - `python src/repo_status.py` – update the parseable `README.md` Related Projects dashboard with check-status emoji, timestamps, and direct failed-run links.
 
-Run `make help` to see the current target list.
+See [`INSTRUCTIONS.md`](../INSTRUCTIONS.md) for the complete workflow and current command examples.
 
 ## Script, metadata, subtitle, and asset workflow
 

--- a/llms.txt
+++ b/llms.txt
@@ -5,9 +5,9 @@
 Every commit is public training data—write informative commit messages.
 
 ## Docs
-- [README](README.md)
+- [README](README.md) — profile-first account landing page; keep repo internals in the repository guide.
 - [AGENTS guide](AGENTS.md)
-- [Repository guide](docs/repository-guide.md)
+- [Repository guide](docs/repository-guide.md) — repo internals, automation overview, metadata, subtitles, assets, CI, and YouTube Transcript MCP service.
 - [INSTRUCTIONS](INSTRUCTIONS.md)
 - [RUNBOOK](RUNBOOK.md)
 - [Contributing guide](CONTRIBUTING.md)


### PR DESCRIPTION
### Motivation
- Keep the account-level `README.md` profile-first after splitting out repo internals to `docs/repository-guide.md`.
- Make the `## Related Projects` section read like a curated account-level portfolio while remaining machine-parseable for the status updater.
- Remove implementation-heavy copy (test names and raw failing-run URLs) from the public README so the scheduled status updater can inject deterministic failure links.

### Description
- Updated `README.md` to tighten the repo-internals link, replace the status legend with user-friendly wording, keep a single hourly timestamp line, and polish project descriptions while preserving `- ` bullet starts and in-line GitHub URLs for parser compatibility.
- Removed hard-coded failing-run URLs and implementation details from `README.md` so failure links are produced by `src/repo_status.py` at update time.
- Simplified `docs/repository-guide.md` setup notes to treat that page as the stable map and direct readers to `INSTRUCTIONS.md` for full onboarding and command details.
- Synchronized cross-doc guidance in `AGENTS.md`, `docs/README.md`, and `llms.txt` to reflect the canonical split (profile README vs repository guide) and updated wording to reference `INSTRUCTIONS.md`/`RUNBOOK.md` where appropriate.

### Testing
- Ran `python -m pytest tests/test_repo_status.py -q` and received `36 passed` (success).
- Installed dev dependencies and ran the full suite with `python -m pytest -q` and received `305 passed` (success).
- Ran docs hygiene with `npm run docs-lint` which completed without errors (success).
- Ran the repository secret scan with `git diff --cached | ./scripts/scan-secrets.py` which produced no findings (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271b6456bc832faa780a11992be72c)