### PR TITLE
docs: polish profile README Related Projects and align docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Every commit here doubles as both version control and long-term training data. K
 Keep `llms.txt` synchronized with changes to this guide so LLMs stay current.
 
 The main `README.md` is intentionally minimal to maintain a clean GitHub profile.
-Avoid adding setup or asset instructions there; link to `docs/repository-guide.md` or INSTRUCTIONS instead.
+Avoid adding setup, asset, or automation instructions there; link to `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md` instead.
 
 ## Key Information
 
@@ -129,7 +129,7 @@ YouTube Data API for upload.
 ## Additional Resources (File List)
 
 ### Documentation
-- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in `docs/repository-guide.md`, INSTRUCTIONS, or RUNBOOK.
+- [README](README.md): concise because it doubles as the GitHub profile. Do **not** include Makefile commands, footage instructions, or other setup details here—they belong in `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md`.
 - [Repository guide](docs/repository-guide.md): repo-internal map, setup pointers, automation, metadata, subtitles, assets, CI, and YouTube Transcript MCP service details.
 - Avoid detailed how-tos like subtitle downloading; store them in other docs.
 - [INSTRUCTIONS](INSTRUCTIONS.md): full workflow and roadmap.

--- a/README.md
+++ b/README.md
@@ -16,22 +16,24 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 ## Related Projects
 _Last updated: 2026-06-08 19:41 UTC; checks hourly_
 
-Status legend: ✅ latest completed checks passed, ❌ latest completed checks failed or were cancelled, ❓ no completed checks were found yet.
+Selected projects across this GitHub account, grouped as a compact portfolio map rather than a dependency list. Each entry links to its GitHub repo so the hourly status updater can keep the health marker current; failure links, when present, point directly to the run or artifact worth inspecting.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for turning maker experiments into reproducible scripts, metadata, and polished Futuroptimist episodes
-- ✅ **[token.place](https://token.place)** – secure peer-to-peer generative AI network for sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried.
+
+- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
+- ✅ **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
 - ❓ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template that bundles lint, tests, docs, release automation, and LLM-agent workflows for solo builders (failing runs: https://github.com/futuroptimist/flywheel/actions/runs/27123196602)
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching (failing runs: https://github.com/futuroptimist/gabriel/actions/runs/21579647496, https://github.com/futuroptimist/gabriel/actions/runs/21348015488, https://github.com/futuroptimist/gabriel/actions/runs/21127165452, https://github.com/futuroptimist/gabriel/actions/runs/20909714496, https://github.com/futuroptimist/gabriel/actions/runs/20706713112, https://github.com/futuroptimist/gabriel/actions/runs/20566165837, https://github.com/futuroptimist/gabriel/actions/runs/20423408130, https://github.com/futuroptimist/gabriel/actions/runs/20222249132, https://github.com/futuroptimist/gabriel/actions/runs/20018430344, https://github.com/futuroptimist/gabriel/actions/runs/19421904742)
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI that parses Codex task pages, grabs failing GitHub logs, and copies concise debugging reports
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repos and curates next steps to keep side projects moving
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control in a 3D-printed case
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – turns GitHub contributions into stackable 3D-printable Gridfinity blocks
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – open toolkit for learning knitting and crochet while exploring CAD-to-textile workflows
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters (failing runs: https://github.com/futuroptimist/sugarkube/actions/runs/27055466699)
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow that safely closes stale pull requests in bulk with dry-run support
+- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
+- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
+- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
+- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
+- ✅ **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
+- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
 - ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot sharing the same automation scaffold as this repo
+- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
 
 ## Values
 

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -43,9 +43,9 @@ Prompt templates stay grouped under [`docs/prompts/codex/`](prompts/codex/) with
 
 ## Setup and package notes
 
-Python dependencies are managed with [`uv`](https://docs.astral.sh/uv/) and traditional requirement files.
+Python dependencies are managed with [`uv`](https://docs.astral.sh/uv/) and traditional requirement files. This section is an overview for orientation; keep the full contributor workflow, platform fallbacks, and long-form setup steps in [`INSTRUCTIONS.md`](../INSTRUCTIONS.md) so they do not drift across multiple docs.
 
-Common setup and verification commands:
+Common entry points:
 
 ```bash
 make setup      # create/sync the virtual environment
@@ -54,7 +54,7 @@ make fmt        # black + ruff check --fix
 python -m pytest -q
 ```
 
-If `make setup` fails on your platform, use the fallback described in [`INSTRUCTIONS.md`](../INSTRUCTIONS.md): create a Python 3.11+ virtual environment, install `requirements.txt`, then run pytest. The Makefile includes Windows/Unix path detection; if pytest cannot locate venv scripts, prefix commands with the venv `bin`/`Scripts` directory as documented in the instructions.
+If an environment-specific setup path is needed, follow the fallback notes in [`INSTRUCTIONS.md`](../INSTRUCTIONS.md). The Makefile includes Windows/Unix path detection, and the instructions document the venv path prefixes to use when local tooling cannot find pytest or `yt-dlp`.
 
 Node is only used for repository hygiene scripts such as docs linting. The package manager is npm, with scripts defined in [`package.json`](../package.json):
 

--- a/llms.txt
+++ b/llms.txt
@@ -5,9 +5,9 @@
 Every commit is public training data—write informative commit messages.
 
 ## Docs
-- [README](README.md)
+- [README](README.md) — profile-first GitHub account landing page
 - [AGENTS guide](AGENTS.md)
-- [Repository guide](docs/repository-guide.md)
+- [Repository guide](docs/repository-guide.md) — repo internals, automation, metadata, subtitles, assets, CI, and YouTube Transcript MCP overview
 - [INSTRUCTIONS](INSTRUCTIONS.md)
 - [RUNBOOK](RUNBOOK.md)
 - [Contributing guide](CONTRIBUTING.md)

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1396,3 +1396,23 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
         "- ✅ ([debug run](https://github.com/user/repo/actions/runs/123)) "
         "https://github.com/user/repo - desc",
     ]
+
+
+def test_profile_readme_related_projects_copy_is_parseable() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+    section = readme.split("## Related Projects", 1)[1].split("\n## ", 1)[0]
+
+    assert section.count("_Last updated:") == 1
+    assert "tests/test_" not in section
+    assert "failing runs:" not in section
+    assert "✅ latest relevant run succeeded" in section
+    assert "❌ one or more relevant runs need attention" in section
+    assert (
+        "❓ no completed relevant run was found or GitHub could not be queried"
+        in section
+    )
+    assert readme.count("docs/repository-guide.md") == 1
+
+    project_lines = [line for line in section.splitlines() if line.startswith("- ")]
+    assert project_lines
+    assert all(repo_status.GITHUB_RE.search(line) for line in project_lines)

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -6,6 +6,8 @@ import pytest
 from src import repo_status
 from src.repo_status import status_to_emoji
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 def test_status_to_emoji() -> None:
     assert status_to_emoji("success") == "✅"
@@ -1399,7 +1401,7 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
 
 
 def test_profile_readme_related_projects_copy_is_parseable() -> None:
-    readme = Path("README.md").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     section = readme.split("## Related Projects", 1)[1].split("\n## ", 1)[0]
 
     assert section.count("_Last updated:") == 1


### PR DESCRIPTION
### Motivation
- Make the top-level `README.md` read like a GitHub profile landing page while keeping one clear link to repo internals, and make the Related Projects section friendlier and easier to scan. 
- Remove implementation-heavy failure text from the profile copy while preserving the parseable format required by `src/repo_status.py`.
- Sweep related docs so guidance about setup, automation, and long-form workflows points to the canonical internals doc rather than appearing in the profile README.

### Description
- Revise `README.md` Related Projects block to add a short curated intro, a user-friendly status legend, a single hourly timestamp line, compact concrete descriptions, and no hand-coded "failing runs:" URL lists while keeping each project bullet starting with `- ` and containing the GitHub URL on the same line for the status updater to parse. 
- Update `AGENTS.md` to explicitly send readers to `docs/repository-guide.md`, `INSTRUCTIONS.md`, or `RUNBOOK.md` for setup/asset/automation instructions instead of the profile README. 
- Tweak `docs/repository-guide.md` to describe setup commands as overview/entry points and point contributors to `INSTRUCTIONS.md` for full platform fallbacks and long-form onboarding steps. 
- Sync `llms.txt` to reflect that `README.md` is profile-first and `docs/repository-guide.md` is the internals overview. 
- Add a focused regression test in `tests/test_repo_status.py` that asserts the Related Projects section is parseable by the status updater (single timestamp line, friendly legend wording, no legacy failure-run text, presence of GitHub URLs, and exactly one repository-guide link).

### Testing
- Ran `black tests/test_repo_status.py` to reformat the updated test file; the formatter completed successfully. (success)
- Ran `python -m pytest tests/test_repo_status.py -q` to validate the new parseability test and related unit tests; the targeted suite passed. (success)
- Ran the full test suite with `python -m pytest -q`; all tests passed (306 passed). (success)
- Ran docs hygiene check `npm run docs-lint`; it completed successfully. (success)
- Ran the repository secret-scan `git diff --cached | ./scripts/scan-secrets.py`; no issues were reported. (success)

If you'd like, I can split the README changes into a smaller editorial commit or follow up by preparing the short entry for `CHANGELOG.md` describing this docs pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271b6456bc832faa780a11992be72c)