### PR TITLE
Add star counts and sort Related Projects by stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 - **Open learning systems** that document the path from rough idea to reusable project.
 
 ## Related Projects
-_Last updated: 2026-06-08 19:41 UTC; checks hourly_
+_Last updated: 2026-06-08 20:03 UTC; checks hourly_
 
 Selected projects across this GitHub account, grouped as a compact portfolio map rather than a dependency list. Each entry links to its GitHub repo so the hourly status updater can keep the health marker current; failure links, when present, point directly to the run or artifact worth inspecting.
 
-Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried.
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows the current GitHub star count when available. Projects are sorted by stars descending, then alphabetically for ties.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
-- ✅ **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ❓ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 6 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+- ❓ ⭐ 3 **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ❌ ([Update Repo Statuses](https://github.com/futuroptimist/flywheel/actions/runs/27123196602)) <!-- repo-status:failure-links --> ⭐ 2 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
+- ✅ ⭐ 1 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ ⭐ 1 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
+- ✅ ⭐ 0 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
+- ✅ ⭐ 0 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ ⭐ 0 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
+- ❌ ([docker in /docker - Update #1154241084](https://github.com/futuroptimist/gabriel/actions/runs/19421904742), [Security Scans #10](https://github.com/futuroptimist/gabriel/actions/runs/20566165837), [Security Scans #11](https://github.com/futuroptimist/gabriel/actions/runs/20706713112), [Security Scans #12](https://github.com/futuroptimist/gabriel/actions/runs/20909714496), [Security Scans #13](https://github.com/futuroptimist/gabriel/actions/runs/21127165452), [Security Scans #14](https://github.com/futuroptimist/gabriel/actions/runs/21348015488), [Security Scans #15](https://github.com/futuroptimist/gabriel/actions/runs/21579647496), [Security Scans #7](https://github.com/futuroptimist/gabriel/actions/runs/20018430344), [Security Scans #8](https://github.com/futuroptimist/gabriel/actions/runs/20222249132), [Security Scans #9](https://github.com/futuroptimist/gabriel/actions/runs/20423408130)) <!-- repo-status:failure-links --> ⭐ 0 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ ⭐ 0 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
+- ✅ ⭐ 0 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 0 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
+- ❌ ([.github/workflows/tests.yml](https://github.com/futuroptimist/sugarkube/actions/runs/27055466699)) <!-- repo-status:failure-links --> ⭐ 0 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ ⭐ 0 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
 
 ## Values
 

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -1,9 +1,9 @@
-"""Update README with repo status emojis.
+"""Update README Related Projects with statuses, star counts, and sorting.
 
-Fetches the latest GitHub Actions run for each repo listed in the README's
-"Related Projects" section and prepends a green check, red cross, or question
-mark depending on whether the most recent workflow run on the default branch
-completed successfully, failed, or hasn't completed.
+Fetches repository metadata and the latest relevant GitHub Actions run for each
+repo listed in the README's "Related Projects" section. Each project bullet gets
+a status emoji, optional failure links, and a GitHub star count before the list is
+sorted by stars descending and alphabetically for ties.
 """
 
 from __future__ import annotations
@@ -30,15 +30,20 @@ class StatusLink:
 
 
 @dataclass(frozen=True)
-class RepoStatus:
-    """Rendered status plus optional direct links for failed checks.
+class RepoMetadata:
+    """Repository metadata used by the README status renderer."""
 
-    The structured shape leaves room for future repository metadata without
-    changing the public status-details API again.
-    """
+    default_branch: str | None = None
+    stars: int | None = None
+
+
+@dataclass(frozen=True)
+class RepoStatus:
+    """Rendered status plus optional direct links and repository metadata."""
 
     emoji: str
     failure_links: tuple[StatusLink, ...] = field(default_factory=tuple)
+    stars: int | None = None
 
 
 @dataclass(frozen=True)
@@ -87,6 +92,58 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
+def _github_headers(token: str | None = None) -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
+    """Fetch default branch and stargazer count for ``repo``.
+
+    Errors and malformed payloads are non-fatal so a README rebuild can still
+    refresh status emojis and render an explicit unknown star marker.
+    """
+
+    try:
+        repo_resp = requests.get(
+            f"https://api.github.com/repos/{repo}",
+            headers=_github_headers(token),
+            timeout=10,
+        )
+        repo_resp.raise_for_status()
+        repo_data = repo_resp.json()
+    except (requests.exceptions.RequestException, ValueError) as exc:
+        LOGGER.warning("Unable to fetch repository metadata for %s: %s", repo, exc)
+        return RepoMetadata()
+    if not isinstance(repo_data, dict):
+        LOGGER.warning(
+            "Unexpected repository payload for %s: %r", repo, type(repo_data)
+        )
+        return RepoMetadata()
+
+    default_branch = repo_data.get("default_branch")
+    if not isinstance(default_branch, str) or not default_branch:
+        default_branch = None
+
+    raw_stars = repo_data.get("stargazers_count")
+    stars = (
+        raw_stars
+        if isinstance(raw_stars, int) and not isinstance(raw_stars, bool)
+        else None
+    )
+    if stars is None:
+        LOGGER.warning("Missing or invalid stargazer count for %s: %r", repo, raw_stars)
+    return RepoMetadata(default_branch, stars)
+
+
+def format_star_count(stars: int | None) -> str:
+    """Format a compact star count marker for README bullets."""
+
+    return f"⭐ {stars}" if stars is not None else "⭐ ?"
+
+
 def fetch_repo_status_details(
     repo: str,
     token: str | None = None,
@@ -101,26 +158,10 @@ def fetch_repo_status_details(
     ``RuntimeError`` so the calling workflow fails loudly.
     """
 
-    headers = {"Accept": "application/vnd.github+json"}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-
+    headers = _github_headers(token)
+    metadata = fetch_repo_metadata(repo, token)
     if branch is None:
-        try:
-            repo_resp = requests.get(
-                f"https://api.github.com/repos/{repo}", headers=headers, timeout=10
-            )
-            repo_resp.raise_for_status()
-            repo_data = repo_resp.json()
-        except (requests.exceptions.RequestException, ValueError) as exc:
-            LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return RepoStatus(status_to_emoji(None))
-        if not isinstance(repo_data, dict):
-            LOGGER.warning(
-                "Unexpected repository payload for %s: %r", repo, type(repo_data)
-            )
-            return RepoStatus(status_to_emoji(None))
-        branch = repo_data.get("default_branch")
+        branch = metadata.default_branch
 
     url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     if branch:
@@ -377,7 +418,9 @@ def fetch_repo_status_details(
         for link in links:
             if link not in failure_links:
                 failure_links.append(link)
-    return RepoStatus(status_to_emoji(conclusions[0]), tuple(failure_links))
+    return RepoStatus(
+        status_to_emoji(conclusions[0]), tuple(failure_links), metadata.stars
+    )
 
 
 def fetch_repo_status(
@@ -444,21 +487,186 @@ LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
 )
 
 
-def _strip_status_prefix(line: str) -> str:
-    """Remove generated status emojis and marked linked-failure prefixes."""
+STAR_PREFIX_RE = re.compile(r"^⭐\s*(?:\?|\d+)\s*")
+VISIBLE_MARKDOWN_LINK_RE = re.compile(
+    r"\*\*\[([^\]]+)\]\([^)]+\)\*\*|\[([^\]]+)\]\([^)]+\)"
+)
 
-    content = line[2:].lstrip()
+
+@dataclass(frozen=True)
+class RelatedProjectItem:
+    """A parsed Related Projects bullet plus continuation lines."""
+
+    first_line: str
+    continuation_lines: tuple[str, ...] = ()
+    cleaned: str = ""
+    repo: str | None = None
+    branch: str | None = None
+    sort_name: str = ""
+    status: RepoStatus | None = None
+
+
+def strip_project_prefix(line: str) -> str:
+    """Remove generated status, failure-link, and star prefixes idempotently."""
+
+    content = line[2:].lstrip() if line.startswith("- ") else line.lstrip()
     while True:
-        match = re.match(r"^([✅❌❓])\s*", content)
-        if not match:
-            return content
-        content = content[match.end() :].lstrip()
-        if match.group(1) == "❌":
+        original = content
+        emoji_match = re.match(r"^([✅❌❓])\s*", content)
+        if emoji_match:
+            content = content[emoji_match.end() :].lstrip()
             content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
             content = LEGACY_STACKED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
             content = LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE.sub(
                 "", content, count=1
             ).lstrip()
+        content = STAR_PREFIX_RE.sub("", content, count=1).lstrip()
+        content = re.sub(r"\s+\(failing runs: [^)]*\)$", "", content)
+        if content == original:
+            return content
+
+
+# Backward-compatible private name used by earlier tests and callers.
+def _strip_status_prefix(line: str) -> str:
+    """Remove generated project prefixes from a Markdown bullet."""
+
+    return strip_project_prefix(line)
+
+
+def _project_sort_name(cleaned: str, repo: str) -> str:
+    """Return the visible project name, falling back to owner/repo."""
+
+    match = VISIBLE_MARKDOWN_LINK_RE.search(cleaned)
+    if match:
+        return (match.group(1) or match.group(2) or repo).strip() or repo
+    return repo
+
+
+def parse_related_project_items(lines: list[str]) -> list[RelatedProjectItem]:
+    """Parse Markdown project bullets with indented continuation lines."""
+
+    items: list[RelatedProjectItem] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not line.startswith("- "):
+            index += 1
+            continue
+        continuation: list[str] = []
+        index += 1
+        while index < len(lines) and lines[index].startswith((" ", "\t")):
+            continuation.append(lines[index])
+            index += 1
+        cleaned = strip_project_prefix(line)
+        match = GITHUB_RE.search(cleaned)
+        repo = None
+        branch = None
+        sort_name = ""
+        if match:
+            repo = f"{match.group(1)}/{match.group(2)}"
+            branch = match.group(3)
+            sort_name = _project_sort_name(cleaned, repo)
+        items.append(
+            RelatedProjectItem(
+                first_line=line,
+                continuation_lines=tuple(continuation),
+                cleaned=cleaned,
+                repo=repo,
+                branch=branch,
+                sort_name=sort_name,
+            )
+        )
+    return items
+
+
+def render_project_item(item: RelatedProjectItem, details: RepoStatus) -> list[str]:
+    """Render one project item with a fresh status and star prefix."""
+
+    link_suffix = _format_failure_links(details.failure_links)
+    first_line = (
+        f"- {details.emoji}{link_suffix} {format_star_count(details.stars)} "
+        f"{item.cleaned}"
+    )
+    return [first_line, *item.continuation_lines]
+
+
+def sort_project_items(items: list[RelatedProjectItem]) -> list[RelatedProjectItem]:
+    """Sort project items by stars descending, then name case-insensitively."""
+
+    return sorted(
+        items,
+        key=lambda item: (
+            -(
+                item.status.stars
+                if item.status and item.status.stars is not None
+                else -1
+            ),
+            item.sort_name.casefold(),
+            item.repo or "",
+        ),
+    )
+
+
+def _render_related_project_block(
+    block: list[RelatedProjectItem], token: str | None
+) -> list[str]:
+    hydrated: list[RelatedProjectItem] = []
+    for item in block:
+        if item.repo is None:
+            hydrated.append(item)
+            continue
+        report = fetch_repo_status_details(item.repo, token, item.branch)
+        hydrated.append(
+            RelatedProjectItem(
+                item.first_line,
+                item.continuation_lines,
+                item.cleaned,
+                item.repo,
+                item.branch,
+                item.sort_name,
+                report,
+            )
+        )
+
+    rendered: list[str] = []
+    for item in sort_project_items(hydrated):
+        if item.status is None:
+            rendered.extend([item.first_line, *item.continuation_lines])
+        else:
+            rendered.extend(render_project_item(item, item.status))
+    return rendered
+
+
+def _update_related_section_lines(lines: list[str], token: str | None) -> list[str]:
+    """Refresh and sort project bullet blocks without moving prose."""
+
+    output: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not line.startswith("- "):
+            output.append(line)
+            index += 1
+            continue
+
+        raw_block: list[str] = []
+        while index < len(lines):
+            current = lines[index]
+            if current.startswith("- "):
+                raw_block.append(current)
+                index += 1
+                while index < len(lines) and lines[index].startswith((" ", "\t")):
+                    raw_block.append(lines[index])
+                    index += 1
+                continue
+            break
+
+        project_items = parse_related_project_items(raw_block)
+        if project_items and all(item.repo is not None for item in project_items):
+            output.extend(_render_related_project_block(project_items, token))
+        else:
+            output.extend(raw_block)
+    return output
 
 
 def update_readme(
@@ -466,14 +674,26 @@ def update_readme(
     token: str | None = None,
     now: datetime | None = None,
 ) -> None:
-    """Update README with status emojis, failure links, and a timestamp."""
+    """Update README with status emojis, star counts, failure links, and timestamp."""
+
     lines = readme_path.read_text(encoding="utf-8").splitlines()
-    in_section = False
     if now is None:
         now = datetime.now(UTC)
     timestamp = now.strftime("%Y-%m-%d %H:%M UTC")
     ts_line = f"_Last updated: {timestamp}; checks hourly_"
+
     output: list[str] = []
+    section_lines: list[str] = []
+    in_section = False
+
+    def flush_section() -> None:
+        nonlocal section_lines
+        filtered = [
+            line for line in section_lines if not line.startswith("_Last updated:")
+        ]
+        output.extend(_update_related_section_lines(filtered, token))
+        section_lines = []
+
     for line in lines:
         if line.strip() == "## Related Projects":
             in_section = True
@@ -481,20 +701,17 @@ def update_readme(
             output.append(ts_line)
             continue
         if in_section and line.startswith("## "):
+            flush_section()
             in_section = False
-        if in_section and line.startswith("_Last updated:"):
+            output.append(line)
             continue
-        if in_section and line.startswith("- "):
-            cleaned = _strip_status_prefix(line)
-            cleaned = re.sub(r"\s+\(failing runs: [^)]*\)$", "", cleaned)
-            match = GITHUB_RE.search(cleaned)
-            if match:
-                repo = f"{match.group(1)}/{match.group(2)}"
-                branch = match.group(3)
-                report = fetch_repo_status_details(repo, token, branch)
-                link_suffix = _format_failure_links(report.failure_links)
-                line = f"- {report.emoji}{link_suffix} {cleaned}"
-        output.append(line)
+        if in_section:
+            section_lines.append(line)
+        else:
+            output.append(line)
+
+    if in_section:
+        flush_section()
 
     # Ensure output file encoded as UTF-8 so emoji render correctly on Windows
     readme_path.write_text("\n".join(output) + "\n", encoding="utf-8")

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -153,6 +153,8 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main", "stargazers_count": 42})
         if url.startswith(
             "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20"
         ):
@@ -184,6 +186,7 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
+        "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
@@ -495,7 +498,8 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert lines[4] == "- ❌ ⭐ ? https://github.com/other/repo/tree/dev"
+    assert lines[5] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_update_readme_uses_current_time(
@@ -529,7 +533,7 @@ def test_update_readme_uses_current_time(
     repo_status.update_readme(readme)
     lines = readme.read_text().splitlines()
     assert lines[1] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[2] == "- ✅ https://github.com/user/repo"
+    assert lines[2] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_update_readme_existing_timestamp(
@@ -564,7 +568,7 @@ def test_update_readme_existing_timestamp(
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_fetch_repo_status_details_includes_failed_run_link(
@@ -961,7 +965,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         (
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
-            "<!-- repo-status:failure-links --> https://github.com/user/repo"
+            "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
         ),
     ]
 
@@ -1010,7 +1014,7 @@ def test_update_readme_strips_linked_failure_prefixes_idempotently(
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
             "<!-- repo-status:failure-links --> "
-            "**[repo](https://github.com/user/repo)** - description"
+            "⭐ ? **[repo](https://github.com/user/repo)** - description"
         ),
     ]
 
@@ -1044,7 +1048,7 @@ def test_update_readme_uses_status_details_not_compatibility_report(
 
     assert (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo"
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
     ) in readme.read_text().splitlines()
 
 
@@ -1225,7 +1229,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -1252,7 +1256,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1263,7 +1267,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -1290,7 +1294,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1328,7 +1332,7 @@ def test_update_readme_migrates_legacy_unmarked_failure_links_before_raw_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1361,11 +1365,11 @@ def test_update_readme_preserves_hand_authored_leading_notes(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ (archived) **[repo](https://github.com/user/repo)** - desc",
-        "- ✅ ([docs](https://example.com)) "
-        "**[docs-repo](https://github.com/user/docs-repo)** - desc",
-        "- ✅ ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
+        "- ✅ ⭐ ? ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
         "**[debug-repo](https://github.com/user/debug-repo)** - desc",
+        "- ✅ ⭐ ? ([docs](https://example.com)) "
+        "**[docs-repo](https://github.com/user/docs-repo)** - desc",
+        "- ✅ ⭐ ? (archived) **[repo](https://github.com/user/repo)** - desc",
     ]
 
 
@@ -1395,7 +1399,7 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ([debug run](https://github.com/user/repo/actions/runs/123)) "
+        "- ✅ ⭐ ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
         "https://github.com/user/repo - desc",
     ]
 
@@ -1413,8 +1417,145 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
         "❓ no completed relevant run was found or GitHub could not be queried"
         in section
     )
+    assert "⭐ shows the current GitHub star count" in section
+    assert "sorted by stars descending, then alphabetically for ties" in section
     assert readme.count("docs/repository-guide.md") == 1
 
     project_lines = [line for line in section.splitlines() if line.startswith("- ")]
     assert project_lines
     assert all(repo_status.GITHUB_RE.search(line) for line in project_lines)
+
+
+def test_fetch_repo_status_details_includes_star_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main", "stargazers_count": 42})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add tests",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "success", "head_sha": "abc", "name": "tests"}
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1).stars == 42
+
+
+def test_fetch_repo_metadata_invalid_star_count_renders_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        assert url == "https://api.github.com/repos/user/repo"
+        return DummyResp({"default_branch": "main", "stargazers_count": "many"})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    metadata = repo_status.fetch_repo_metadata("user/repo")
+
+    assert metadata.stars is None
+    assert repo_status.format_star_count(metadata.stars) == "⭐ ?"
+
+
+def test_update_readme_sorts_by_stars_then_name_and_preserves_multiline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "Intro prose stays put.\n"
+        "- ✅ ⭐ 1 **[Beta](https://github.com/user/beta)** - desc\n"
+        "  Continued beta detail.\n"
+        "- ❓ ⭐ ? **[Alpha](https://github.com/user/alpha)** - desc\n"
+        "- ❌ ([old](https://github.com/user/gamma/actions/runs/0)) "
+        "<!-- repo-status:failure-links --> ⭐ 999 "
+        "**[gamma](https://github.com/user/gamma)** - desc\n"
+        "- ✅ ⭐ 4 **[delta](https://github.com/user/delta)** - desc\n"
+    )
+
+    reports = {
+        "user/beta": repo_status.RepoStatus("✅", stars=5),
+        "user/alpha": repo_status.RepoStatus("✅", stars=None),
+        "user/gamma": repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "tests", "https://github.com/user/gamma/actions/runs/1"
+                ),
+            ),
+            stars=5,
+        ),
+        "user/delta": repo_status.RepoStatus("✅", stars=0),
+    }
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: reports[repo],
+    )
+    from datetime import datetime
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=now)
+
+    assert readme.read_text() == first
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "Intro prose stays put.",
+        "- ✅ ⭐ 5 **[Beta](https://github.com/user/beta)** - desc",
+        "  Continued beta detail.",
+        "- ❌ ([tests](https://github.com/user/gamma/actions/runs/1)) "
+        "<!-- repo-status:failure-links --> ⭐ 5 "
+        "**[gamma](https://github.com/user/gamma)** - desc",
+        "- ✅ ⭐ 0 **[delta](https://github.com/user/delta)** - desc",
+        "- ✅ ⭐ ? **[Alpha](https://github.com/user/alpha)** - desc",
+    ]
+
+
+def test_update_readme_external_link_uses_repo_link_and_branch_for_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- **[Site](https://example.com)** - public website "
+        "([repo](https://github.com/user/site/tree/dev))\n"
+    )
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_details(repo: str, token=None, branch=None):
+        calls.append((repo, branch))
+        return repo_status.RepoStatus("✅", stars=7)
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_details)
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert calls == [("user/site", "dev")]
+    assert (
+        "- ✅ ⭐ 7 **[Site](https://example.com)** - public website "
+        "([repo](https://github.com/user/site/tree/dev))"
+    ) in readme.read_text().splitlines()


### PR DESCRIPTION
### Motivation
- Show GitHub star counts alongside status markers in the profile README "Related Projects" list and make each scheduled rebuild order projects by star count (desc) then alphabetically for ties while preserving existing status and failure-link behavior.

### Description
- Modified `src/repo_status.py` to fetch repository metadata (default branch and `stargazers_count`) and extended the structured status shape to include `stars` (`RepoStatus.stars` and new `RepoMetadata`).
- Kept branch-aware workflow checks unchanged by using the README's explicit branch for Actions queries while still fetching owner/repo metadata for stars; added compact rendering `format_star_count(stars)` that outputs `⭐ N` or `⭐ ?` for unknown counts.
- Reworked Related Projects parsing and rendering with helpers (`strip_project_prefix`, `parse_related_project_items`, `render_project_item`, `sort_project_items`, `_update_related_section_lines`) so bullets (including multi-line descriptions and external-display links) are parsed as single items, old prefixes are idempotently stripped, failure links are preserved, and items are sorted by stars then name.
- Updated `README.md` legend to mention star counts and the new sort order, and adjusted the Related Projects block output format to include the star marker; added and updated focused tests in `tests/test_repo_status.py` to cover star counts, invalid/missing stars, branch handling, sorting, idempotence, failure-link preservation, multiline items, and external display links.

### Testing
- Ran `ruff check --fix src/repo_status.py tests/test_repo_status.py` and `black src/repo_status.py tests/test_repo_status.py`, both completed successfully.
- Ran the focused tests with `python -m pytest tests/test_repo_status.py -q` and observed all tests passing (`41 passed`).
- Ran the full test suite with `python -m pytest -q` and observed all tests passing (`310 passed`, 2 warnings reported by test tooling).
- Ran repository docs checks `npm run docs-lint` and the command completed without error.
- Ran the repository secret scan (`git diff --cached | ./scripts/scan-secrets.py`) and it reported no findings.
- Notes: all GitHub API access in tests is mocked (no live API calls), unknown star counts are rendered as `⭐ ?` and are treated as `-1` for sorting so they sort after known counts as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271f190154832faf6ca1826755d955)