### PR TITLE
feat: add star counts and sort Related Projects by stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 - **Open learning systems** that document the path from rough idea to reusable project.
 
 ## Related Projects
-_Last updated: 2026-06-08 19:41 UTC; checks hourly_
+_Last updated: 2026-06-08 20:04 UTC; checks hourly_
 
 Selected projects across this GitHub account, grouped as a compact portfolio map rather than a dependency list. Each entry links to its GitHub repo so the hourly status updater can keep the health marker current; failure links, when present, point directly to the run or artifact worth inspecting.
 
-Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried.
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows the current GitHub star count, and projects are sorted by stars descending, then alphabetically for ties.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
-- ✅ **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ❓ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 6 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+- ❓ ⭐ 3 **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ❌ ([Update Repo Statuses](https://github.com/futuroptimist/flywheel/actions/runs/27123196602)) <!-- repo-status:failure-links --> ⭐ 2 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
+- ✅ ⭐ 1 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ ⭐ 1 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
+- ✅ ⭐ 0 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
+- ✅ ⭐ 0 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ ⭐ 0 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
+- ❌ ([docker in /docker - Update #1154241084](https://github.com/futuroptimist/gabriel/actions/runs/19421904742), [Security Scans #10](https://github.com/futuroptimist/gabriel/actions/runs/20566165837), [Security Scans #11](https://github.com/futuroptimist/gabriel/actions/runs/20706713112), [Security Scans #12](https://github.com/futuroptimist/gabriel/actions/runs/20909714496), [Security Scans #13](https://github.com/futuroptimist/gabriel/actions/runs/21127165452), [Security Scans #14](https://github.com/futuroptimist/gabriel/actions/runs/21348015488), [Security Scans #15](https://github.com/futuroptimist/gabriel/actions/runs/21579647496), [Security Scans #7](https://github.com/futuroptimist/gabriel/actions/runs/20018430344), [Security Scans #8](https://github.com/futuroptimist/gabriel/actions/runs/20222249132), [Security Scans #9](https://github.com/futuroptimist/gabriel/actions/runs/20423408130)) <!-- repo-status:failure-links --> ⭐ 0 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ ⭐ 0 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
+- ✅ ⭐ 0 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 0 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
+- ❌ ([.github/workflows/tests.yml](https://github.com/futuroptimist/sugarkube/actions/runs/27055466699)) <!-- repo-status:failure-links --> ⭐ 0 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ ⭐ 0 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
 
 ## Values
 

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -1,9 +1,8 @@
-"""Update README with repo status emojis.
+"""Update README with repo status emojis and star counts.
 
-Fetches the latest GitHub Actions run for each repo listed in the README's
-"Related Projects" section and prepends a green check, red cross, or question
-mark depending on whether the most recent workflow run on the default branch
-completed successfully, failed, or hasn't completed.
+Fetches repository metadata and the latest GitHub Actions run for each repo
+listed in the README's "Related Projects" section, then rebuilds project bullets
+with status, failure links, star counts, and star-descending sort order.
 """
 
 from __future__ import annotations
@@ -30,15 +29,20 @@ class StatusLink:
 
 
 @dataclass(frozen=True)
-class RepoStatus:
-    """Rendered status plus optional direct links for failed checks.
+class RepoMetadata:
+    """Repository metadata used by the README status renderer."""
 
-    The structured shape leaves room for future repository metadata without
-    changing the public status-details API again.
-    """
+    default_branch: str | None = None
+    stars: int | None = None
+
+
+@dataclass(frozen=True)
+class RepoStatus:
+    """Rendered status plus optional direct links and repository metadata."""
 
     emoji: str
     failure_links: tuple[StatusLink, ...] = field(default_factory=tuple)
+    stars: int | None = None
 
 
 @dataclass(frozen=True)
@@ -87,6 +91,48 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
+def _github_headers(token: str | None = None) -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
+    """Fetch default branch and star count for ``repo`` without crashing callers."""
+
+    try:
+        repo_resp = requests.get(
+            f"https://api.github.com/repos/{repo}",
+            headers=_github_headers(token),
+            timeout=10,
+        )
+        repo_resp.raise_for_status()
+        repo_data = repo_resp.json()
+    except (requests.exceptions.RequestException, ValueError) as exc:
+        LOGGER.warning("Unable to fetch repository metadata for %s: %s", repo, exc)
+        return RepoMetadata()
+    if not isinstance(repo_data, dict):
+        LOGGER.warning(
+            "Unexpected repository payload for %s: %r", repo, type(repo_data)
+        )
+        return RepoMetadata()
+
+    default_branch = repo_data.get("default_branch")
+    if not isinstance(default_branch, str) or not default_branch:
+        default_branch = None
+
+    raw_stars = repo_data.get("stargazers_count")
+    stars = (
+        raw_stars
+        if isinstance(raw_stars, int) and not isinstance(raw_stars, bool)
+        else None
+    )
+    if raw_stars is not None and stars is None:
+        LOGGER.warning("Unexpected stargazers_count for %s: %r", repo, raw_stars)
+    return RepoMetadata(default_branch=default_branch, stars=stars)
+
+
 def fetch_repo_status_details(
     repo: str,
     token: str | None = None,
@@ -101,26 +147,13 @@ def fetch_repo_status_details(
     ``RuntimeError`` so the calling workflow fails loudly.
     """
 
-    headers = {"Accept": "application/vnd.github+json"}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    headers = _github_headers(token)
+    metadata = fetch_repo_metadata(repo, token)
 
     if branch is None:
-        try:
-            repo_resp = requests.get(
-                f"https://api.github.com/repos/{repo}", headers=headers, timeout=10
-            )
-            repo_resp.raise_for_status()
-            repo_data = repo_resp.json()
-        except (requests.exceptions.RequestException, ValueError) as exc:
-            LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return RepoStatus(status_to_emoji(None))
-        if not isinstance(repo_data, dict):
-            LOGGER.warning(
-                "Unexpected repository payload for %s: %r", repo, type(repo_data)
-            )
-            return RepoStatus(status_to_emoji(None))
-        branch = repo_data.get("default_branch")
+        branch = metadata.default_branch
+        if branch is None:
+            return RepoStatus(status_to_emoji(None), stars=metadata.stars)
 
     url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     if branch:
@@ -377,7 +410,9 @@ def fetch_repo_status_details(
         for link in links:
             if link not in failure_links:
                 failure_links.append(link)
-    return RepoStatus(status_to_emoji(conclusions[0]), tuple(failure_links))
+    return RepoStatus(
+        status_to_emoji(conclusions[0]), tuple(failure_links), metadata.stars
+    )
 
 
 def fetch_repo_status(
@@ -430,7 +465,7 @@ GENERATED_FAILURE_LINKS_RE = re.compile(
     rf"\s*{re.escape(GENERATED_FAILURE_LINKS_MARKER)}\s*"
 )
 LEGACY_STACKED_FAILURE_LINKS_RE = re.compile(
-    rf"^\((?:{GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*(?=[✅❌❓])"
+    rf"^\((?:{GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*(?=[✅❌❓⭐])"
 )
 LEGACY_GENERATED_LABEL_RE = r"(?:\\.|[^\]\\])*?(?:ci|test|lint|build)(?:\\.|[^\]\\])*?"
 LEGACY_GENERATED_ACTION_RUN_LINK_RE = (
@@ -439,26 +474,133 @@ LEGACY_GENERATED_ACTION_RUN_LINK_RE = (
 )
 LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
-    r"(?=https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?(?:\s|$))",
+    r"(?=(?:⭐\s*(?:\?|\d[\d,]*)\s*)?https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?(?:\s|$))",
     re.IGNORECASE,
 )
+STAR_PREFIX_RE = re.compile(r"^⭐\s*(?:\?|\d[\d,]*)\s*")
+LEGACY_FAILING_RUNS_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
+TIMESTAMP_RE = re.compile(r"^_Last updated: .+; checks hourly_$")
+
+
+@dataclass(frozen=True)
+class RelatedProjectItem:
+    """A complete Related Projects list item, including wrapped continuation lines."""
+
+    lines: tuple[str, ...]
+    repo: str
+    branch: str | None
+    name: str
+    cleaned_first_line: str
+    status: RepoStatus
+
+
+def format_star_count(stars: int | None) -> str:
+    """Render a compact star-count marker for README project bullets."""
+
+    return f"⭐ {stars}" if stars is not None else "⭐ ?"
 
 
 def _strip_status_prefix(line: str) -> str:
-    """Remove generated status emojis and marked linked-failure prefixes."""
+    """Remove generated status, failure-link, and star prefixes from a bullet line."""
 
     content = line[2:].lstrip()
     while True:
+        previous = content
+        content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
+        content = LEGACY_STACKED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
+        content = LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE.sub(
+            "", content, count=1
+        ).lstrip()
+        content = STAR_PREFIX_RE.sub("", content, count=1).lstrip()
         match = re.match(r"^([✅❌❓])\s*", content)
+        if match:
+            content = content[match.end() :].lstrip()
+        if content == previous:
+            return LEGACY_FAILING_RUNS_RE.sub("", content)
+
+
+def _project_name(cleaned_line: str, repo: str) -> str:
+    """Return a stable human-readable project name for sorting."""
+
+    for pattern in (r"\*\*\[([^\]]+)\]\([^)]*\)\*\*", r"\[([^\]]+)\]\([^)]*\)"):
+        match = re.search(pattern, cleaned_line)
+        if match:
+            return match.group(1).strip() or repo
+    match = GITHUB_RE.search(cleaned_line)
+    if match:
+        return match.group(2)
+    return repo
+
+
+def _project_sort_key(item: RelatedProjectItem) -> tuple[int, str, str]:
+    stars = item.status.stars if item.status.stars is not None else -1
+    return (-stars, item.name.casefold(), item.repo.casefold())
+
+
+def parse_related_project_items(
+    lines: list[str], token: str | None = None
+) -> tuple[list[str], list[RelatedProjectItem], list[str]]:
+    """Parse project bullets as whole Markdown list items with continuation lines."""
+
+    prefix: list[str] = []
+    suffix: list[str] = []
+    items: list[RelatedProjectItem] = []
+    index = 0
+    while index < len(lines) and not lines[index].startswith("- "):
+        prefix.append(lines[index])
+        index += 1
+
+    while index < len(lines):
+        line = lines[index]
+        if not line.startswith("- "):
+            suffix.extend(lines[index:])
+            break
+        item_lines = [line]
+        index += 1
+        while index < len(lines) and not lines[index].startswith("- "):
+            if lines[index] == "" and (
+                index + 1 == len(lines) or lines[index + 1].startswith("## ")
+            ):
+                break
+            item_lines.append(lines[index])
+            index += 1
+
+        cleaned = _strip_status_prefix(item_lines[0])
+        match = GITHUB_RE.search(cleaned)
         if not match:
-            return content
-        content = content[match.end() :].lstrip()
-        if match.group(1) == "❌":
-            content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
-            content = LEGACY_STACKED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
-            content = LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE.sub(
-                "", content, count=1
-            ).lstrip()
+            suffix.extend(item_lines)
+            continue
+        repo = f"{match.group(1)}/{match.group(2)}"
+        branch = match.group(3)
+        status = fetch_repo_status_details(repo, token, branch)
+        items.append(
+            RelatedProjectItem(
+                lines=tuple(item_lines),
+                repo=repo,
+                branch=branch,
+                name=_project_name(cleaned, repo),
+                cleaned_first_line=cleaned,
+                status=status,
+            )
+        )
+    return prefix, items, suffix
+
+
+def render_project_item(item: RelatedProjectItem) -> list[str]:
+    """Render a Related Projects item with fresh status, failure links, and stars."""
+
+    link_suffix = _format_failure_links(item.status.failure_links)
+    first = (
+        f"- {item.status.emoji}{link_suffix} "
+        f"{format_star_count(item.status.stars)} {item.cleaned_first_line}"
+    )
+    return [first, *item.lines[1:]]
+
+
+def sort_project_items(items: list[RelatedProjectItem]) -> list[RelatedProjectItem]:
+    """Sort projects by stars descending, then name alphabetically for ties."""
+
+    return sorted(items, key=_project_sort_key)
 
 
 def update_readme(
@@ -466,35 +608,37 @@ def update_readme(
     token: str | None = None,
     now: datetime | None = None,
 ) -> None:
-    """Update README with status emojis, failure links, and a timestamp."""
+    """Update README with status emojis, star counts, failure links, and a timestamp."""
     lines = readme_path.read_text(encoding="utf-8").splitlines()
-    in_section = False
     if now is None:
         now = datetime.now(UTC)
     timestamp = now.strftime("%Y-%m-%d %H:%M UTC")
     ts_line = f"_Last updated: {timestamp}; checks hourly_"
+
     output: list[str] = []
-    for line in lines:
-        if line.strip() == "## Related Projects":
-            in_section = True
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.strip() != "## Related Projects":
             output.append(line)
-            output.append(ts_line)
+            index += 1
             continue
-        if in_section and line.startswith("## "):
-            in_section = False
-        if in_section and line.startswith("_Last updated:"):
-            continue
-        if in_section and line.startswith("- "):
-            cleaned = _strip_status_prefix(line)
-            cleaned = re.sub(r"\s+\(failing runs: [^)]*\)$", "", cleaned)
-            match = GITHUB_RE.search(cleaned)
-            if match:
-                repo = f"{match.group(1)}/{match.group(2)}"
-                branch = match.group(3)
-                report = fetch_repo_status_details(repo, token, branch)
-                link_suffix = _format_failure_links(report.failure_links)
-                line = f"- {report.emoji}{link_suffix} {cleaned}"
+
         output.append(line)
+        output.append(ts_line)
+        index += 1
+
+        section_lines: list[str] = []
+        while index < len(lines) and not lines[index].startswith("## "):
+            if not TIMESTAMP_RE.match(lines[index]):
+                section_lines.append(lines[index])
+            index += 1
+
+        prefix, items, suffix = parse_related_project_items(section_lines, token)
+        output.extend(prefix)
+        for item in sort_project_items(items):
+            output.extend(render_project_item(item))
+        output.extend(suffix)
 
     # Ensure output file encoded as UTF-8 so emoji render correctly on Windows
     readme_path.write_text("\n".join(output) + "\n", encoding="utf-8")

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -153,6 +153,8 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main", "stargazers_count": 42})
         if url.startswith(
             "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20"
         ):
@@ -184,6 +186,7 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
+        "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
@@ -495,7 +498,8 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert lines[4] == "- ❌ ⭐ ? https://github.com/other/repo/tree/dev"
+    assert lines[5] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_update_readme_uses_current_time(
@@ -529,7 +533,7 @@ def test_update_readme_uses_current_time(
     repo_status.update_readme(readme)
     lines = readme.read_text().splitlines()
     assert lines[1] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[2] == "- ✅ https://github.com/user/repo"
+    assert lines[2] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_update_readme_existing_timestamp(
@@ -564,7 +568,7 @@ def test_update_readme_existing_timestamp(
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_fetch_repo_status_details_includes_failed_run_link(
@@ -961,7 +965,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         (
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
-            "<!-- repo-status:failure-links --> https://github.com/user/repo"
+            "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
         ),
     ]
 
@@ -1010,7 +1014,7 @@ def test_update_readme_strips_linked_failure_prefixes_idempotently(
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
             "<!-- repo-status:failure-links --> "
-            "**[repo](https://github.com/user/repo)** - description"
+            "⭐ ? **[repo](https://github.com/user/repo)** - description"
         ),
     ]
 
@@ -1044,7 +1048,7 @@ def test_update_readme_uses_status_details_not_compatibility_report(
 
     assert (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo"
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
     ) in readme.read_text().splitlines()
 
 
@@ -1252,7 +1256,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1290,7 +1294,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1328,7 +1332,7 @@ def test_update_readme_migrates_legacy_unmarked_failure_links_before_raw_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1361,11 +1365,11 @@ def test_update_readme_preserves_hand_authored_leading_notes(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ (archived) **[repo](https://github.com/user/repo)** - desc",
-        "- ✅ ([docs](https://example.com)) "
-        "**[docs-repo](https://github.com/user/docs-repo)** - desc",
-        "- ✅ ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
+        "- ✅ ⭐ ? ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
         "**[debug-repo](https://github.com/user/debug-repo)** - desc",
+        "- ✅ ⭐ ? ([docs](https://example.com)) "
+        "**[docs-repo](https://github.com/user/docs-repo)** - desc",
+        "- ✅ ⭐ ? (archived) **[repo](https://github.com/user/repo)** - desc",
     ]
 
 
@@ -1395,7 +1399,7 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ([debug run](https://github.com/user/repo/actions/runs/123)) "
+        "- ✅ ⭐ ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
         "https://github.com/user/repo - desc",
     ]
 
@@ -1418,3 +1422,156 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
     project_lines = [line for line in section.splitlines() if line.startswith("- ")]
     assert project_lines
     assert all(repo_status.GITHUB_RE.search(line) for line in project_lines)
+
+
+def test_fetch_repo_metadata_renders_star_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        repo_status.requests,
+        "get",
+        lambda url, headers, timeout: DummyResp(
+            {"default_branch": "main", "stargazers_count": 42}
+        ),
+    )
+
+    assert repo_status.fetch_repo_metadata("user/repo") == repo_status.RepoMetadata(
+        default_branch="main", stars=42
+    )
+    assert repo_status.format_star_count(42) == "⭐ 42"
+
+
+def test_fetch_repo_metadata_invalid_stars_are_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        repo_status.requests,
+        "get",
+        lambda url, headers, timeout: DummyResp(
+            {"default_branch": "main", "stargazers_count": "42"}
+        ),
+    )
+
+    metadata = repo_status.fetch_repo_metadata("user/repo")
+
+    assert metadata == repo_status.RepoMetadata(default_branch="main", stars=None)
+    assert repo_status.format_star_count(metadata.stars) == "⭐ ?"
+
+
+def test_fetch_repo_status_details_branch_url_uses_branch_and_metadata_stars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append(url)
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main", "stargazers_count": 7})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=release&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: release branch",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=release"
+        )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "success", "head_sha": "abc", "name": "tests"}
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    details = repo_status.fetch_repo_status_details(
+        "user/repo", branch="release", attempts=1
+    )
+
+    assert details == repo_status.RepoStatus("✅", stars=7)
+    assert "https://api.github.com/repos/user/repo" in calls
+    assert (
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=release"
+        in calls
+    )
+
+
+def test_update_readme_sorts_by_stars_then_name_preserves_multiline_and_external_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "intro\n\n"
+        "## Related Projects\n"
+        "Status legend: existing copy stays put.\n\n"
+        "- ✅ ⭐ 999 **[Zero](https://github.com/user/zero)** - zero stars\n"
+        "  continued zero details\n"
+        "- ❓ ⭐ ? **[Beta](https://github.com/user/beta)** - beta tie\n"
+        "- ✅ **[Alpha](https://github.com/user/alpha)** - alpha tie\n"
+        "- ❌ ([old tests](https://github.com/user/high/actions/runs/0)) ⭐ 1 "
+        "**[High](https://github.com/user/high)** - high stars\n"
+        "- ✅ **[External](https://example.com)** - external display ([repo](https://github.com/user/external))\n"
+        "\n## Footer\n"
+    )
+    statuses = {
+        "user/zero": repo_status.RepoStatus("✅", stars=0),
+        "user/beta": repo_status.RepoStatus("✅", stars=5),
+        "user/alpha": repo_status.RepoStatus("✅", stars=5),
+        "user/high": repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "tests", "https://github.com/user/high/actions/runs/1"
+                ),
+            ),
+            10,
+        ),
+        "user/external": repo_status.RepoStatus("✅", stars=None),
+    }
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: statuses[repo],
+    )
+    from datetime import datetime
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=now)
+
+    assert readme.read_text() == first
+    lines = first.splitlines()
+    assert lines == [
+        "intro",
+        "",
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "Status legend: existing copy stays put.",
+        "",
+        (
+            "- ❌ ([tests](https://github.com/user/high/actions/runs/1)) "
+            "<!-- repo-status:failure-links --> ⭐ 10 "
+            "**[High](https://github.com/user/high)** - high stars"
+        ),
+        "- ✅ ⭐ 5 **[Alpha](https://github.com/user/alpha)** - alpha tie",
+        "- ✅ ⭐ 5 **[Beta](https://github.com/user/beta)** - beta tie",
+        "- ✅ ⭐ 0 **[Zero](https://github.com/user/zero)** - zero stars",
+        "  continued zero details",
+        "- ✅ ⭐ ? **[External](https://example.com)** - external display ([repo](https://github.com/user/external))",
+        "",
+        "## Footer",
+    ]


### PR DESCRIPTION
### Motivation
- Make the README Related Projects list easier to scan by showing each repo's GitHub star count and ordering projects by popularity (stars) rather than an arbitrary order.
- Preserve existing workflow-status behavior, branch-aware checks, and the P2 failure-link format while adding non-breaking metadata for star counts.
- Keep the updater idempotent and tolerant of legacy prefixes so repeated runs and older README formats are safe.

### Description
- Add `RepoMetadata` and `fetch_repo_metadata(repo, token)` to fetch `default_branch` and `stargazers_count` from `https://api.github.com/repos/{owner}/{repo}` and surface `stars` as `int | None`.
- Extend the structured status model to include `stars` (added `stars: int | None` to `RepoStatus`) and pass metadata through `fetch_repo_status_details` so callers receive star info alongside emoji and failure links.
- Rework README parsing and rendering with helpers: `RelatedProjectItem`, `parse_related_project_items`, `render_project_item`, `format_star_count`, `_project_name`, and `sort_project_items`, enabling multi-line bullets, preservation of external/display links, idempotent stripping of old/new prefixes (status, failure links, and `⭐`), and sorting by stars descending then alphabetically for ties.
- Update `update_readme` to rebuild only the `## Related Projects` block (preserve surrounding text and timestamp handling), inject compact star markers like `⭐ 12` or `⭐ ?` for unknowns, and update the status legend to mention star sorting.
- Add and adapt tests in `tests/test_repo_status.py` to cover `fetch_repo_metadata`, `format_star_count`, unknown/invalid star counts, branch URL handling with metadata, sorting behavior, idempotency, failure-link preservation, and multi-line item preservation; keep all API calls mocked in tests.

### Testing
- Ran formatter and linters: `python -m black src/repo_status.py tests/test_repo_status.py` and `ruff check --fix src/repo_status.py tests/test_repo_status.py`; checks completed (formatting applied and lint fixes), no blocking issues.
- Unit tests for the updater: `python -m pytest tests/test_repo_status.py -q`; result: passed.
- Full test suite: `python -m pytest -q`; result: all tests passed (`310 passed`, 2 warnings reported).
- Docs lint: `npm run docs-lint`; ran without blocking errors.
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py`; ran as part of verification with no secrets detected.

All automated checks listed above succeeded in the run; tests use mocked GitHub responses so no live GitHub API calls occur during CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271f190154832faf6ca1826755d955)