### PR TITLE
Add GitHub star counts to Related Projects and sort by stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 - **Open learning systems** that document the path from rough idea to reusable project.
 
 ## Related Projects
-_Last updated: 2026-06-08 19:41 UTC; checks hourly_
+_Last updated: 2026-06-08 20:04 UTC; checks hourly_
 
 Selected projects across this GitHub account, grouped as a compact portfolio map rather than a dependency list. Each entry links to its GitHub repo so the hourly status updater can keep the health marker current; failure links, when present, point directly to the run or artifact worth inspecting.
 
-Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried.
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows the repo star count when available. Projects are sorted by stars descending, then alphabetically for ties.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
-- ✅ **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ❓ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 6 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+- ❓ ⭐ 3 **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ❌ ([Update Repo Statuses](https://github.com/futuroptimist/flywheel/actions/runs/27123196602)) <!-- repo-status:failure-links --> ⭐ 2 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
+- ✅ ⭐ 1 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ ⭐ 1 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
+- ✅ ⭐ 0 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
+- ✅ ⭐ 0 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ ⭐ 0 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
+- ❌ ([docker in /docker - Update #1154241084](https://github.com/futuroptimist/gabriel/actions/runs/19421904742), [Security Scans #10](https://github.com/futuroptimist/gabriel/actions/runs/20566165837), [Security Scans #11](https://github.com/futuroptimist/gabriel/actions/runs/20706713112), [Security Scans #12](https://github.com/futuroptimist/gabriel/actions/runs/20909714496), [Security Scans #13](https://github.com/futuroptimist/gabriel/actions/runs/21127165452), [Security Scans #14](https://github.com/futuroptimist/gabriel/actions/runs/21348015488), [Security Scans #15](https://github.com/futuroptimist/gabriel/actions/runs/21579647496), [Security Scans #7](https://github.com/futuroptimist/gabriel/actions/runs/20018430344), [Security Scans #8](https://github.com/futuroptimist/gabriel/actions/runs/20222249132), [Security Scans #9](https://github.com/futuroptimist/gabriel/actions/runs/20423408130)) <!-- repo-status:failure-links --> ⭐ 0 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ ⭐ 0 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
+- ✅ ⭐ 0 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 0 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
+- ❌ ([.github/workflows/tests.yml](https://github.com/futuroptimist/sugarkube/actions/runs/27055466699)) <!-- repo-status:failure-links --> ⭐ 0 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ ⭐ 0 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
 
 ## Values
 

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -31,14 +31,19 @@ class StatusLink:
 
 @dataclass(frozen=True)
 class RepoStatus:
-    """Rendered status plus optional direct links for failed checks.
-
-    The structured shape leaves room for future repository metadata without
-    changing the public status-details API again.
-    """
+    """Rendered status, failure links, and optional repository star count."""
 
     emoji: str
     failure_links: tuple[StatusLink, ...] = field(default_factory=tuple)
+    stars: int | None = None
+
+
+@dataclass(frozen=True)
+class RepoMetadata:
+    """Small subset of GitHub repository metadata used by the updater."""
+
+    default_branch: str | None = None
+    stars: int | None = None
 
 
 @dataclass(frozen=True)
@@ -49,10 +54,65 @@ class RepoStatusReport:
     failure_links: tuple[str, ...] = field(default_factory=tuple)
 
 
+@dataclass(frozen=True)
+class ProjectItem:
+    """A Markdown list item in the Related Projects section."""
+
+    lines: tuple[str, ...]
+    repo: str | None = None
+    branch: str | None = None
+    name: str = ""
+    details: RepoStatus | None = None
+
+
 GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+))?")
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
+
+
+def _github_headers(token: str | None = None) -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _parse_star_count(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value >= 0:
+        return value
+    return None
+
+
+def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
+    """Fetch default branch and star count for ``repo`` without crashing callers."""
+
+    try:
+        repo_resp = requests.get(
+            f"https://api.github.com/repos/{repo}",
+            headers=_github_headers(token),
+            timeout=10,
+        )
+        repo_resp.raise_for_status()
+        repo_data = repo_resp.json()
+    except (requests.exceptions.RequestException, ValueError) as exc:
+        LOGGER.warning("Unable to fetch repository metadata for %s: %s", repo, exc)
+        return RepoMetadata()
+    if not isinstance(repo_data, dict):
+        LOGGER.warning(
+            "Unexpected repository payload for %s: %r", repo, type(repo_data)
+        )
+        return RepoMetadata()
+
+    default_branch = repo_data.get("default_branch")
+    if not isinstance(default_branch, str) or not default_branch:
+        default_branch = None
+    return RepoMetadata(
+        default_branch=default_branch,
+        stars=_parse_star_count(repo_data.get("stargazers_count")),
+    )
 
 
 def status_to_emoji(conclusion: str | None) -> str:
@@ -101,26 +161,13 @@ def fetch_repo_status_details(
     ``RuntimeError`` so the calling workflow fails loudly.
     """
 
-    headers = {"Accept": "application/vnd.github+json"}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    headers = _github_headers(token)
+    metadata = fetch_repo_metadata(repo, token)
 
     if branch is None:
-        try:
-            repo_resp = requests.get(
-                f"https://api.github.com/repos/{repo}", headers=headers, timeout=10
-            )
-            repo_resp.raise_for_status()
-            repo_data = repo_resp.json()
-        except (requests.exceptions.RequestException, ValueError) as exc:
-            LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return RepoStatus(status_to_emoji(None))
-        if not isinstance(repo_data, dict):
-            LOGGER.warning(
-                "Unexpected repository payload for %s: %r", repo, type(repo_data)
-            )
-            return RepoStatus(status_to_emoji(None))
-        branch = repo_data.get("default_branch")
+        branch = metadata.default_branch
+        if branch is None:
+            return RepoStatus(status_to_emoji(None), stars=metadata.stars)
 
     url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     if branch:
@@ -377,7 +424,9 @@ def fetch_repo_status_details(
         for link in links:
             if link not in failure_links:
                 failure_links.append(link)
-    return RepoStatus(status_to_emoji(conclusions[0]), tuple(failure_links))
+    return RepoStatus(
+        status_to_emoji(conclusions[0]), tuple(failure_links), metadata.stars
+    )
 
 
 def fetch_repo_status(
@@ -420,6 +469,12 @@ def _format_failure_links(links: tuple[StatusLink, ...]) -> str:
     return f" ({rendered}) {GENERATED_FAILURE_LINKS_MARKER}"
 
 
+def format_star_count(stars: int | None) -> str:
+    """Format a compact README star count marker."""
+
+    return f"⭐ {stars}" if stars is not None else "⭐ ?"
+
+
 GENERATED_ACTION_RUN_LINK_RE = (
     r"\[(?:\\.|[^\]\\])+\]"
     r"\(https://github\.com/[\w.-]+/[\w.-]+/actions/runs/[^)]*\)"
@@ -442,23 +497,145 @@ LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     r"(?=https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?(?:\s|$))",
     re.IGNORECASE,
 )
+GENERATED_STAR_RE = re.compile(r"^⭐\s*(?:\?|\d+)\s*")
+VISIBLE_PROJECT_LINK_RE = re.compile(
+    r"\*\*\[([^\]]+)\]\([^)]+\)\*\*|\[([^\]]+)\]\([^)]+\)"
+)
 
 
-def _strip_status_prefix(line: str) -> str:
-    """Remove generated status emojis and marked linked-failure prefixes."""
+def strip_project_prefix(line: str) -> str:
+    """Remove generated status, failure-link, and star prefixes from a bullet."""
 
-    content = line[2:].lstrip()
+    content = line[2:].lstrip() if line.startswith("- ") else line.lstrip()
     while True:
+        original = content
         match = re.match(r"^([✅❌❓])\s*", content)
-        if not match:
+        if match:
+            content = content[match.end() :].lstrip()
+            if match.group(1) == "❌":
+                content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
+                content = LEGACY_STACKED_FAILURE_LINKS_RE.sub(
+                    "", content, count=1
+                ).lstrip()
+                content = LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE.sub(
+                    "", content, count=1
+                ).lstrip()
+        content = GENERATED_STAR_RE.sub("", content, count=1).lstrip()
+        if content == original:
             return content
-        content = content[match.end() :].lstrip()
-        if match.group(1) == "❌":
-            content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
-            content = LEGACY_STACKED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
-            content = LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE.sub(
-                "", content, count=1
-            ).lstrip()
+
+
+# Backward-compatible private name used by older tests and callers.
+def _strip_status_prefix(line: str) -> str:
+    return strip_project_prefix(line)
+
+
+def _project_name(markdown: str, repo: str | None) -> str:
+    match = VISIBLE_PROJECT_LINK_RE.search(markdown)
+    if match:
+        return (match.group(1) or match.group(2) or "").strip()
+    if repo:
+        return repo.rsplit("/", 1)[-1]
+    return markdown.strip()
+
+
+def parse_related_project_items(lines: list[str]) -> list[ProjectItem]:
+    """Parse Markdown project bullets, preserving wrapped continuation lines."""
+
+    items: list[ProjectItem] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not line.startswith("- "):
+            index += 1
+            continue
+        item_lines = [line]
+        index += 1
+        while index < len(lines) and not lines[index].startswith("- "):
+            if lines[index].startswith(" "):
+                item_lines.append(lines[index])
+                index += 1
+                continue
+            break
+        cleaned = strip_project_prefix(item_lines[0])
+        cleaned = re.sub(r"\s+\(failing runs: [^)]*\)$", "", cleaned)
+        match = GITHUB_RE.search(cleaned)
+        if not match:
+            continue
+        repo = f"{match.group(1)}/{match.group(2)}"
+        branch = match.group(3)
+        items.append(
+            ProjectItem(tuple(item_lines), repo, branch, _project_name(cleaned, repo))
+        )
+    return items
+
+
+def render_project_item(item: ProjectItem, details: RepoStatus) -> list[str]:
+    """Render a project item with fresh status and star prefixes."""
+
+    cleaned = strip_project_prefix(item.lines[0])
+    cleaned = re.sub(r"\s+\(failing runs: [^)]*\)$", "", cleaned)
+    link_suffix = _format_failure_links(details.failure_links)
+    first = (
+        f"- {details.emoji}{link_suffix} {format_star_count(details.stars)} {cleaned}"
+    )
+    return [first, *item.lines[1:]]
+
+
+def _sort_key(item: ProjectItem) -> tuple[int, str]:
+    stars = (
+        item.details.stars if item.details and item.details.stars is not None else -1
+    )
+    return (-stars, item.name.casefold())
+
+
+def sort_project_items(items: list[ProjectItem]) -> list[ProjectItem]:
+    """Sort known-star projects above unknowns, then alphabetically for ties."""
+
+    return sorted(items, key=_sort_key)
+
+
+def _update_related_project_lines(lines: list[str], token: str | None) -> list[str]:
+    items = parse_related_project_items(lines)
+    if not items:
+        return lines
+
+    enriched: list[ProjectItem] = []
+    for item in items:
+        if item.repo:
+            details = fetch_repo_status_details(item.repo, token, item.branch)
+        else:
+            details = RepoStatus("❓")
+        enriched.append(
+            ProjectItem(item.lines, item.repo, item.branch, item.name, details)
+        )
+
+    sorted_items = sort_project_items(enriched)
+    rendered_items: list[str] = []
+    for item in sorted_items:
+        rendered_items.extend(
+            render_project_item(item, item.details or RepoStatus("❓"))
+        )
+
+    project_starts = {item.lines[0] for item in items}
+    output: list[str] = []
+    inserted = False
+    index = 0
+    while index < len(lines):
+        if lines[index].startswith("- ") and lines[index] in project_starts:
+            if not inserted:
+                output.extend(rendered_items)
+                inserted = True
+            index += 1
+            while index < len(lines) and not lines[index].startswith("- "):
+                if lines[index].startswith(" "):
+                    index += 1
+                    continue
+                break
+            continue
+        output.append(lines[index])
+        index += 1
+    return output
 
 
 def update_readme(
@@ -466,35 +643,31 @@ def update_readme(
     token: str | None = None,
     now: datetime | None = None,
 ) -> None:
-    """Update README with status emojis, failure links, and a timestamp."""
+    """Update README with status emojis, failure links, star counts, and a timestamp."""
     lines = readme_path.read_text(encoding="utf-8").splitlines()
-    in_section = False
     if now is None:
         now = datetime.now(UTC)
     timestamp = now.strftime("%Y-%m-%d %H:%M UTC")
     ts_line = f"_Last updated: {timestamp}; checks hourly_"
+
     output: list[str] = []
-    for line in lines:
-        if line.strip() == "## Related Projects":
-            in_section = True
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.strip() != "## Related Projects":
             output.append(line)
-            output.append(ts_line)
+            index += 1
             continue
-        if in_section and line.startswith("## "):
-            in_section = False
-        if in_section and line.startswith("_Last updated:"):
-            continue
-        if in_section and line.startswith("- "):
-            cleaned = _strip_status_prefix(line)
-            cleaned = re.sub(r"\s+\(failing runs: [^)]*\)$", "", cleaned)
-            match = GITHUB_RE.search(cleaned)
-            if match:
-                repo = f"{match.group(1)}/{match.group(2)}"
-                branch = match.group(3)
-                report = fetch_repo_status_details(repo, token, branch)
-                link_suffix = _format_failure_links(report.failure_links)
-                line = f"- {report.emoji}{link_suffix} {cleaned}"
+
         output.append(line)
+        output.append(ts_line)
+        index += 1
+        section_lines: list[str] = []
+        while index < len(lines) and not lines[index].startswith("## "):
+            if not lines[index].startswith("_Last updated:"):
+                section_lines.append(lines[index])
+            index += 1
+        output.extend(_update_related_project_lines(section_lines, token))
 
     # Ensure output file encoded as UTF-8 so emoji render correctly on Windows
     readme_path.write_text("\n".join(output) + "\n", encoding="utf-8")

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -153,6 +153,8 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main", "stargazers_count": 42})
         if url.startswith(
             "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20"
         ):
@@ -184,6 +186,7 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
+        "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
@@ -495,7 +498,7 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_update_readme_uses_current_time(
@@ -529,7 +532,7 @@ def test_update_readme_uses_current_time(
     repo_status.update_readme(readme)
     lines = readme.read_text().splitlines()
     assert lines[1] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[2] == "- ✅ https://github.com/user/repo"
+    assert lines[2] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_update_readme_existing_timestamp(
@@ -564,7 +567,7 @@ def test_update_readme_existing_timestamp(
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_fetch_repo_status_details_includes_failed_run_link(
@@ -961,7 +964,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         (
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
-            "<!-- repo-status:failure-links --> https://github.com/user/repo"
+            "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
         ),
     ]
 
@@ -1010,7 +1013,7 @@ def test_update_readme_strips_linked_failure_prefixes_idempotently(
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
             "<!-- repo-status:failure-links --> "
-            "**[repo](https://github.com/user/repo)** - description"
+            "⭐ ? **[repo](https://github.com/user/repo)** - description"
         ),
     ]
 
@@ -1044,7 +1047,7 @@ def test_update_readme_uses_status_details_not_compatibility_report(
 
     assert (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo"
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
     ) in readme.read_text().splitlines()
 
 
@@ -1252,7 +1255,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1290,7 +1293,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1328,7 +1331,7 @@ def test_update_readme_migrates_legacy_unmarked_failure_links_before_raw_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1361,11 +1364,11 @@ def test_update_readme_preserves_hand_authored_leading_notes(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ (archived) **[repo](https://github.com/user/repo)** - desc",
-        "- ✅ ([docs](https://example.com)) "
-        "**[docs-repo](https://github.com/user/docs-repo)** - desc",
-        "- ✅ ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
+        "- ✅ ⭐ ? ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
         "**[debug-repo](https://github.com/user/debug-repo)** - desc",
+        "- ✅ ⭐ ? ([docs](https://example.com)) "
+        "**[docs-repo](https://github.com/user/docs-repo)** - desc",
+        "- ✅ ⭐ ? (archived) **[repo](https://github.com/user/repo)** - desc",
     ]
 
 
@@ -1395,7 +1398,7 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ([debug run](https://github.com/user/repo/actions/runs/123)) "
+        "- ✅ ⭐ ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
         "https://github.com/user/repo - desc",
     ]
 
@@ -1418,3 +1421,196 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
     project_lines = [line for line in section.splitlines() if line.startswith("- ")]
     assert project_lines
     assert all(repo_status.GITHUB_RE.search(line) for line in project_lines)
+
+
+def test_update_readme_renders_star_counts_and_sorts_projects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ✅ ⭐ 1 **[zero](https://github.com/user/zero)** - desc\n"
+        "- ❓ ⭐ ? **[alpha](https://github.com/user/alpha)** - desc\n"
+        "- ❌ ([old](https://github.com/user/bravo/actions/runs/0)) "
+        "<!-- repo-status:failure-links --> ⭐ 999 "
+        "**[bravo](https://github.com/user/bravo)** - desc\n"
+    )
+
+    statuses = {
+        "zero": repo_status.RepoStatus("✅", stars=0),
+        "alpha": repo_status.RepoStatus("✅", stars=7),
+        "bravo": repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "tests", "https://github.com/user/bravo/actions/runs/1"
+                ),
+            ),
+            stars=7,
+        ),
+    }
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: statuses[repo.rsplit("/", 1)[1]],
+    )
+    from datetime import datetime
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=now)
+
+    assert readme.read_text() == first
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "- ✅ ⭐ 7 **[alpha](https://github.com/user/alpha)** - desc",
+        "- ❌ ([tests](https://github.com/user/bravo/actions/runs/1)) "
+        "<!-- repo-status:failure-links --> ⭐ 7 "
+        "**[bravo](https://github.com/user/bravo)** - desc",
+        "- ✅ ⭐ 0 **[zero](https://github.com/user/zero)** - desc",
+    ]
+
+
+def test_update_readme_unknown_stars_sort_after_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- **[unknown](https://github.com/user/unknown)** - desc\n"
+        "- **[zero](https://github.com/user/zero)** - desc\n"
+    )
+    statuses = {
+        "unknown": repo_status.RepoStatus("✅", stars=None),
+        "zero": repo_status.RepoStatus("✅", stars=0),
+    }
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: statuses[repo.rsplit("/", 1)[1]],
+    )
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text().splitlines()[2:] == [
+        "- ✅ ⭐ 0 **[zero](https://github.com/user/zero)** - desc",
+        "- ✅ ⭐ ? **[unknown](https://github.com/user/unknown)** - desc",
+    ]
+
+
+def test_update_readme_preserves_multiline_and_external_repo_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- **[Website](https://example.com)** - desc "
+        "([repo](https://github.com/user/site))\n"
+        "  continued detail\n"
+        "- **[Tool](https://github.com/user/tool)** - desc\n"
+        "  tool continuation\n"
+    )
+    statuses = {
+        "site": repo_status.RepoStatus("✅", stars=5),
+        "tool": repo_status.RepoStatus("✅", stars=10),
+    }
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: statuses[repo.rsplit("/", 1)[1]],
+    )
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "- ✅ ⭐ 10 **[Tool](https://github.com/user/tool)** - desc",
+        "  tool continuation",
+        "- ✅ ⭐ 5 **[Website](https://example.com)** - desc "
+        "([repo](https://github.com/user/site))",
+        "  continued detail",
+    ]
+
+
+def test_fetch_repo_metadata_handles_invalid_stars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        repo_status.requests,
+        "get",
+        lambda url, headers, timeout: DummyResp(
+            {"default_branch": "main", "stargazers_count": "42"}
+        ),
+    )
+
+    assert repo_status.fetch_repo_metadata("user/repo") == repo_status.RepoMetadata(
+        default_branch="main", stars=None
+    )
+
+
+def test_update_readme_branch_url_checks_branch_but_fetches_repo_stars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- **[repo](https://github.com/user/repo/tree/dev)** - desc\n"
+    )
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_status(repo: str, token=None, branch=None):
+        calls.append((repo, branch))
+        return repo_status.RepoStatus("✅", stars=42)
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert calls == [("user/repo", "dev")]
+    assert (
+        "- ✅ ⭐ 42 **[repo](https://github.com/user/repo/tree/dev)** - desc"
+        in readme.read_text().splitlines()
+    )
+
+
+def test_update_readme_leaves_non_project_bullets_in_place(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "Intro prose.\n"
+        "- not a GitHub project\n"
+        "- **[Beta](https://github.com/user/beta)** - desc\n"
+        "- **[Alpha](https://github.com/user/alpha)** - desc\n"
+        "Closing prose.\n"
+    )
+    statuses = {
+        "alpha": repo_status.RepoStatus("✅", stars=2),
+        "beta": repo_status.RepoStatus("✅", stars=1),
+    }
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: statuses[repo.rsplit("/", 1)[1]],
+    )
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "Intro prose.",
+        "- not a GitHub project",
+        "- ✅ ⭐ 2 **[Alpha](https://github.com/user/alpha)** - desc",
+        "- ✅ ⭐ 1 **[Beta](https://github.com/user/beta)** - desc",
+        "Closing prose.",
+    ]


### PR DESCRIPTION
### Motivation
- Show each Related Projects entry's GitHub star count and make the hourly updater present a deterministic, useful ordering (stars descending, then alphabetical for ties). 
- Keep existing failure-link behavior, branch-aware status checks, and idempotent README rewriting while adding minimal, testable metadata logic.

### Description
- Added lightweight repository metadata support: new `RepoMetadata` type and `fetch_repo_metadata(repo, token)` to fetch `default_branch` and `stargazers_count` from `https://api.github.com/repos/{owner}/{repo}` with robust error handling and a `_parse_star_count` helper.  
- Extended `RepoStatus` with a `stars: int | None` field and threaded star counts through `fetch_repo_status_details` so status reports carry star information.  
- Implemented star rendering and idempotent prefix stripping: `format_star_count`, improved prefix stripping (`strip_project_prefix`/_strip_status_prefix), and a `GENERATED_STAR_RE` to remove stale star markers safely.  
- Added parsing/rendering pipeline for Related Projects bullets: `ProjectItem`, `parse_related_project_items`, `render_project_item`, `sort_project_items` (sort key = stars desc, then casefolded name), and `_update_related_project_lines` that preserves multi-line descriptions and non-project bullets while replacing only project items.  
- Updated `update_readme` to rebuild only the `## Related Projects` section, add/refresh the timestamp, and call the new pipeline; updated the README legend to mention stars and sort order.  
- Tests: expanded and added focused tests in `tests/test_repo_status.py` covering star rendering (`⭐ N` / `⭐ ?`), unknown-star sorting behavior, branch URL handling for status checks (branch kept for CI checks; metadata fetched from owner/repo), idempotency, failure-link preservation, multiline & external-link bullets, and invalid star payload handling.  

### Testing
- Run unit tests: `python -m pytest -q` — all tests passed (`312 passed, 2 warnings`).  
- Run the focused suite: `python -m pytest tests/test_repo_status.py -q` — passed (all project-status unit tests).  
- Lint/format checks: `ruff check src/repo_status.py tests/test_repo_status.py` — passed; `black src/repo_status.py tests/test_repo_status.py` — ran and reformatted where needed (Black emitted a Python 3.14 safety-check warning when run under Python 3.12).  
- Docs lint: `npm run docs-lint` — ran (no blocking issues).  
- Secret scans: `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` — ran (no secrets found).  
- Manual/run-time check: ran `python src/repo_status.py` to exercise updater against live GitHub; the updater executed and regenerated the README section, but one repo commit lookup returned 404 for `democratizedspace/dspace@v3` (handled gracefully and rendered as `❓` for status).  

Residual notes and follow-ups: the updater treats unknown star counts as `-1` for sorting (so known zero-star repos sort above unknowns) and renders `⭐ ?` when stars cannot be fetched; tests use mocked responses only (no live API calls in test asserts). No new runtime dependencies were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271f190154832faf6ca1826755d955)