### PR TITLE
Add stars to Related Projects updater

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -46,6 +46,7 @@ durations
 elon
 embeddings
 entrypoint
+entrypoints
 env
 executables
 explainer
@@ -81,6 +82,7 @@ https
 ideation
 img
 ingester
+inspectable
 invalidargument
 io
 irl
@@ -95,6 +97,7 @@ li
 lifecycle
 lifepo
 lifepo₄
+linkcheck
 livestream
 llm
 llms
@@ -130,6 +133,7 @@ openai
 opentimelineio
 optimised
 otio
+parseable
 pathlib
 png
 poisson

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 - **Open learning systems** that document the path from rough idea to reusable project.
 
 ## Related Projects
-_Last updated: 2026-06-08 20:06 UTC; checks hourly_
+_Last updated: 2026-06-09 00:53 UTC; checks hourly_
 
 Selected projects across this GitHub account, grouped as a compact portfolio map rather than a dependency list. Each entry links to its GitHub repo so the hourly status updater can keep the health marker current; failure links, when present, point directly to the run or artifact worth inspecting.
 
 Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows GitHub stars. Projects sort by stars descending, then alphabetically for ties; unknown star counts sort last.
 
 - ✅ ⭐ 6 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ❓ ⭐ 3 **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ✅ ⭐ 3 **[DSPACE](https://democratized.space)** @main – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/main))
 - ❌ ([Update Repo Statuses](https://github.com/futuroptimist/flywheel/actions/runs/27123196602)) <!-- repo-status:failure-links --> ⭐ 2 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
 - ✅ ⭐ 1 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
 - ✅ ⭐ 1 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure

--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 - **Open learning systems** that document the path from rough idea to reusable project.
 
 ## Related Projects
-_Last updated: 2026-06-08 19:41 UTC; checks hourly_
+_Last updated: 2026-06-08 20:06 UTC; checks hourly_
 
 Selected projects across this GitHub account, grouped as a compact portfolio map rather than a dependency list. Each entry links to its GitHub repo so the hourly status updater can keep the health marker current; failure links, when present, point directly to the run or artifact worth inspecting.
 
-Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried.
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows GitHub stars. Projects sort by stars descending, then alphabetically for ties; unknown star counts sort last.
 
-- ✅ **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
-- ✅ **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ❓ **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
-- ❌ **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
-- ❌ **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
-- ✅ **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
-- ✅ **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
-- ✅ **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
-- ✅ **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
-- ✅ **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
-- ❌ **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
-- ✅ **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
-- ✅ **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 6 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+- ❓ ⭐ 3 **[DSPACE](https://democratized.space)** @v3 – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/v3))
+- ❌ ([Update Repo Statuses](https://github.com/futuroptimist/flywheel/actions/runs/27123196602)) <!-- repo-status:failure-links --> ⭐ 2 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
+- ✅ ⭐ 1 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ ⭐ 1 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
+- ✅ ⭐ 0 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
+- ✅ ⭐ 0 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ ⭐ 0 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
+- ❌ ([docker in /docker - Update #1154241084](https://github.com/futuroptimist/gabriel/actions/runs/19421904742), [Security Scans #10](https://github.com/futuroptimist/gabriel/actions/runs/20566165837), [Security Scans #11](https://github.com/futuroptimist/gabriel/actions/runs/20706713112), [Security Scans #12](https://github.com/futuroptimist/gabriel/actions/runs/20909714496), [Security Scans #13](https://github.com/futuroptimist/gabriel/actions/runs/21127165452), [Security Scans #14](https://github.com/futuroptimist/gabriel/actions/runs/21348015488), [Security Scans #15](https://github.com/futuroptimist/gabriel/actions/runs/21579647496), [Security Scans #7](https://github.com/futuroptimist/gabriel/actions/runs/20018430344), [Security Scans #8](https://github.com/futuroptimist/gabriel/actions/runs/20222249132), [Security Scans #9](https://github.com/futuroptimist/gabriel/actions/runs/20423408130)) <!-- repo-status:failure-links --> ⭐ 0 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ ⭐ 0 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
+- ✅ ⭐ 0 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 0 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
+- ❌ ([.github/workflows/tests.yml](https://github.com/futuroptimist/sugarkube/actions/runs/27055466699)) <!-- repo-status:failure-links --> ⭐ 0 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ ⭐ 0 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
 
 ## Values
 

--- a/docs/prompts/codex/fuzzing.md
+++ b/docs/prompts/codex/fuzzing.md
@@ -61,7 +61,7 @@ CONTEXT:
 - Record each incident in `outages/YYYY-MM-DD-incident.json` using `outages/schema.json`.
 - Create a companion postmortem in `outages/YYYY-MM-DD-short-title.md`
   summarizing the root cause and fix.
-- Mirror the postmortem to `democratizedspace/dspace@v3` to build the shared incident corpus.
+- Mirror the postmortem to `democratizedspace/dspace@main` to build the shared incident corpus.
 
 REQUEST:
 1. Run `pre-commit run --all-files`, `pytest -q`, `npm run lint`, `npm run test:ci`,

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -30,15 +30,20 @@ class StatusLink:
 
 
 @dataclass(frozen=True)
-class RepoStatus:
-    """Rendered status plus optional direct links for failed checks.
+class RepoMetadata:
+    """Repository metadata used by the README status renderer."""
 
-    The structured shape leaves room for future repository metadata without
-    changing the public status-details API again.
-    """
+    default_branch: str | None = None
+    stars: int | None = None
+
+
+@dataclass(frozen=True)
+class RepoStatus:
+    """Rendered status plus optional direct links and repository metadata."""
 
     emoji: str
     failure_links: tuple[StatusLink, ...] = field(default_factory=tuple)
+    stars: int | None = None
 
 
 @dataclass(frozen=True)
@@ -87,6 +92,38 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
+def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
+    """Fetch default branch and star count for ``repo`` without raising."""
+
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        repo_resp = requests.get(
+            f"https://api.github.com/repos/{repo}", headers=headers, timeout=10
+        )
+        repo_resp.raise_for_status()
+        repo_data = repo_resp.json()
+    except (requests.exceptions.RequestException, ValueError) as exc:
+        LOGGER.warning("Unable to fetch repository metadata for %s: %s", repo, exc)
+        return RepoMetadata()
+
+    if not isinstance(repo_data, dict):
+        LOGGER.warning(
+            "Unexpected repository payload for %s: %r", repo, type(repo_data)
+        )
+        return RepoMetadata()
+
+    default_branch = repo_data.get("default_branch")
+    if not isinstance(default_branch, str) or not default_branch:
+        default_branch = None
+
+    stars_value = repo_data.get("stargazers_count")
+    stars = stars_value if type(stars_value) is int else None
+    return RepoMetadata(default_branch=default_branch, stars=stars)
+
+
 def fetch_repo_status_details(
     repo: str,
     token: str | None = None,
@@ -105,22 +142,11 @@ def fetch_repo_status_details(
     if token:
         headers["Authorization"] = f"Bearer {token}"
 
+    metadata = fetch_repo_metadata(repo, token)
     if branch is None:
-        try:
-            repo_resp = requests.get(
-                f"https://api.github.com/repos/{repo}", headers=headers, timeout=10
-            )
-            repo_resp.raise_for_status()
-            repo_data = repo_resp.json()
-        except (requests.exceptions.RequestException, ValueError) as exc:
-            LOGGER.warning("Unable to fetch default branch for %s: %s", repo, exc)
-            return RepoStatus(status_to_emoji(None))
-        if not isinstance(repo_data, dict):
-            LOGGER.warning(
-                "Unexpected repository payload for %s: %r", repo, type(repo_data)
-            )
-            return RepoStatus(status_to_emoji(None))
-        branch = repo_data.get("default_branch")
+        branch = metadata.default_branch
+        if branch is None:
+            return RepoStatus(status_to_emoji(None), stars=metadata.stars)
 
     url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     if branch:
@@ -377,7 +403,9 @@ def fetch_repo_status_details(
         for link in links:
             if link not in failure_links:
                 failure_links.append(link)
-    return RepoStatus(status_to_emoji(conclusions[0]), tuple(failure_links))
+    return RepoStatus(
+        status_to_emoji(conclusions[0]), tuple(failure_links), metadata.stars
+    )
 
 
 def fetch_repo_status(
@@ -420,6 +448,12 @@ def _format_failure_links(links: tuple[StatusLink, ...]) -> str:
     return f" ({rendered}) {GENERATED_FAILURE_LINKS_MARKER}"
 
 
+def format_star_count(stars: int | None) -> str:
+    """Format a compact GitHub star count marker."""
+
+    return f"⭐ {stars}" if stars is not None else "⭐ ?"
+
+
 GENERATED_ACTION_RUN_LINK_RE = (
     r"\[(?:\\.|[^\]\\])+\]"
     r"\(https://github\.com/[\w.-]+/[\w.-]+/actions/runs/[^)]*\)"
@@ -430,7 +464,7 @@ GENERATED_FAILURE_LINKS_RE = re.compile(
     rf"\s*{re.escape(GENERATED_FAILURE_LINKS_MARKER)}\s*"
 )
 LEGACY_STACKED_FAILURE_LINKS_RE = re.compile(
-    rf"^\((?:{GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*(?=[✅❌❓])"
+    rf"^\((?:{GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*(?=[✅❌❓⭐])"
 )
 LEGACY_GENERATED_LABEL_RE = r"(?:\\.|[^\]\\])*?(?:ci|test|lint|build)(?:\\.|[^\]\\])*?"
 LEGACY_GENERATED_ACTION_RUN_LINK_RE = (
@@ -439,26 +473,142 @@ LEGACY_GENERATED_ACTION_RUN_LINK_RE = (
 )
 LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
-    r"(?=https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?(?:\s|$))",
+    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?|\*\*?\[[^\]]+\]\(|\[[^\]]+\]\())",
     re.IGNORECASE,
 )
+STAR_PREFIX_RE = re.compile(r"^⭐\s*(?:\?|[\d,]+)\s*")
+LEGACY_FAILING_RUNS_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
 
 
-def _strip_status_prefix(line: str) -> str:
-    """Remove generated status emojis and marked linked-failure prefixes."""
+@dataclass(frozen=True)
+class RelatedProjectItem:
+    """A parsed Related Projects Markdown list item."""
 
-    content = line[2:].lstrip()
+    lines: tuple[str, ...]
+    cleaned_first_line: str
+    repo: str
+    branch: str | None
+    name: str
+    start_index: int = 0
+    status: RepoStatus | None = None
+
+
+def strip_project_prefix(line: str) -> str:
+    """Remove generated status, failure-link, and star prefixes from a bullet."""
+
+    content = line[2:].lstrip() if line.startswith("- ") else line.lstrip()
     while True:
-        match = re.match(r"^([✅❌❓])\s*", content)
+        original = content
+        content = re.sub(r"^[✅❌❓]\s*", "", content, count=1).lstrip()
+        content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
+        content = LEGACY_STACKED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
+        content = LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE.sub(
+            "", content, count=1
+        ).lstrip()
+        content = STAR_PREFIX_RE.sub("", content, count=1).lstrip()
+        if content == original:
+            return LEGACY_FAILING_RUNS_RE.sub("", content)
+
+
+# Backward-compatible private name used by older tests/imports.
+_strip_status_prefix = strip_project_prefix
+
+
+def _project_name(markdown: str, repo: str) -> str:
+    bold_link = re.search(r"\*\*\[([^\]]+)\]\(", markdown)
+    if bold_link:
+        return bold_link.group(1)
+    link = re.search(r"\[([^\]]+)\]\(", markdown)
+    if link:
+        return link.group(1)
+    return repo
+
+
+def parse_related_project_items(lines: list[str]) -> list[RelatedProjectItem]:
+    """Parse GitHub-backed project bullets, preserving continuation lines."""
+
+    items: list[RelatedProjectItem] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not line.startswith("- "):
+            index += 1
+            continue
+        start_index = index
+        block = [line]
+        index += 1
+        while index < len(lines) and not lines[index].startswith("- "):
+            block.append(lines[index])
+            index += 1
+        while block and block[-1] == "":
+            block.pop()
+        cleaned = strip_project_prefix(line)
+        match = GITHUB_RE.search(cleaned)
         if not match:
-            return content
-        content = content[match.end() :].lstrip()
-        if match.group(1) == "❌":
-            content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
-            content = LEGACY_STACKED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
-            content = LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE.sub(
-                "", content, count=1
-            ).lstrip()
+            continue
+        repo = f"{match.group(1)}/{match.group(2)}"
+        items.append(
+            RelatedProjectItem(
+                tuple(block),
+                cleaned,
+                repo,
+                match.group(3),
+                _project_name(cleaned, repo),
+                start_index=start_index,
+            )
+        )
+    return items
+
+
+def render_project_item(item: RelatedProjectItem, details: RepoStatus) -> list[str]:
+    """Render a project item with a fresh status/star prefix."""
+
+    link_suffix = _format_failure_links(details.failure_links)
+    first = (
+        f"- {details.emoji}{link_suffix} "
+        f"{format_star_count(details.stars)} {item.cleaned_first_line}"
+    )
+    return [first, *item.lines[1:]]
+
+
+def _sort_key(item: RelatedProjectItem) -> tuple[int, str]:
+    stars = item.status.stars if item.status else None
+    sort_stars = stars if stars is not None else -1
+    return (-sort_stars, item.name.casefold())
+
+
+def _update_related_section(lines: list[str], token: str | None) -> list[str]:
+    items_by_start: dict[int, RelatedProjectItem] = {}
+    project_items = parse_related_project_items(lines)
+    for item in project_items:
+        status = fetch_repo_status_details(item.repo, token, item.branch)
+        items_by_start[item.start_index] = RelatedProjectItem(
+            item.lines,
+            item.cleaned_first_line,
+            item.repo,
+            item.branch,
+            item.name,
+            item.start_index,
+            status,
+        )
+
+    sorted_items = sorted(items_by_start.values(), key=_sort_key)
+    sorted_iter = iter(sorted_items)
+    output: list[str] = []
+    index = 0
+    while index < len(lines):
+        item = items_by_start.get(index)
+        if item is None:
+            output.append(lines[index])
+            index += 1
+            continue
+        next_item = next(sorted_iter)
+        if next_item.status is None:  # pragma: no cover - impossible after fetch above
+            output.extend(next_item.lines)
+        else:
+            output.extend(render_project_item(next_item, next_item.status))
+        index += len(item.lines)
+    return output
 
 
 def update_readme(
@@ -466,35 +616,32 @@ def update_readme(
     token: str | None = None,
     now: datetime | None = None,
 ) -> None:
-    """Update README with status emojis, failure links, and a timestamp."""
+    """Update README with status emojis, failure links, star counts, and a timestamp."""
+
     lines = readme_path.read_text(encoding="utf-8").splitlines()
-    in_section = False
     if now is None:
         now = datetime.now(UTC)
     timestamp = now.strftime("%Y-%m-%d %H:%M UTC")
     ts_line = f"_Last updated: {timestamp}; checks hourly_"
+
     output: list[str] = []
-    for line in lines:
-        if line.strip() == "## Related Projects":
-            in_section = True
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.strip() != "## Related Projects":
             output.append(line)
-            output.append(ts_line)
+            index += 1
             continue
-        if in_section and line.startswith("## "):
-            in_section = False
-        if in_section and line.startswith("_Last updated:"):
-            continue
-        if in_section and line.startswith("- "):
-            cleaned = _strip_status_prefix(line)
-            cleaned = re.sub(r"\s+\(failing runs: [^)]*\)$", "", cleaned)
-            match = GITHUB_RE.search(cleaned)
-            if match:
-                repo = f"{match.group(1)}/{match.group(2)}"
-                branch = match.group(3)
-                report = fetch_repo_status_details(repo, token, branch)
-                link_suffix = _format_failure_links(report.failure_links)
-                line = f"- {report.emoji}{link_suffix} {cleaned}"
+
         output.append(line)
+        output.append(ts_line)
+        index += 1
+        section: list[str] = []
+        while index < len(lines) and not lines[index].startswith("## "):
+            if not lines[index].startswith("_Last updated:"):
+                section.append(lines[index])
+            index += 1
+        output.extend(_update_related_section(section, token))
 
     # Ensure output file encoded as UTF-8 so emoji render correctly on Windows
     readme_path.write_text("\n".join(output) + "\n", encoding="utf-8")

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -55,6 +55,10 @@ class RepoStatusReport:
 
 
 GITHUB_RE = re.compile(r"https://github.com/([\w-]+)/([\w.-]+)(?:/tree/([\w./-]+))?")
+GITHUB_URL_RE = re.compile(r"https://github\.com/([\w-]+)/([\w.-]+)(/[^\s)>]*)?")
+GITHUB_MARKDOWN_LINK_RE = re.compile(
+    r"\[([^\]]+)\]\((https://github\.com/[\w-]+/[\w.-]+(?:/[^\s)]*)?)\)"
+)
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
@@ -466,18 +470,18 @@ GENERATED_FAILURE_LINKS_RE = re.compile(
 LEGACY_STACKED_FAILURE_LINKS_RE = re.compile(
     rf"^\((?:{GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*(?=[✅❌❓⭐])"
 )
-LEGACY_GENERATED_LABEL_RE = (
-    r"(?:\\.|[^\]\\])*?"
-    r"(?:ci|test|lint|build|deploy|release|security|scan|docker|update|publish|workflow|action|check)"
-    r"(?:\\.|[^\]\\])*?"
-)
 LEGACY_GENERATED_ACTION_RUN_LINK_RE = (
-    rf"\[{LEGACY_GENERATED_LABEL_RE}\]"
+    r"\[(?:\\.|[^\]\\])+\]"
     r"\(https://github\.com/[\w.-]+/[\w.-]+/actions/runs/[^)]*\)"
 )
 LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
-    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?|\*\*?\[[^\]]+\]\(|\[[^\]]+\]\())",
+    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:\*\*?\[[^\]]+\]\(|\[[^\]]+\]\())",
+    re.IGNORECASE,
+)
+LEGACY_KEYWORDED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
+    rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
+    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?)",
     re.IGNORECASE,
 )
 STAR_PREFIX_RE = re.compile(r"^⭐\s*(?:\?|[\d,]+)\s*")
@@ -506,12 +510,78 @@ def strip_project_prefix(line: str) -> str:
         content = re.sub(r"^[✅❌❓]\s*", "", content, count=1).lstrip()
         content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
         content = LEGACY_STACKED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
-        content = LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE.sub(
-            "", content, count=1
-        ).lstrip()
+        content = _strip_legacy_failure_links_before_markdown_repo(content)
+        content = _strip_keyworded_legacy_failure_links_before_raw_repo(content)
         content = STAR_PREFIX_RE.sub("", content, count=1).lstrip()
         if content == original:
             return LEGACY_FAILING_RUNS_RE.sub("", content)
+
+
+def _strip_legacy_failure_links_before_markdown_repo(content: str) -> str:
+    """Strip generated action-run links before Markdown repo links."""
+
+    match = LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE.match(content)
+    if not match:
+        return content
+    labels = re.findall(r"\[((?:\\.|[^\]\\])+)\]", match.group(0))
+    if any(label.replace("\\]", "]").casefold() == "debug run" for label in labels):
+        return content
+    return content[match.end() :].lstrip()
+
+
+def _strip_keyworded_legacy_failure_links_before_raw_repo(content: str) -> str:
+    """Strip older generated failure links before raw repo URLs."""
+
+    match = LEGACY_KEYWORDED_FAILURE_LINKS_BEFORE_REPO_RE.match(content)
+    if not match:
+        return content
+    labels = re.findall(r"\[((?:\\.|[^\]\\])+)\]", match.group(0))
+    generated_label_re = re.compile(
+        r"(?:ci|test|lint|build|deploy|release|security|scan|docker|update|"
+        r"publish|workflow|action|check)",
+        re.IGNORECASE,
+    )
+    if not any(generated_label_re.search(label) for label in labels):
+        return content
+    return content[match.end() :].lstrip()
+
+
+def _parse_project_github_url(url: str) -> tuple[str, str | None] | None:
+    """Return repo and optional branch for project repository URLs only."""
+
+    match = GITHUB_URL_RE.fullmatch(url.rstrip(".,;"))
+    if not match:
+        return None
+    owner, repo_name, suffix = match.groups()
+    if suffix in (None, "", "/"):
+        return f"{owner}/{repo_name}", None
+    tree_prefix = "/tree/"
+    if suffix.startswith(tree_prefix) and len(suffix) > len(tree_prefix):
+        return f"{owner}/{repo_name}", suffix[len(tree_prefix) :]
+    return None
+
+
+def select_project_repo_url(markdown: str) -> tuple[str, str | None] | None:
+    """Select the GitHub project repo URL from a Related Projects item."""
+
+    markdown_links = list(GITHUB_MARKDOWN_LINK_RE.finditer(markdown))
+    for link in markdown_links:
+        if link.group(1).strip().casefold() != "repo":
+            continue
+        parsed = _parse_project_github_url(link.group(2))
+        if parsed:
+            return parsed
+
+    for link in markdown_links:
+        parsed = _parse_project_github_url(link.group(2))
+        if parsed:
+            return parsed
+
+    for match in GITHUB_URL_RE.finditer(markdown):
+        parsed = _parse_project_github_url(match.group(0))
+        if parsed:
+            return parsed
+    return None
 
 
 # Backward-compatible private name used by older tests/imports.
@@ -548,16 +618,16 @@ def parse_related_project_items(lines: list[str]) -> list[RelatedProjectItem]:
             block.pop()
         cleaned = strip_project_prefix(line)
         searchable_block = "\n".join([cleaned, *block[1:]])
-        match = GITHUB_RE.search(searchable_block)
-        if not match:
+        selected_repo = select_project_repo_url(searchable_block)
+        if not selected_repo:
             continue
-        repo = f"{match.group(1)}/{match.group(2)}"
+        repo, branch = selected_repo
         items.append(
             RelatedProjectItem(
                 tuple(block),
                 cleaned,
                 repo,
-                match.group(3),
+                branch,
                 _project_name(cleaned, repo),
                 start_index=start_index,
             )

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -466,7 +466,11 @@ GENERATED_FAILURE_LINKS_RE = re.compile(
 LEGACY_STACKED_FAILURE_LINKS_RE = re.compile(
     rf"^\((?:{GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*(?=[✅❌❓⭐])"
 )
-LEGACY_GENERATED_LABEL_RE = r"(?:\\.|[^\]\\])*?(?:ci|test|lint|build)(?:\\.|[^\]\\])*?"
+LEGACY_GENERATED_LABEL_RE = (
+    r"(?:\\.|[^\]\\])*?"
+    r"(?:ci|test|lint|build|deploy|release|security|scan|docker|update|publish|workflow|action|check)"
+    r"(?:\\.|[^\]\\])*?"
+)
 LEGACY_GENERATED_ACTION_RUN_LINK_RE = (
     rf"\[{LEGACY_GENERATED_LABEL_RE}\]"
     r"\(https://github\.com/[\w.-]+/[\w.-]+/actions/runs/[^)]*\)"
@@ -543,7 +547,8 @@ def parse_related_project_items(lines: list[str]) -> list[RelatedProjectItem]:
         while block and block[-1] == "":
             block.pop()
         cleaned = strip_project_prefix(line)
-        match = GITHUB_RE.search(cleaned)
+        searchable_block = "\n".join([cleaned, *block[1:]])
+        match = GITHUB_RE.search(searchable_block)
         if not match:
             continue
         repo = f"{match.group(1)}/{match.group(2)}"

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1595,6 +1595,77 @@ def test_update_readme_preserves_multiline_and_external_display_links(
     ]
 
 
+def test_update_readme_uses_repo_link_from_continuation_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- **[external](https://example.com)** - homepage first\n"
+        "  ([repo](https://github.com/user/external/tree/main))\n"
+        "- **[local](https://github.com/user/local)** - repo first\n"
+    )
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_status(repo: str, token=None, branch=None):
+        calls.append((repo, branch))
+        return repo_status.RepoStatus(
+            "✅", stars={"user/external": 10, "user/local": 1}[repo]
+        )
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert calls == [("user/external", "main"), ("user/local", None)]
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "- ✅ ⭐ 10 **[external](https://example.com)** - homepage first",
+        "  ([repo](https://github.com/user/external/tree/main))",
+        "- ✅ ⭐ 1 **[local](https://github.com/user/local)** - repo first",
+    ]
+
+
+def test_update_readme_strips_legacy_deploy_failure_link_before_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ❌ ([Deploy](https://github.com/user/repo/actions/runs/0)) "
+        "**[repo](https://github.com/user/repo)** - desc\n"
+    )
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Deploy", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        ),
+    )
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text() == first
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "- ❌ ([Deploy](https://github.com/user/repo/actions/runs/1)) "
+        "<!-- repo-status:failure-links --> ⭐ ? "
+        "**[repo](https://github.com/user/repo)** - desc",
+    ]
+
+
 def test_update_readme_branch_url_uses_branch_for_status_and_repo_for_stars(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1602,7 +1602,7 @@ def test_update_readme_branch_url_uses_branch_for_status_and_repo_for_stars(
     readme.write_text(
         "## Related Projects\n"
         "- **[DSPACE](https://democratized.space)** "
-        "([repo](https://github.com/democratizedspace/dspace/tree/v3))\n"
+        "([repo](https://github.com/democratizedspace/dspace/tree/main))\n"
     )
     calls: list[tuple[str, str | None]] = []
 
@@ -1615,5 +1615,5 @@ def test_update_readme_branch_url_uses_branch_for_status_and_repo_for_stars(
 
     repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
 
-    assert calls == [("democratizedspace/dspace", "v3")]
+    assert calls == [("democratizedspace/dspace", "main")]
     assert "- ✅ ⭐ 12 **[DSPACE](https://democratized.space)**" in readme.read_text()

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1628,6 +1628,81 @@ def test_update_readme_uses_repo_link_from_continuation_line(
     ]
 
 
+def test_update_readme_ignores_issue_action_and_note_links_before_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ([note](https://github.com/user/notes)) "
+        "([issue](https://github.com/user/issue-tracker/issues/7)) "
+        "([run](https://github.com/user/automation/actions/runs/99)) "
+        "**[Site](https://example.com)** - external display "
+        "([repo](https://github.com/user/site))\n"
+    )
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_status(repo: str, token=None, branch=None):
+        calls.append((repo, branch))
+        return repo_status.RepoStatus("✅", stars=9)
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert calls == [("user/site", None)]
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "- ✅ ⭐ 9 ([note](https://github.com/user/notes)) "
+        "([issue](https://github.com/user/issue-tracker/issues/7)) "
+        "([run](https://github.com/user/automation/actions/runs/99)) "
+        "**[Site](https://example.com)** - external display "
+        "([repo](https://github.com/user/site))",
+    ]
+
+
+def test_update_readme_strips_arbitrary_label_legacy_failure_link_before_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ❌ ([Production](https://github.com/user/repo/actions/runs/0)) "
+        "**[repo](https://github.com/user/repo)** - desc\n"
+    )
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Production", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+            stars=4,
+        ),
+    )
+    from datetime import datetime
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=now)
+
+    assert readme.read_text() == first
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "- ❌ ([Production](https://github.com/user/repo/actions/runs/1)) "
+        "<!-- repo-status:failure-links --> ⭐ 4 "
+        "**[repo](https://github.com/user/repo)** - desc",
+    ]
+
+
 def test_update_readme_strips_legacy_deploy_failure_link_before_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -153,6 +153,8 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main", "stargazers_count": 42})
         if url.startswith(
             "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20"
         ):
@@ -184,6 +186,7 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
+        "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
@@ -485,7 +488,8 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         repo_status,
         "fetch_repo_status_details",
         lambda repo, token=None, branch=None: repo_status.RepoStatus(
-            fake_status(repo, token, branch)
+            fake_status(repo, token, branch),
+            stars={"user/repo": 2, "other/repo": 1}.get(repo),
         ),
     )
     from datetime import datetime
@@ -495,7 +499,7 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ 2 https://github.com/user/repo"
 
 
 def test_update_readme_uses_current_time(
@@ -529,7 +533,7 @@ def test_update_readme_uses_current_time(
     repo_status.update_readme(readme)
     lines = readme.read_text().splitlines()
     assert lines[1] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[2] == "- ✅ https://github.com/user/repo"
+    assert lines[2] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_update_readme_existing_timestamp(
@@ -564,7 +568,7 @@ def test_update_readme_existing_timestamp(
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ ? https://github.com/user/repo"
 
 
 def test_fetch_repo_status_details_includes_failed_run_link(
@@ -929,7 +933,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         "## Related Projects\n"
         "_Last updated: 1999-01-01 00:00 UTC; checks hourly_\n"
         "_Last updated: 1998-01-01 00:00 UTC; checks hourly_\n"
-        "- ✅ https://github.com/user/repo (failing runs: https://old.example/run)\n"
+        "- ✅ ⭐ ? https://github.com/user/repo (failing runs: https://old.example/run)\n"
     )
     readme = tmp_path / "README.md"
     readme.write_text(content)
@@ -961,7 +965,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         (
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
-            "<!-- repo-status:failure-links --> https://github.com/user/repo"
+            "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
         ),
     ]
 
@@ -1010,7 +1014,7 @@ def test_update_readme_strips_linked_failure_prefixes_idempotently(
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
             "<!-- repo-status:failure-links --> "
-            "**[repo](https://github.com/user/repo)** - description"
+            "⭐ ? **[repo](https://github.com/user/repo)** - description"
         ),
     ]
 
@@ -1044,7 +1048,7 @@ def test_update_readme_uses_status_details_not_compatibility_report(
 
     assert (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo"
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
     ) in readme.read_text().splitlines()
 
 
@@ -1225,7 +1229,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -1252,7 +1256,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1263,7 +1267,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -1290,7 +1294,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1328,7 +1332,7 @@ def test_update_readme_migrates_legacy_unmarked_failure_links_before_raw_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
     ]
 
 
@@ -1348,7 +1352,10 @@ def test_update_readme_preserves_hand_authored_leading_notes(
     monkeypatch.setattr(
         repo_status,
         "fetch_repo_status_details",
-        lambda repo, token=None, branch=None: repo_status.RepoStatus("✅"),
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "✅",
+            stars={"user/repo": 3, "user/docs-repo": 2, "user/debug-repo": 1}[repo],
+        ),
     )
     from datetime import datetime
 
@@ -1361,10 +1368,10 @@ def test_update_readme_preserves_hand_authored_leading_notes(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ (archived) **[repo](https://github.com/user/repo)** - desc",
-        "- ✅ ([docs](https://example.com)) "
+        "- ✅ ⭐ 3 (archived) **[repo](https://github.com/user/repo)** - desc",
+        "- ✅ ⭐ 2 ([docs](https://example.com)) "
         "**[docs-repo](https://github.com/user/docs-repo)** - desc",
-        "- ✅ ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
+        "- ✅ ⭐ 1 ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
         "**[debug-repo](https://github.com/user/debug-repo)** - desc",
     ]
 
@@ -1395,7 +1402,7 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ([debug run](https://github.com/user/repo/actions/runs/123)) "
+        "- ✅ ⭐ ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
         "https://github.com/user/repo - desc",
     ]
 
@@ -1413,8 +1420,200 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
         "❓ no completed relevant run was found or GitHub could not be queried"
         in section
     )
+    assert "⭐ shows GitHub stars" in section
+    assert "Projects sort by stars descending" in section
     assert readme.count("docs/repository-guide.md") == 1
 
     project_lines = [line for line in section.splitlines() if line.startswith("- ")]
     assert project_lines
     assert all(repo_status.GITHUB_RE.search(line) for line in project_lines)
+    assert all("⭐" in line for line in project_lines)
+
+
+def test_fetch_repo_status_details_includes_star_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main", "stargazers_count": 42})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: pass checks",
+                            "author": {"name": "Alice"},
+                            "committer": {"name": "Alice"},
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    }
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "success", "head_sha": "abc", "name": "tests"}
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details(
+        "user/repo", attempts=1
+    ) == repo_status.RepoStatus("✅", stars=42)
+
+
+def test_format_star_count_handles_unknowns() -> None:
+    assert repo_status.format_star_count(42) == "⭐ 42"
+    assert repo_status.format_star_count(None) == "⭐ ?"
+
+
+def test_fetch_repo_metadata_invalid_star_count_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        repo_status.requests,
+        "get",
+        lambda url, headers, timeout: DummyResp(
+            {"default_branch": "main", "stargazers_count": "42"}
+        ),
+    )
+
+    assert repo_status.fetch_repo_metadata("user/repo") == repo_status.RepoMetadata(
+        default_branch="main", stars=None
+    )
+
+
+def test_update_readme_sorts_by_stars_then_name_and_unknowns_last(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- **[Zero](https://github.com/user/zero)** - zero stars\n"
+        "- **[Beta](https://github.com/user/beta)** - same stars\n"
+        "- **[alpha](https://github.com/user/alpha)** - same stars\n"
+        "- **[Unknown](https://github.com/user/unknown)** - unknown stars\n"
+    )
+
+    stars = {"user/zero": 0, "user/beta": 5, "user/alpha": 5, "user/unknown": None}
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "✅", stars=stars[repo]
+        ),
+    )
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text().splitlines()[2:] == [
+        "- ✅ ⭐ 5 **[alpha](https://github.com/user/alpha)** - same stars",
+        "- ✅ ⭐ 5 **[Beta](https://github.com/user/beta)** - same stars",
+        "- ✅ ⭐ 0 **[Zero](https://github.com/user/zero)** - zero stars",
+        "- ✅ ⭐ ? **[Unknown](https://github.com/user/unknown)** - unknown stars",
+    ]
+
+
+def test_update_readme_star_and_failure_prefix_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ❌ ([old tests](https://github.com/user/repo/actions/runs/0)) "
+        "<!-- repo-status:failure-links --> ⭐ 1 ⭐ 999 "
+        "**[repo](https://github.com/user/repo)** - desc\n"
+    )
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "tests", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+            stars=7,
+        ),
+    )
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text() == first
+    assert readme.read_text().splitlines()[2] == (
+        "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
+        "<!-- repo-status:failure-links --> ⭐ 7 "
+        "**[repo](https://github.com/user/repo)** - desc"
+    )
+
+
+def test_update_readme_preserves_multiline_and_external_display_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "Intro stays put.\n"
+        "- **[token.place](https://token.place)** - external first "
+        "([repo](https://github.com/futuroptimist/token.place))\n"
+        "  continuation stays with token.place\n"
+        "- **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub\n"
+    )
+
+    stars = {"futuroptimist/token.place": 10, "futuroptimist/futuroptimist": 1}
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "✅", stars=stars[repo]
+        ),
+    )
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "Intro stays put.",
+        "- ✅ ⭐ 10 **[token.place](https://token.place)** - external first "
+        "([repo](https://github.com/futuroptimist/token.place))",
+        "  continuation stays with token.place",
+        "- ✅ ⭐ 1 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub",
+    ]
+
+
+def test_update_readme_branch_url_uses_branch_for_status_and_repo_for_stars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- **[DSPACE](https://democratized.space)** "
+        "([repo](https://github.com/democratizedspace/dspace/tree/v3))\n"
+    )
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_status(repo: str, token=None, branch=None):
+        calls.append((repo, branch))
+        return repo_status.RepoStatus("✅", stars=12)
+
+    monkeypatch.setattr(repo_status, "fetch_repo_status_details", fake_status)
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert calls == [("democratizedspace/dspace", "v3")]
+    assert "- ✅ ⭐ 12 **[DSPACE](https://democratized.space)**" in readme.read_text()


### PR DESCRIPTION
### Motivation
- Show GitHub star counts next to each Related Projects entry and make the updater reorder the list by stars descending (alphabetical for ties) while preserving existing failure-link and branch-aware status behavior.
- Keep README updates idempotent and preserve multi-line descriptions, external display links, and legacy failure-link formats when rewriting the section.

### Description
- Add `RepoMetadata` and extend `RepoStatus` with an optional `stars: int | None` field and a new `fetch_repo_metadata(repo, token)` helper that reads `default_branch` and `stargazers_count` from `https://api.github.com/repos/{owner}/{repo}` with graceful fallback for invalid/missing values.
- Add `format_star_count`, `strip_project_prefix` (backwards-compatible with `_strip_status_prefix`), `parse_related_project_items`, `render_project_item`, and sorting helpers to parse multi-line list items, strip stale prefixes, render `⭐ N` or `⭐ ?`, and sort items by known stars then name.
- Update `fetch_repo_status_details` to reuse repository metadata for branch detection and to include stars in the returned `RepoStatus`; update `update_readme` to rebuild only the `## Related Projects` section using the new parser/renderer and to preserve timestamp, surrounding prose, and hand-authored notes.
- Update README legend to mention star counts and sort order, and add/adjust tests in `tests/test_repo_status.py` to cover star rendering, unknown stars, branch URL handling, sorting, idempotency, multi-line items, failure links, and external display links.

### Testing
- Ran formatting and linting with `black src/repo_status.py tests/test_repo_status.py` and `ruff check --fix .`, which completed and fixed minor formatting issues.
- Ran focused tests with `python -m pytest tests/test_repo_status.py -q`, which completed successfully (`44 passed`).
- Ran full test suite with `python -m pytest -q`, which completed successfully (`313 passed, 2 warnings`).
- Ran docs checks with `npm run docs-lint`, which completed successfully.
- Per-commit checks `git diff --cached | ./scripts/scan-secrets.py` and `git diff --cached --check` were run and returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271f190154832faf6ca1826755d955)