### PR TITLE
Fix repo status: prefer newer completed run per workflow identity to suppress stale failures

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -96,6 +96,119 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
+def _normalize_identifier(value: object) -> str:
+    """Return a stable, case-insensitive identifier fragment."""
+
+    if value is None:
+        return ""
+    return re.sub(r"[\s-]+", "_", str(value).strip().lower())
+
+
+def _normalize_conclusion(value: object) -> str:
+    """Normalize GitHub workflow conclusion strings for comparisons."""
+
+    if not isinstance(value, str):
+        return ""
+    return _normalize_identifier(value)
+
+
+def _workflow_identity(run: dict) -> tuple[str, object]:
+    """Return the strongest durable workflow identity available for ``run``."""
+
+    workflow_id = run.get("workflow_id")
+    if workflow_id is not None:
+        return ("workflow_id", workflow_id)
+
+    path = run.get("path")
+    if isinstance(path, str) and path.strip():
+        return ("path", path.strip().casefold())
+
+    name = run.get("name") or run.get("workflow_name") or run.get("display_title")
+    normalized_name = _normalize_identifier(name)
+    if normalized_name:
+        return ("name", normalized_name)
+
+    run_id = run.get("id")
+    if run_id is not None:
+        return ("run_id", run_id)
+    return ("unknown", "")
+
+
+def _timestamp_key(value: object) -> tuple[int, str]:
+    if not isinstance(value, str) or not value.strip():
+        return (0, "")
+    normalized = value.strip()
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        return (1, normalized)
+    return (2, parsed.astimezone(UTC).isoformat())
+
+
+def _integer_key(value: object) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _run_recency_key(run: dict) -> tuple[tuple[int, str], int, int, int]:
+    """Return a deterministic key for selecting the newest completed run."""
+
+    timestamp = run.get("created_at") or run.get("updated_at")
+    return (
+        _timestamp_key(timestamp),
+        _integer_key(run.get("run_number")),
+        _integer_key(run.get("run_attempt")),
+        _integer_key(run.get("id")),
+    )
+
+
+def _run_attempt_key(run: dict) -> tuple[int, tuple[int, str], int, int]:
+    """Return a key that keeps rerun attempts of the same run ordered correctly."""
+
+    timestamp = run.get("updated_at") or run.get("created_at")
+    return (
+        _integer_key(run.get("run_attempt")),
+        _timestamp_key(timestamp),
+        _integer_key(run.get("run_number")),
+        _integer_key(run.get("id")),
+    )
+
+
+def _run_instance_identity(run: dict) -> tuple[object, object, object]:
+    workflow_id = run.get("workflow_id")
+    run_number = run.get("run_number")
+    run_id = run.get("id")
+    if workflow_id is not None and run_number is not None:
+        return ("workflow_run", workflow_id, run_number)
+    if run_id is not None:
+        return ("run_id", run_id, None)
+    return ("workflow_identity", _workflow_identity(run), run_number)
+
+
+def _latest_attempts_by_run(runs: Iterable[dict]) -> list[dict]:
+    latest_runs: dict[tuple[object, object, object], dict] = {}
+    for run in runs:
+        key = _run_instance_identity(run)
+        current = latest_runs.get(key)
+        if current is None or _run_attempt_key(run) > _run_attempt_key(current):
+            latest_runs[key] = run
+    return list(latest_runs.values())
+
+
+def _latest_completed_runs_by_workflow(runs: Iterable[dict]) -> list[dict]:
+    """Return the latest completed run for each workflow identity."""
+
+    latest_by_workflow: dict[tuple[str, object], dict] = {}
+    for run in _latest_attempts_by_run(runs):
+        identity = _workflow_identity(run)
+        current = latest_by_workflow.get(identity)
+        if current is None or _run_recency_key(run) > _run_recency_key(current):
+            latest_by_workflow[identity] = run
+    return list(latest_by_workflow.values())
+
+
 def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
     """Fetch default branch and star count for ``repo`` without raising."""
 
@@ -165,11 +278,6 @@ def fetch_repo_status_details(
         "startup_failure",
         "action_required",
     }
-
-    def _normalize_conclusion(value: str | None) -> str:
-        if not isinstance(value, str):
-            return ""
-        return re.sub(r"[\s-]+", "_", value.strip().lower())
 
     def _should_skip_commit(commit: dict) -> bool:
         message = commit.get("commit", {}).get("message", "")
@@ -275,46 +383,19 @@ def fetch_repo_status_details(
         )
 
     def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[StatusLink, ...]]:
-        """Return conclusion and failure links for each workflow latest attempt."""
-
-        latest_runs: dict[tuple[object, object, object], dict] = {}
-
-        def _attempt_key(run: dict) -> tuple[int, str]:
-            raw_attempt = run.get("run_attempt")
-            try:
-                attempt = int(raw_attempt)
-            except (TypeError, ValueError):
-                attempt = 0
-            updated = run.get("updated_at")
-            return (attempt, str(updated) if updated is not None else "")
-
-        for run in runs:
-            workflow_id = run.get("workflow_id")
-            run_number = run.get("run_number")
-            run_id = run.get("id")
-            if workflow_id is not None and run_number is not None:
-                key = (workflow_id, run_number, None)
-            elif run_id is not None:
-                key = (None, None, run_id)
-            else:
-                key = (None, None, run.get("name"))
-            current = latest_runs.get(key)
-            if current is None or _attempt_key(run) > _attempt_key(current):
-                latest_runs[key] = run
+        """Return conclusion and failure links for each workflow latest run."""
 
         latest = sorted(
-            latest_runs.values(),
+            _latest_completed_runs_by_workflow(runs),
             key=lambda run: (
                 _run_label(run).casefold(),
-                str(run.get("workflow_id") or ""),
+                str(_workflow_identity(run)),
                 str(run.get("run_number") or ""),
                 str(run.get("id") or ""),
             ),
         )
         failed_links = _disambiguated_failure_links(latest)
-        conclusions = {
-            _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
-        }
+        conclusions = {_normalize_conclusion(r.get("conclusion")) for r in latest}
         if any(c in failures for c in conclusions):
             return "failure", failed_links
         if "success" in conclusions:
@@ -372,25 +453,25 @@ def fetch_repo_status_details(
             )
             return None, ()
 
-        runs_by_sha: dict[str, list[dict]] = {}
+        candidate_runs: list[dict] = []
         for run in runs:
-            sha = run.get("head_sha")
-            if not isinstance(sha, str):
+            head_branch = run.get("head_branch")
+            if isinstance(head_branch, str) and head_branch != branch:
                 continue
-            runs_by_sha.setdefault(sha, []).append(run)
+            candidate_runs.append(run)
+
+        if candidate_runs:
+            important = [
+                r for r in candidate_runs if keywords.search(str(r.get("name", "")))
+            ]
+            if important:
+                candidate_runs = important
+            return _evaluate_runs(candidate_runs)
 
         for commit in commits:
             sha = commit.get("sha")
             if not isinstance(sha, str):
                 continue
-            commit_runs = runs_by_sha.get(sha, [])
-            if commit_runs:
-                important = [
-                    r for r in commit_runs if keywords.search(r.get("name", ""))
-                ]
-                if important:
-                    commit_runs = important
-                return _evaluate_runs(commit_runs)
             if _should_skip_commit(commit):
                 continue
             return None, ()

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -60,6 +60,81 @@ class DummyResp:
         return self._data
 
 
+def stub_github_status(
+    monkeypatch: pytest.MonkeyPatch,
+    runs: list[dict],
+    *,
+    commits: list[dict] | None = None,
+    default_branch: str = "main",
+    stars: int | None = None,
+) -> None:
+    if commits is None:
+        commits = [commit("new"), commit("old")]
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            data = {"default_branch": default_branch}
+            if stars is not None:
+                data["stargazers_count"] = stars
+            return DummyResp(data)
+        if url.startswith(
+            f"https://api.github.com/repos/user/repo/commits?sha={default_branch}&per_page=20"
+        ):
+            return DummyResp(commits)
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            f"per_page=100&status=completed&branch={default_branch}"
+        )
+        return DummyResp({"workflow_runs": runs})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+
+def commit(sha: str, *, message: str = "feat: update") -> dict:
+    return {
+        "sha": sha,
+        "commit": {
+            "message": message,
+            "author": {"name": "Alice"},
+            "committer": {"name": "Alice"},
+        },
+        "author": {"login": "alice"},
+        "committer": {"login": "alice"},
+    }
+
+
+def workflow_run(
+    conclusion: str,
+    *,
+    workflow_id: int | None = 100,
+    path: str | None = None,
+    name: str = "tests",
+    head_sha: str = "new",
+    head_branch: str = "main",
+    run_number: int = 2,
+    run_attempt: int = 1,
+    run_id: int = 2,
+    created_at: str = "2025-09-25T12:05:00Z",
+) -> dict:
+    run = {
+        "conclusion": conclusion,
+        "head_sha": head_sha,
+        "head_branch": head_branch,
+        "html_url": f"https://github.com/user/repo/actions/runs/{run_id}",
+        "id": run_id,
+        "name": name,
+        "run_attempt": run_attempt,
+        "run_number": run_number,
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+    if workflow_id is not None:
+        run["workflow_id"] = workflow_id
+    if path is not None:
+        run["path"] = path
+    return run
+
+
 def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
@@ -369,6 +444,280 @@ def test_fetch_repo_status_prefers_latest_attempt(
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "✅"
+
+
+def test_fetch_repo_status_newer_success_overrides_failure_by_workflow_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_github_status(
+        monkeypatch,
+        [
+            workflow_run(
+                "failure",
+                head_sha="old",
+                run_number=1,
+                run_id=1,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run("success"),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "✅"
+    )
+
+
+def test_fetch_repo_status_newer_success_overrides_failure_by_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_github_status(
+        monkeypatch,
+        [
+            workflow_run(
+                "failure",
+                workflow_id=None,
+                path=".github/workflows/tests.yml",
+                head_sha="old",
+                run_number=1,
+                run_id=1,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run(
+                "success", workflow_id=None, path=".github/workflows/tests.yml"
+            ),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "✅"
+    )
+
+
+def test_fetch_repo_status_newer_success_overrides_failure_by_normalized_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_github_status(
+        monkeypatch,
+        [
+            workflow_run(
+                "failure",
+                workflow_id=None,
+                name="Update Repo Statuses",
+                head_sha="old",
+                run_number=1,
+                run_id=1,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run(
+                "success",
+                workflow_id=None,
+                name="update-repo   statuses",
+            ),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "✅"
+    )
+
+
+def test_fetch_repo_status_unrelated_names_do_not_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_github_status(
+        monkeypatch,
+        [
+            workflow_run(
+                "failure",
+                workflow_id=None,
+                name="build",
+                head_sha="old",
+                run_number=1,
+                run_id=1,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run("success", workflow_id=None, name="tests"),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "build", "https://github.com/user/repo/actions/runs/1"
+            ),
+        ),
+    )
+
+
+def test_fetch_repo_status_different_workflow_success_does_not_hide_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_github_status(
+        monkeypatch,
+        [
+            workflow_run(
+                "failure",
+                workflow_id=100,
+                name="build",
+                head_sha="old",
+                run_number=1,
+                run_id=1,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run("success", workflow_id=200, name="tests"),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "build", "https://github.com/user/repo/actions/runs/1"
+            ),
+        ),
+    )
+
+
+def test_fetch_repo_status_different_branch_success_does_not_override_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_github_status(
+        monkeypatch,
+        [
+            workflow_run(
+                "failure",
+                head_sha="old",
+                run_number=1,
+                run_id=1,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run("success", head_branch="dev"),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "tests", "https://github.com/user/repo/actions/runs/1"
+            ),
+        ),
+    )
+
+
+def test_fetch_repo_status_latest_failure_keeps_latest_failure_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_github_status(
+        monkeypatch,
+        [
+            workflow_run(
+                "success",
+                head_sha="old",
+                run_number=1,
+                run_id=1,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run("failure", run_id=2),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "tests", "https://github.com/user/repo/actions/runs/2"
+            ),
+        ),
+    )
+
+
+def test_fetch_repo_status_multiple_workflows_links_only_latest_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_github_status(
+        monkeypatch,
+        [
+            workflow_run(
+                "failure",
+                workflow_id=100,
+                name="tests",
+                head_sha="old",
+                run_number=1,
+                run_id=1,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run("success", workflow_id=100, name="tests", run_id=2),
+            workflow_run(
+                "success",
+                workflow_id=200,
+                name="build",
+                head_sha="old",
+                run_number=1,
+                run_id=3,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run("failure", workflow_id=200, name="build", run_id=4),
+            workflow_run("success", workflow_id=300, name="lint", run_id=5),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo") == repo_status.RepoStatus(
+        "❌",
+        (
+            repo_status.StatusLink(
+                "build", "https://github.com/user/repo/actions/runs/4"
+            ),
+        ),
+    )
+
+
+def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ❌ "
+        "([Update Repo Statuses](https://github.com/user/repo/actions/runs/27123196602)) "
+        "<!-- repo-status:failure-links --> ⭐ ? "
+        "[flywheel](https://github.com/user/repo)\n"
+    )
+    stub_github_status(
+        monkeypatch,
+        [
+            workflow_run(
+                "failure",
+                workflow_id=None,
+                name="Update Repo Statuses",
+                head_sha="old",
+                run_number=10,
+                run_id=27123196602,
+                created_at="2025-09-25T12:00:00Z",
+            ),
+            workflow_run(
+                "success",
+                workflow_id=None,
+                name="Update Repo Statuses",
+                run_number=11,
+                run_id=27123200000,
+                created_at="2025-09-25T12:05:00Z",
+            ),
+        ],
+        stars=7,
+    )
+
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
+        "- ✅ ⭐ 7 [flywheel](https://github.com/user/repo)",
+    ]
 
 
 def test_fetch_repo_status_skips_bot_commit(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Prevent stale failed workflow runs from keeping Related Projects entries red when a newer completed successful run of the same workflow on the same branch clearly supersedes the older failure.

### Description
- Added durable identity and recency helpers (`_workflow_identity`, `_normalize_identifier`, `_run_recency_key`, `_run_attempt_key`, `_run_instance_identity`, `_latest_attempts_by_run`, `_latest_completed_runs_by_workflow`) to determine same-workflow identity and deterministic recency ordering. 
- Refactored evaluation to pick the latest completed run per workflow identity on the selected branch (prefer `workflow_id`, then `path`, then normalized `name`) and preserved the existing latest-attempt behavior for reruns. 
- Updated candidate selection to prefer runs on the requested branch and to suppress older failure links when a newer same-workflow success exists, while keeping independent workflow failures, branch isolation, star-count fetching, sorting, and idempotent README rendering unchanged. 
- Added and extended unit tests in `tests/test_repo_status.py` to cover workflow-id/path/name overriding, unrelated-name isolation, branch isolation, multiple workflows, latest-attempt behavior, and the flywheel-style regression where a newer success should remove a stale failure link.

### Testing
- Ran formatter: `python -m black src/repo_status.py tests/test_repo_status.py` (succeeded).
- Ran linter: `python -m ruff check src/repo_status.py tests/test_repo_status.py` (succeeded).
- Ran targeted tests: `python -m pytest tests/test_repo_status.py -q` (57 passed).
- Ran full test suite: `python -m pytest -q` (326 passed, 2 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c73f1c64832fb0b21dfebccf1193)