### PR TITLE
Prefer newer completed workflow runs when evaluating Related Projects status

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -117,7 +117,7 @@ def _workflow_identity(run: dict) -> tuple[str, object] | None:
 
     workflow_name = _normalize_run_name(run.get("workflow_name"))
     if workflow_name:
-        return ("workflow_name", workflow_name)
+        return ("name", workflow_name)
 
     name = _normalize_run_name(run.get("name") or run.get("display_title"))
     if name:

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -109,7 +109,7 @@ def _workflow_identity(run: dict) -> tuple[str, object] | None:
 
     workflow_id = run.get("workflow_id")
     if workflow_id is not None:
-        return ("workflow_id", workflow_id)
+        return ("workflow_id", str(workflow_id))
 
     path = run.get("path")
     if isinstance(path, str) and path.strip():
@@ -118,6 +118,10 @@ def _workflow_identity(run: dict) -> tuple[str, object] | None:
     name = _normalize_run_name(run.get("name") or run.get("display_title"))
     if name:
         return ("name", name)
+
+    run_id = run.get("id")
+    if run_id is not None:
+        return ("run_id", str(run_id))
     return None
 
 
@@ -131,6 +135,8 @@ def _parse_github_timestamp(value: object) -> tuple[int, str]:
         parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
     except ValueError:
         return (0, normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
     return (1, parsed.astimezone(UTC).isoformat())
 
 
@@ -141,17 +147,19 @@ def _coerce_int(value: object) -> int:
         return 0
 
 
-def _run_recency_key(run: dict) -> tuple[tuple[int, str], int, int, int]:
+def _run_recency_key(run: dict) -> tuple[int, int, int, tuple[int, str], int]:
     """Return a deterministic key for comparing completed workflow runs."""
 
     timestamp = max(
         _parse_github_timestamp(run.get("created_at")),
         _parse_github_timestamp(run.get("updated_at")),
     )
+    run_number = run.get("run_number")
     return (
-        timestamp,
-        _coerce_int(run.get("run_number")),
+        int(run_number is not None),
+        _coerce_int(run_number),
         _coerce_int(run.get("run_attempt")),
+        timestamp,
         _coerce_int(run.get("id")),
     )
 

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -96,6 +96,110 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
+def _normalize_run_name(value: object) -> str:
+    """Normalize a workflow/run name for weak identity fallback."""
+
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"\s+", " ", value.strip().casefold())
+
+
+def _workflow_identity(run: dict) -> tuple[str, object] | None:
+    """Return the strongest durable workflow identity available for ``run``."""
+
+    workflow_id = run.get("workflow_id")
+    if workflow_id is not None:
+        return ("workflow_id", workflow_id)
+
+    path = run.get("path")
+    if isinstance(path, str) and path.strip():
+        return ("path", path.strip().casefold())
+
+    name = _normalize_run_name(run.get("name") or run.get("display_title"))
+    if name:
+        return ("name", name)
+    return None
+
+
+def _parse_github_timestamp(value: object) -> tuple[int, str]:
+    """Return a sortable timestamp key without raising for malformed values."""
+
+    if not isinstance(value, str) or not value:
+        return (0, "")
+    normalized = value.strip()
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        return (0, normalized)
+    return (1, parsed.astimezone(UTC).isoformat())
+
+
+def _coerce_int(value: object) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _run_recency_key(run: dict) -> tuple[tuple[int, str], int, int, int]:
+    """Return a deterministic key for comparing completed workflow runs."""
+
+    timestamp = max(
+        _parse_github_timestamp(run.get("created_at")),
+        _parse_github_timestamp(run.get("updated_at")),
+    )
+    return (
+        timestamp,
+        _coerce_int(run.get("run_number")),
+        _coerce_int(run.get("run_attempt")),
+        _coerce_int(run.get("id")),
+    )
+
+
+def _latest_completed_runs_by_workflow(runs: Iterable[dict]) -> list[dict]:
+    """Return the latest completed run for each workflow identity."""
+
+    latest_attempts: dict[tuple[object, object, object], dict] = {}
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        identity = _workflow_identity(run)
+        if identity is None:
+            continue
+        run_number = run.get("run_number")
+        run_id = run.get("id")
+        if run_id is not None:
+            attempt_key = (identity, None, run_id)
+        elif run_number is not None:
+            attempt_key = (identity, run_number, None)
+        else:
+            attempt_key = (identity, None, None)
+        current_attempt = latest_attempts.get(attempt_key)
+        if current_attempt is None or _run_recency_key(run) > _run_recency_key(
+            current_attempt
+        ):
+            latest_attempts[attempt_key] = run
+
+    latest_by_workflow: dict[tuple[str, object], dict] = {}
+    for run in latest_attempts.values():
+        identity = _workflow_identity(run)
+        if identity is None:
+            continue
+        current = latest_by_workflow.get(identity)
+        if current is None or _run_recency_key(run) > _run_recency_key(current):
+            latest_by_workflow[identity] = run
+
+    return sorted(
+        latest_by_workflow.values(),
+        key=lambda run: (
+            _normalize_run_name(run.get("name") or run.get("display_title")),
+            str(_workflow_identity(run) or ""),
+            _coerce_int(run.get("run_number")),
+            _coerce_int(run.get("id")),
+        ),
+    )
+
+
 def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
     """Fetch default branch and star count for ``repo`` without raising."""
 
@@ -274,53 +378,22 @@ def fetch_repo_status_details(
             )
         )
 
-    def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[StatusLink, ...]]:
-        """Return conclusion and failure links for each workflow latest attempt."""
+    def _evaluate_runs(
+        runs: Iterable[dict],
+    ) -> tuple[str | None, tuple[StatusLink, ...]]:
+        """Return conclusion and failure links for each workflow's latest run."""
 
-        latest_runs: dict[tuple[object, object, object], dict] = {}
-
-        def _attempt_key(run: dict) -> tuple[int, str]:
-            raw_attempt = run.get("run_attempt")
-            try:
-                attempt = int(raw_attempt)
-            except (TypeError, ValueError):
-                attempt = 0
-            updated = run.get("updated_at")
-            return (attempt, str(updated) if updated is not None else "")
-
-        for run in runs:
-            workflow_id = run.get("workflow_id")
-            run_number = run.get("run_number")
-            run_id = run.get("id")
-            if workflow_id is not None and run_number is not None:
-                key = (workflow_id, run_number, None)
-            elif run_id is not None:
-                key = (None, None, run_id)
-            else:
-                key = (None, None, run.get("name"))
-            current = latest_runs.get(key)
-            if current is None or _attempt_key(run) > _attempt_key(current):
-                latest_runs[key] = run
-
-        latest = sorted(
-            latest_runs.values(),
-            key=lambda run: (
-                _run_label(run).casefold(),
-                str(run.get("workflow_id") or ""),
-                str(run.get("run_number") or ""),
-                str(run.get("id") or ""),
-            ),
-        )
+        latest = _latest_completed_runs_by_workflow(runs)
         failed_links = _disambiguated_failure_links(latest)
-        conclusions = {
-            _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
-        }
+        conclusions = {_normalize_conclusion(r.get("conclusion")) for r in latest}
         if any(c in failures for c in conclusions):
             return "failure", failed_links
         if "success" in conclusions:
             return "success", ()
-        # Default to failure so lack of CI coverage surfaces as ❌
-        return "failure", failed_links
+        if conclusions:
+            # Completed runs with non-success conclusions still indicate no green CI.
+            return "failure", failed_links
+        return None, ()
 
     def _fetch() -> tuple[str | None, tuple[StatusLink, ...]]:
         try:
@@ -374,27 +447,33 @@ def fetch_repo_status_details(
 
         runs_by_sha: dict[str, list[dict]] = {}
         for run in runs:
+            run_branch = run.get("head_branch")
+            if isinstance(run_branch, str) and branch and run_branch != branch:
+                continue
             sha = run.get("head_sha")
             if not isinstance(sha, str):
                 continue
             runs_by_sha.setdefault(sha, []).append(run)
 
+        selected_runs: list[dict] = []
         for commit in commits:
             sha = commit.get("sha")
             if not isinstance(sha, str):
                 continue
             commit_runs = runs_by_sha.get(sha, [])
             if commit_runs:
-                important = [
-                    r for r in commit_runs if keywords.search(r.get("name", ""))
-                ]
-                if important:
-                    commit_runs = important
-                return _evaluate_runs(commit_runs)
+                selected_runs.extend(commit_runs)
+                continue
             if _should_skip_commit(commit):
                 continue
+            break
+
+        if not selected_runs:
             return None, ()
-        return None, ()
+        important = [r for r in selected_runs if keywords.search(r.get("name", ""))]
+        if important:
+            selected_runs = important
+        return _evaluate_runs(selected_runs)
 
     reports = [_fetch() for _ in range(attempts)]
     conclusions = [report[0] for report in reports]
@@ -467,6 +546,10 @@ GENERATED_FAILURE_LINKS_RE = re.compile(
     rf"^\((?:{GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)"
     rf"\s*{re.escape(GENERATED_FAILURE_LINKS_MARKER)}\s*"
 )
+GENERATED_LEADING_FAILURE_LINKS_RE = re.compile(
+    rf"^(?:{GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+"
+    rf"\s*{re.escape(GENERATED_FAILURE_LINKS_MARKER)}\s*"
+)
 LEGACY_STACKED_FAILURE_LINKS_RE = re.compile(
     rf"^\((?:{GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*(?=[✅❌❓⭐])"
 )
@@ -509,6 +592,7 @@ def strip_project_prefix(line: str) -> str:
         original = content
         content = re.sub(r"^[✅❌❓]\s*", "", content, count=1).lstrip()
         content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
+        content = GENERATED_LEADING_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
         content = LEGACY_STACKED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
         content = _strip_legacy_failure_links_before_markdown_repo(content)
         content = _strip_keyworded_legacy_failure_links_before_raw_repo(content)

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -129,27 +129,14 @@ def _workflow_identity(run: dict) -> tuple[str, object] | None:
     return None
 
 
-def _workflow_identity_aliases(run: dict) -> tuple[tuple[str, object], ...]:
-    """Return identity keys that can safely refer to the same workflow.
+def _workflow_name_bridge_identity(run: dict) -> tuple[str, object] | None:
+    """Return the weak name bridge for strong same-name workflow payloads."""
 
-    ``workflow_name`` is stronger than the fallback run ``name``/``display_title``
-    identity, so it normally lives in its own namespace. GitHub payloads can be
-    inconsistent, though: one run may only include ``name="CI"`` while a newer
-    payload for the same workflow includes both ``workflow_name="CI"`` and
-    ``name="CI"``. In that exact same-name shape, include the weak name as a
-    compatibility alias so newer runs do not leave stale failures behind.
-    """
-
-    identity = _workflow_identity(run)
-    if identity is None:
-        return ()
-
-    aliases = [identity]
-    if identity[0] == "workflow_name":
-        fallback_name = _normalize_run_name(run.get("name") or run.get("display_title"))
-        if fallback_name and fallback_name == identity[1]:
-            aliases.append(("name", fallback_name))
-    return tuple(aliases)
+    workflow_name = _normalize_run_name(run.get("workflow_name"))
+    fallback_name = _normalize_run_name(run.get("name") or run.get("display_title"))
+    if workflow_name and workflow_name == fallback_name:
+        return ("name", fallback_name)
+    return None
 
 
 def _parse_github_timestamp(value: object) -> tuple[int, str]:
@@ -217,20 +204,32 @@ def _latest_completed_runs_by_workflow(runs: Iterable[dict]) -> list[dict]:
 
     latest_by_workflow: dict[tuple[str, object], dict] = {}
     for run in latest_attempts.values():
-        identities = _workflow_identity_aliases(run)
-        if not identities:
+        identity = _workflow_identity(run)
+        if identity is None:
             continue
-        current = next(
-            (
-                latest_by_workflow[identity]
-                for identity in identities
-                if identity in latest_by_workflow
-            ),
-            None,
+
+        current = latest_by_workflow.get(identity)
+        run_is_newer = current is None or _run_recency_key(run) > _run_recency_key(
+            current
         )
-        if current is None or _run_recency_key(run) > _run_recency_key(current):
-            for identity in identities + _workflow_identity_aliases(current or {}):
-                latest_by_workflow[identity] = run
+        if run_is_newer:
+            latest_by_workflow[identity] = run
+
+        bridge_identity = _workflow_name_bridge_identity(run)
+        if bridge_identity is None:
+            continue
+
+        # Bridge only from a strong same-name ``workflow_name`` run to an older
+        # weak title-only identity. Never let a weak title-only run overwrite a
+        # separate strong ``workflow_name`` workflow that happens to share text.
+        bridge_current = latest_by_workflow.get(bridge_identity)
+        bridge_current_identity = _workflow_identity(bridge_current or {})
+        bridge_current_is_weak = bridge_current_identity == bridge_identity
+        if bridge_current is None or (
+            bridge_current_is_weak
+            and _run_recency_key(run) > _run_recency_key(bridge_current)
+        ):
+            latest_by_workflow[bridge_identity] = run
 
     return sorted(
         {id(run): run for run in latest_by_workflow.values()}.values(),

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -117,7 +117,7 @@ def _workflow_identity(run: dict) -> tuple[str, object] | None:
 
     workflow_name = _normalize_run_name(run.get("workflow_name"))
     if workflow_name:
-        return ("name", workflow_name)
+        return ("workflow_name", workflow_name)
 
     name = _normalize_run_name(run.get("name") or run.get("display_title"))
     if name:
@@ -127,6 +127,29 @@ def _workflow_identity(run: dict) -> tuple[str, object] | None:
     if run_id is not None:
         return ("run_id", str(run_id))
     return None
+
+
+def _workflow_identity_aliases(run: dict) -> tuple[tuple[str, object], ...]:
+    """Return identity keys that can safely refer to the same workflow.
+
+    ``workflow_name`` is stronger than the fallback run ``name``/``display_title``
+    identity, so it normally lives in its own namespace. GitHub payloads can be
+    inconsistent, though: one run may only include ``name="CI"`` while a newer
+    payload for the same workflow includes both ``workflow_name="CI"`` and
+    ``name="CI"``. In that exact same-name shape, include the weak name as a
+    compatibility alias so newer runs do not leave stale failures behind.
+    """
+
+    identity = _workflow_identity(run)
+    if identity is None:
+        return ()
+
+    aliases = [identity]
+    if identity[0] == "workflow_name":
+        fallback_name = _normalize_run_name(run.get("name") or run.get("display_title"))
+        if fallback_name and fallback_name == identity[1]:
+            aliases.append(("name", fallback_name))
+    return tuple(aliases)
 
 
 def _parse_github_timestamp(value: object) -> tuple[int, str]:
@@ -194,15 +217,23 @@ def _latest_completed_runs_by_workflow(runs: Iterable[dict]) -> list[dict]:
 
     latest_by_workflow: dict[tuple[str, object], dict] = {}
     for run in latest_attempts.values():
-        identity = _workflow_identity(run)
-        if identity is None:
+        identities = _workflow_identity_aliases(run)
+        if not identities:
             continue
-        current = latest_by_workflow.get(identity)
+        current = next(
+            (
+                latest_by_workflow[identity]
+                for identity in identities
+                if identity in latest_by_workflow
+            ),
+            None,
+        )
         if current is None or _run_recency_key(run) > _run_recency_key(current):
-            latest_by_workflow[identity] = run
+            for identity in identities + _workflow_identity_aliases(current or {}):
+                latest_by_workflow[identity] = run
 
     return sorted(
-        latest_by_workflow.values(),
+        {id(run): run for run in latest_by_workflow.values()}.values(),
         key=lambda run: (
             _normalize_run_name(run.get("name") or run.get("display_title")),
             str(_workflow_identity(run) or ""),

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -73,7 +73,7 @@ def status_to_emoji(conclusion: str | None) -> str:
     ``"SUCCESS"``, ``" failure \n"``, or ``"TIMED\tOUT"`` and receive the same
     result.
 
-    - ``"success"`` → ✅
+    - ``"success"``, ``"neutral"``, ``"skipped"`` → ✅
     - ``"failure"``, ``"cancelled"``, ``"canceled"``, ``"timed_out"``,
       ``"startup_failure"``, ``"action_required"`` → ❌
     - anything else (including ``None`` or non-strings) → ❓
@@ -82,7 +82,7 @@ def status_to_emoji(conclusion: str | None) -> str:
         normalized = ""
     else:
         normalized = re.sub(r"[\s-]+", "_", conclusion.strip().lower())
-    if normalized == "success":
+    if normalized in {"success", "neutral", "skipped"}:
         return "✅"
     if normalized in {
         "failure",
@@ -114,6 +114,10 @@ def _workflow_identity(run: dict) -> tuple[str, object] | None:
     path = run.get("path")
     if isinstance(path, str) and path.strip():
         return ("path", path.strip().casefold())
+
+    workflow_name = _normalize_run_name(run.get("workflow_name"))
+    if workflow_name:
+        return ("workflow_name", workflow_name)
 
     name = _normalize_run_name(run.get("name") or run.get("display_title"))
     if name:
@@ -277,6 +281,7 @@ def fetch_repo_status_details(
         "startup_failure",
         "action_required",
     }
+    passing = {"success", "neutral", "skipped"}
 
     def _normalize_conclusion(value: str | None) -> str:
         if not isinstance(value, str):
@@ -396,7 +401,7 @@ def fetch_repo_status_details(
         conclusions = {_normalize_conclusion(r.get("conclusion")) for r in latest}
         if any(c in failures for c in conclusions):
             return "failure", failed_links
-        if "success" in conclusions:
+        if any(c in passing for c in conclusions):
             return "success", ()
         if conclusions:
             # Completed runs with non-success conclusions still indicate no green CI.

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -216,12 +216,14 @@ def _latest_completed_runs_by_workflow(runs: Iterable[dict]) -> list[dict]:
             latest_by_workflow[identity] = run
 
         bridge_identity = _workflow_name_bridge_identity(run)
-        if bridge_identity is None:
+        if bridge_identity is None or identity[0] != "workflow_name":
             continue
 
-        # Bridge only from a strong same-name ``workflow_name`` run to an older
-        # weak title-only identity. Never let a weak title-only run overwrite a
-        # separate strong ``workflow_name`` workflow that happens to share text.
+        # Bridge only from a same-name ``workflow_name`` run to an older weak
+        # title-only identity. Runs with stronger IDs or paths must not bridge,
+        # because they can be unrelated workflows that happen to share a title.
+        # Never let a weak title-only run overwrite a separate strong
+        # ``workflow_name`` workflow that happens to share text.
         bridge_current = latest_by_workflow.get(bridge_identity)
         bridge_current_identity = _workflow_identity(bridge_current or {})
         bridge_current_is_weak = bridge_current_identity == bridge_identity

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -807,6 +807,49 @@ def test_fetch_repo_status_workflow_name_and_name_do_not_weak_merge_newer_title_
     )
 
 
+def test_fetch_repo_status_workflow_id_does_not_bridge_to_weak_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="CI",
+                workflow_id=None,
+                path=None,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="CI",
+                workflow_id=7,
+                path=None,
+                workflow_name="CI",
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "CI", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
 def test_fetch_repo_status_workflow_name_precedes_run_name_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -60,6 +60,81 @@ class DummyResp:
         return self._data
 
 
+def _human_commit(sha: str, message: str = "feat: update") -> dict:
+    return {
+        "sha": sha,
+        "commit": {
+            "message": message,
+            "author": {"name": "Alice"},
+            "committer": {"name": "Alice"},
+        },
+        "author": {"login": "alice"},
+        "committer": {"login": "alice"},
+    }
+
+
+def _workflow_run(
+    conclusion: str,
+    *,
+    sha: str = "abc",
+    name: str = "Test Suite",
+    workflow_id: int | None = 123,
+    path: str | None = ".github/workflows/tests.yml",
+    run_number: int = 1,
+    run_attempt: int = 1,
+    created_at: str = "2025-09-25T12:00:00Z",
+    updated_at: str | None = None,
+    run_id: int | None = None,
+    branch: str = "main",
+) -> dict:
+    run: dict = {
+        "conclusion": conclusion,
+        "head_sha": sha,
+        "head_branch": branch,
+        "name": name,
+        "run_number": run_number,
+        "run_attempt": run_attempt,
+        "created_at": created_at,
+        "html_url": f"https://github.com/user/repo/actions/runs/{run_id or run_number}",
+    }
+    if workflow_id is not None:
+        run["workflow_id"] = workflow_id
+    if path is not None:
+        run["path"] = path
+    if updated_at is not None:
+        run["updated_at"] = updated_at
+    if run_id is not None:
+        run["id"] = run_id
+    return run
+
+
+def _mock_repo_status_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    runs: list[dict],
+    *,
+    commits: list[dict] | None = None,
+    branch: str = "main",
+    stars: int | None = None,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            data: dict = {"default_branch": branch}
+            if stars is not None:
+                data["stargazers_count"] = stars
+            return DummyResp(data)
+        if url.startswith(
+            f"https://api.github.com/repos/user/repo/commits?sha={branch}&per_page=20"
+        ):
+            return DummyResp(commits or [_human_commit("abc")])
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            f"per_page=100&status=completed&branch={branch}"
+        )
+        return DummyResp({"workflow_runs": runs})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+
 def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
@@ -369,6 +444,316 @@ def test_fetch_repo_status_prefers_latest_attempt(
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "✅"
+
+
+def test_fetch_repo_status_newer_success_overrides_failed_workflow_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                workflow_id=7,
+                run_number=10,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=10,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                workflow_id=7,
+                run_number=11,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=11,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_newer_success_overrides_failed_workflow_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                workflow_id=None,
+                path=".github/workflows/ci.yml",
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                workflow_id=None,
+                path=".github/workflows/ci.yml",
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_newer_success_overrides_failed_normalized_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name=" Test   Suite ",
+                workflow_id=None,
+                path=None,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="test suite",
+                workflow_id=None,
+                path=None,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_unrelated_names_do_not_override_each_other(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="Test Suite",
+                workflow_id=None,
+                path=None,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="Lint Suite",
+                workflow_id=None,
+                path=None,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Test Suite", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_newer_different_workflow_success_keeps_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="Test Suite",
+                workflow_id=1,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="Lint Suite",
+                workflow_id=2,
+                path=".github/workflows/lint.yml",
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Test Suite", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_different_branch_success_does_not_override_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="main-sha",
+                workflow_id=7,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+                branch="main",
+            ),
+            _workflow_run(
+                "success",
+                sha="dev-sha",
+                workflow_id=7,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+                branch="dev",
+            ),
+        ],
+        commits=[_human_commit("main-sha"), _human_commit("dev-sha")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Test Suite", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_latest_failed_run_links_latest_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "success",
+                sha="old",
+                workflow_id=7,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "failure",
+                sha="new",
+                workflow_id=7,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Test Suite", "https://github.com/user/repo/actions/runs/2"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_multiple_workflows_link_only_latest_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="Test Suite",
+                workflow_id=1,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="Test Suite",
+                workflow_id=1,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+            _workflow_run(
+                "failure",
+                sha="new",
+                name="Lint Suite",
+                workflow_id=2,
+                path=".github/workflows/lint.yml",
+                run_number=3,
+                created_at="2025-09-25T13:05:00Z",
+                run_id=3,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Lint Suite", "https://github.com/user/repo/actions/runs/3"
+                ),
+            ),
+        )
+    )
 
 
 def test_fetch_repo_status_skips_bot_commit(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1405,6 +1790,75 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
         "- ✅ ⭐ ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
         "https://github.com/user/repo - desc",
     ]
+
+
+def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import datetime
+
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "# Futuroptimist\n\n"
+        "## Related Projects\n"
+        "- ❌ [Update Repo Statuses](https://github.com/futuroptimist/flywheel/actions/"
+        "runs/27123196602) "
+        "<!-- repo-status:failure-links --> ⭐ ? "
+        "**[flywheel](https://github.com/futuroptimist/flywheel)** - automate the loop\n",
+        encoding="utf-8",
+    )
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/futuroptimist/flywheel":
+            return DummyResp({"default_branch": "main", "stargazers_count": 9})
+        if url.startswith(
+            "https://api.github.com/repos/futuroptimist/flywheel/commits?sha=main&per_page=20"
+        ):
+            return DummyResp([_human_commit("new"), _human_commit("old")])
+        assert url == (
+            "https://api.github.com/repos/futuroptimist/flywheel/actions/runs?"
+            "per_page=100&status=completed&branch=main"
+        )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "failure",
+                        "head_sha": "old",
+                        "head_branch": "main",
+                        "name": "Update Repo Statuses",
+                        "workflow_id": 99,
+                        "run_number": 20,
+                        "run_attempt": 1,
+                        "created_at": "2025-09-25T12:00:00Z",
+                        "html_url": "https://github.com/futuroptimist/flywheel/actions/runs/27123196602",
+                    },
+                    {
+                        "conclusion": "success",
+                        "head_sha": "new",
+                        "head_branch": "main",
+                        "name": "Update Repo Statuses",
+                        "workflow_id": 99,
+                        "run_number": 21,
+                        "run_attempt": 1,
+                        "created_at": "2025-09-25T13:00:00Z",
+                        "html_url": "https://github.com/futuroptimist/flywheel/actions/runs/27199999999",
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    repo_status.update_readme(readme, now=datetime(2025, 9, 25, 14, 0, tzinfo=UTC))
+
+    rendered = readme.read_text(encoding="utf-8")
+    assert (
+        "- ✅ ⭐ 9 **[flywheel](https://github.com/futuroptimist/flywheel)** - automate the loop"
+        in rendered
+    )
+    assert "27123196602" not in rendered
+    assert "repo-status:failure-links" not in rendered
 
 
 def test_profile_readme_related_projects_copy_is_parseable() -> None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -78,7 +78,7 @@ def _workflow_run(
     *,
     sha: str = "abc",
     name: str = "Test Suite",
-    workflow_id: int | None = 123,
+    workflow_id: int | str | None = 123,
     path: str | None = ".github/workflows/tests.yml",
     run_number: int = 1,
     run_attempt: int = 1,
@@ -474,6 +474,105 @@ def test_fetch_repo_status_newer_success_overrides_failed_workflow_id(
 
     assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
         repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_preserves_id_only_failed_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            {
+                "conclusion": "failure",
+                "head_sha": "abc",
+                "head_branch": "main",
+                "id": 99,
+                "html_url": "https://github.com/user/repo/actions/runs/99",
+            }
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "workflow run", "https://github.com/user/repo/actions/runs/99"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_mixed_workflow_id_types_share_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                workflow_id=7,
+                run_number=10,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=10,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                workflow_id="7",
+                run_number=11,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=11,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_run_number_beats_later_updated_at(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                workflow_id=7,
+                run_number=10,
+                created_at="2025-09-25T12:00:00Z",
+                updated_at="2025-09-25T14:00:00Z",
+                run_id=10,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                workflow_id=7,
+                run_number=11,
+                created_at="2025-09-25T13:00:00Z",
+                updated_at="2025-09-25T13:05:00Z",
+                run_id=11,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_parse_github_timestamp_treats_naive_iso_as_utc() -> None:
+    assert repo_status._parse_github_timestamp("2025-09-25T12:00:00") == (
+        1,
+        "2025-09-25T12:00:00+00:00",
     )
 
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -721,6 +721,49 @@ def test_fetch_repo_status_mixed_workflow_name_and_name_share_identity(
     )
 
 
+def test_fetch_repo_status_workflow_name_does_not_merge_unrelated_run_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="Test Suite",
+                workflow_id=None,
+                path=None,
+                workflow_name="Deploy",
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="Deploy",
+                workflow_id=None,
+                path=None,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Test Suite", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
 def test_fetch_repo_status_workflow_name_precedes_run_name_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -16,7 +16,8 @@ def test_status_to_emoji() -> None:
     assert status_to_emoji("SUCCESS") == "✅"
     assert status_to_emoji("FAILURE") == "❌"
     assert status_to_emoji(None) == "❓"
-    assert status_to_emoji("neutral") == "❓"
+    assert status_to_emoji("neutral") == "✅"
+    assert status_to_emoji("skipped") == "✅"
 
 
 def test_status_to_emoji_strips_whitespace() -> None:
@@ -80,6 +81,7 @@ def _workflow_run(
     name: str = "Test Suite",
     workflow_id: int | str | None = 123,
     path: str | None = ".github/workflows/tests.yml",
+    workflow_name: str | None = None,
     run_number: int = 1,
     run_attempt: int = 1,
     created_at: str = "2025-09-25T12:00:00Z",
@@ -101,6 +103,8 @@ def _workflow_run(
         run["workflow_id"] = workflow_id
     if path is not None:
         run["path"] = path
+    if workflow_name is not None:
+        run["workflow_name"] = workflow_name
     if updated_at is not None:
         run["updated_at"] = updated_at
     if run_id is not None:
@@ -637,6 +641,160 @@ def test_fetch_repo_status_newer_success_overrides_failed_normalized_name(
             ),
         ],
         commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_newer_success_overrides_failed_workflow_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="run title changed",
+                workflow_id=None,
+                path=None,
+                workflow_name=" CI   Checks ",
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="different run title",
+                workflow_id=None,
+                path=None,
+                workflow_name="ci checks",
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_workflow_name_precedes_run_name_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="Test Suite",
+                workflow_id=None,
+                path=None,
+                workflow_name="CI",
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="Test Suite",
+                workflow_id=None,
+                path=None,
+                workflow_name="Deploy",
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Test Suite", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_bot_success_overrides_older_same_workflow_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                workflow_id=7,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="bot",
+                workflow_id=7,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[
+            {
+                "sha": "bot",
+                "commit": {
+                    "message": "chore: automated update",
+                    "author": {"name": "github-actions[bot]"},
+                    "committer": {"name": "github-actions[bot]"},
+                },
+                "author": {"login": "github-actions[bot]"},
+                "committer": {"login": "github-actions[bot]"},
+            },
+            _human_commit("old"),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_neutral_and_skipped_are_passing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "neutral",
+                sha="abc",
+                workflow_id=7,
+                run_number=1,
+                run_id=1,
+            ),
+            _workflow_run(
+                "skipped",
+                sha="abc",
+                name="Lint Suite",
+                workflow_id=8,
+                path=".github/workflows/lint.yml",
+                run_number=1,
+                run_id=2,
+            ),
+        ],
     )
 
     assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -764,6 +764,49 @@ def test_fetch_repo_status_workflow_name_does_not_merge_unrelated_run_title(
     )
 
 
+def test_fetch_repo_status_workflow_name_and_name_do_not_weak_merge_newer_title_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="CI",
+                workflow_id=None,
+                path=None,
+                workflow_name="CI",
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="CI",
+                workflow_id=None,
+                path=None,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "CI", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
 def test_fetch_repo_status_workflow_name_precedes_run_name_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -685,6 +685,42 @@ def test_fetch_repo_status_newer_success_overrides_failed_workflow_name(
     )
 
 
+def test_fetch_repo_status_mixed_workflow_name_and_name_share_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="CI",
+                workflow_id=None,
+                path=None,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="CI",
+                workflow_id=None,
+                path=None,
+                workflow_name="CI",
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
 def test_fetch_repo_status_workflow_name_precedes_run_name_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -47,6 +47,44 @@ def test_status_to_emoji_failure_variants() -> None:
     assert status_to_emoji("action required") == "❌"
 
 
+def test_status_to_emoji_unrecognized_status_is_unknown() -> None:
+    assert status_to_emoji("queued") == "❓"
+    assert status_to_emoji("mysterious") == "❓"
+
+
+def test_workflow_identity_order_and_unknown_fallback() -> None:
+    assert repo_status._workflow_identity(
+        {
+            "workflow_id": 7,
+            "path": ".github/workflows/ci.yml",
+            "workflow_name": "Deploy",
+            "name": "CI",
+            "display_title": "Fallback",
+        }
+    ) == ("workflow_id", "7")
+    assert repo_status._workflow_identity(
+        {
+            "path": " .github/workflows/ci.yml ",
+            "workflow_name": "Deploy",
+            "name": "CI",
+            "display_title": "Fallback",
+        }
+    ) == ("path", ".github/workflows/ci.yml")
+    assert repo_status._workflow_identity(
+        {"workflow_name": " Deploy  Checks ", "name": "CI"}
+    ) == ("workflow_name", "deploy checks")
+    assert repo_status._workflow_identity({"name": " CI  Checks "}) == (
+        "name",
+        "ci checks",
+    )
+    assert repo_status._workflow_identity({"display_title": " CI  Checks "}) == (
+        "name",
+        "ci checks",
+    )
+    assert repo_status._workflow_identity({"id": 123}) == ("run_id", "123")
+    assert repo_status._workflow_identity({}) is None
+
+
 class DummyResp:
     def __init__(self, data, *, json_error: Exception | None = None):
         self._data = data


### PR DESCRIPTION
### Motivation
- Prevent stale failed workflow runs from keeping a repository marked ❌ in the README when a newer completed successful run of the same workflow on the same branch supersedes the old failure.
- Make status determination durable across different GitHub run payload shapes by using stronger workflow identity signals and deterministic recency ordering.

### Description
- Add durable identity helpers: `_workflow_identity(run)` prefers `workflow_id`, falls back to workflow `path`, then a normalized `name` for weak identity matching. (`src/repo_status.py`)
- Add deterministic recency helpers: `_parse_github_timestamp`, `_coerce_int`, and `_run_recency_key` and a helper `_latest_completed_runs_by_workflow(runs)` that returns the latest completed run per workflow identity using timestamps, `run_number`, `run_attempt`, and `id` as tie-breakers. (`src/repo_status.py`)
- Refactor evaluation to use the latest completed run per workflow identity (not just runs for the first matching commit), preserve latest-attempt rerun behavior, and respect branch isolation and keywords filtering. Failures are reported only when a workflow identity's latest completed run on the selected branch is failing. (`src/repo_status.py`)
- Improve README prefix stripping to remove stale generated leading failure links so stale run links are not preserved when a newer same-workflow success supersedes them. (`src/repo_status.py`)
- Add unit tests covering: newer-success-overrides-old-failure for `workflow_id`, `path`, and normalized `name` fallbacks; unrelated workflows and different-branch runs not masking failures; latest-failure linking; multi-workflow behavior; and a regression test reproducing the flywheel README false-positive case. (`tests/test_repo_status.py`)

### Testing
- Ran linters: `ruff check src/repo_status.py tests/test_repo_status.py` (passed).
- Ran the focused tests: `python -m pytest tests/test_repo_status.py -q` which passed (`57 passed`).
- Ran full test suite: `python -m pytest -q` which passed (`326 passed`, 2 existing warnings reported by pytest).
- Verified dependency/dev install when needed via `python -m pip install '.[dev]'` and scanned staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (no secrets found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c73f1c64832fb0b21dfebccf1193)