### PR TITLE
Fix stale Related Projects workflow status detection

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -96,6 +96,113 @@ def status_to_emoji(conclusion: str | None) -> str:
     return "❓"
 
 
+def _normalize_conclusion(value: str | None) -> str:
+    """Normalize GitHub Actions conclusions for durable comparisons."""
+
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"[\s-]+", "_", value.strip().lower())
+
+
+def _normalize_workflow_name(value: object) -> str:
+    """Normalize weak workflow names used only as a last-resort identity."""
+
+    return re.sub(r"\s+", " ", str(value).strip()).casefold()
+
+
+def _workflow_identity(run: dict) -> tuple[str, object]:
+    """Return the strongest durable workflow identity available for a run."""
+
+    workflow_id = run.get("workflow_id")
+    if workflow_id is not None:
+        return ("workflow_id", workflow_id)
+
+    path = run.get("path")
+    if isinstance(path, str) and path.strip():
+        return ("path", path.strip().casefold())
+
+    name = run.get("name") or run.get("display_title") or ""
+    return ("name", _normalize_workflow_name(name))
+
+
+def _coerce_int(value: object) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _parse_github_timestamp(value: object) -> tuple[int, str]:
+    """Return a sortable timestamp key without raising on malformed data."""
+
+    if not isinstance(value, str) or not value:
+        return (0, "")
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return (0, value)
+    return (1, parsed.astimezone(UTC).isoformat())
+
+
+def _run_recency_key(run: dict) -> tuple[tuple[int, str], int, int]:
+    """Return a deterministic key for selecting the newer completed run."""
+
+    timestamp = run.get("created_at") or run.get("updated_at")
+    return (
+        _parse_github_timestamp(timestamp),
+        _coerce_int(run.get("run_number")),
+        _coerce_int(run.get("run_attempt")),
+    )
+
+
+def _run_attempt_key(run: dict) -> tuple[int, tuple[int, str]]:
+    """Return a deterministic key for selecting the latest attempt of one run."""
+
+    return (
+        _coerce_int(run.get("run_attempt")),
+        _parse_github_timestamp(run.get("updated_at") or run.get("created_at")),
+    )
+
+
+def _run_instance_identity(run: dict) -> tuple[object, object, object]:
+    workflow_id = run.get("workflow_id")
+    run_number = run.get("run_number")
+    run_id = run.get("id")
+    if workflow_id is not None and run_number is not None:
+        return ("workflow_run", workflow_id, run_number)
+    if run_id is not None:
+        return ("run_id", run_id, None)
+    return ("workflow_name_run", _workflow_identity(run), run_number)
+
+
+def _latest_completed_runs_by_workflow(runs: Iterable[dict]) -> list[dict]:
+    """Collapse reruns and return the latest completed run per workflow identity."""
+
+    latest_attempts: dict[tuple[object, object, object], dict] = {}
+    for run in runs:
+        current = latest_attempts.get(_run_instance_identity(run))
+        if current is None or _run_attempt_key(run) > _run_attempt_key(current):
+            latest_attempts[_run_instance_identity(run)] = run
+
+    latest_by_workflow: dict[tuple[str, object], dict] = {}
+    for run in latest_attempts.values():
+        identity = _workflow_identity(run)
+        current = latest_by_workflow.get(identity)
+        if current is None or _run_recency_key(run) > _run_recency_key(current):
+            latest_by_workflow[identity] = run
+
+    return sorted(
+        latest_by_workflow.values(),
+        key=lambda run: (
+            _workflow_identity(run)[0],
+            str(_workflow_identity(run)[1]),
+            str(run.get("run_number") or ""),
+            str(run.get("id") or ""),
+        ),
+    )
+
+
 def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
     """Fetch default branch and star count for ``repo`` without raising."""
 
@@ -156,7 +263,7 @@ def fetch_repo_status_details(
     if branch:
         url += f"&branch={branch}"
 
-    keywords = re.compile(r"(test|lint|build|ci)", re.I)
+    keywords = re.compile(r"(test|lint|build|ci|status|security|scan|docker)", re.I)
     failures = {
         "failure",
         "cancelled",
@@ -165,11 +272,6 @@ def fetch_repo_status_details(
         "startup_failure",
         "action_required",
     }
-
-    def _normalize_conclusion(value: str | None) -> str:
-        if not isinstance(value, str):
-            return ""
-        return re.sub(r"[\s-]+", "_", value.strip().lower())
 
     def _should_skip_commit(commit: dict) -> bool:
         message = commit.get("commit", {}).get("message", "")
@@ -274,47 +376,16 @@ def fetch_repo_status_details(
             )
         )
 
-    def _evaluate_runs(runs: Iterable[dict]) -> tuple[str, tuple[StatusLink, ...]]:
-        """Return conclusion and failure links for each workflow latest attempt."""
+    def _evaluate_runs(
+        runs: Iterable[dict],
+    ) -> tuple[str | None, tuple[StatusLink, ...]]:
+        """Return conclusion and failure links for latest workflow runs."""
 
-        latest_runs: dict[tuple[object, object, object], dict] = {}
-
-        def _attempt_key(run: dict) -> tuple[int, str]:
-            raw_attempt = run.get("run_attempt")
-            try:
-                attempt = int(raw_attempt)
-            except (TypeError, ValueError):
-                attempt = 0
-            updated = run.get("updated_at")
-            return (attempt, str(updated) if updated is not None else "")
-
-        for run in runs:
-            workflow_id = run.get("workflow_id")
-            run_number = run.get("run_number")
-            run_id = run.get("id")
-            if workflow_id is not None and run_number is not None:
-                key = (workflow_id, run_number, None)
-            elif run_id is not None:
-                key = (None, None, run_id)
-            else:
-                key = (None, None, run.get("name"))
-            current = latest_runs.get(key)
-            if current is None or _attempt_key(run) > _attempt_key(current):
-                latest_runs[key] = run
-
-        latest = sorted(
-            latest_runs.values(),
-            key=lambda run: (
-                _run_label(run).casefold(),
-                str(run.get("workflow_id") or ""),
-                str(run.get("run_number") or ""),
-                str(run.get("id") or ""),
-            ),
-        )
+        latest = _latest_completed_runs_by_workflow(runs)
+        if not latest:
+            return None, ()
         failed_links = _disambiguated_failure_links(latest)
-        conclusions = {
-            _normalize_conclusion(r.get("conclusion")) for r in latest_runs.values()
-        }
+        conclusions = {_normalize_conclusion(r.get("conclusion")) for r in latest}
         if any(c in failures for c in conclusions):
             return "failure", failed_links
         if "success" in conclusions:
@@ -372,29 +443,33 @@ def fetch_repo_status_details(
             )
             return None, ()
 
-        runs_by_sha: dict[str, list[dict]] = {}
-        for run in runs:
-            sha = run.get("head_sha")
-            if not isinstance(sha, str):
-                continue
-            runs_by_sha.setdefault(sha, []).append(run)
-
-        for commit in commits:
-            sha = commit.get("sha")
-            if not isinstance(sha, str):
-                continue
-            commit_runs = runs_by_sha.get(sha, [])
-            if commit_runs:
-                important = [
-                    r for r in commit_runs if keywords.search(r.get("name", ""))
-                ]
-                if important:
-                    commit_runs = important
-                return _evaluate_runs(commit_runs)
-            if _should_skip_commit(commit):
-                continue
+        branch_runs = [
+            run
+            for run in runs
+            if not isinstance(run.get("head_branch"), str)
+            or run.get("head_branch") == branch
+        ]
+        if not branch_runs:
             return None, ()
-        return None, ()
+
+        important = [
+            r
+            for r in branch_runs
+            if keywords.search(
+                " ".join(
+                    str(value)
+                    for value in (r.get("name"), r.get("display_title"), r.get("path"))
+                    if value is not None
+                )
+            )
+        ]
+        if important:
+            branch_runs = important
+
+        if not any(not _should_skip_commit(commit) for commit in commits):
+            LOGGER.info("Only bot or skip-ci commits found for %s@%s", repo, branch)
+
+        return _evaluate_runs(branch_runs)
 
     reports = [_fetch() for _ in range(attempts)]
     conclusions = [report[0] for report in reports]

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -60,6 +60,78 @@ class DummyResp:
         return self._data
 
 
+def _commit(sha: str = "abc", message: str = "feat: update") -> dict:
+    return {
+        "sha": sha,
+        "commit": {
+            "message": message,
+            "author": {"name": "Alice"},
+            "committer": {"name": "Alice"},
+        },
+        "author": {"login": "alice"},
+        "committer": {"login": "alice"},
+    }
+
+
+def _mock_repo_status_api(
+    monkeypatch: pytest.MonkeyPatch,
+    runs: list[dict],
+    *,
+    branch: str = "main",
+    default_branch: str = "main",
+    commits: list[dict] | None = None,
+) -> None:
+    commits = commits if commits is not None else [_commit("new"), _commit("old")]
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": default_branch})
+        if url.startswith(
+            f"https://api.github.com/repos/user/repo/commits?sha={branch}&per_page=20"
+        ):
+            return DummyResp(commits)
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            f"per_page=100&status=completed&branch={branch}"
+        )
+        return DummyResp({"workflow_runs": runs})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+
+def _run(
+    conclusion: str,
+    *,
+    name: str = "CI",
+    workflow_id: int | None = 1,
+    path: str | None = None,
+    head_sha: str = "new",
+    head_branch: str = "main",
+    run_number: int = 1,
+    run_attempt: int = 1,
+    created_at: str = "2026-01-01T00:00:00Z",
+    run_id: int | None = None,
+) -> dict:
+    run = {
+        "conclusion": conclusion,
+        "created_at": created_at,
+        "head_branch": head_branch,
+        "head_sha": head_sha,
+        "html_url": f"https://github.com/user/repo/actions/runs/{run_id or run_number}",
+        "name": name,
+        "run_attempt": run_attempt,
+        "run_number": run_number,
+        "updated_at": created_at,
+    }
+    if workflow_id is not None:
+        run["workflow_id"] = workflow_id
+    if path is not None:
+        run["path"] = path
+    if run_id is not None:
+        run["id"] = run_id
+    return run
+
+
 def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
@@ -465,6 +537,402 @@ def test_fetch_repo_status_skip_ci_message(monkeypatch: pytest.MonkeyPatch) -> N
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "✅"
+
+
+def test_fetch_repo_status_newer_success_overrides_failure_by_workflow_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            _run(
+                "failure",
+                workflow_id=42,
+                head_sha="old",
+                run_number=9,
+                created_at="2026-01-01T00:00:00Z",
+            ),
+            _run(
+                "success",
+                workflow_id=42,
+                head_sha="new",
+                run_number=10,
+                created_at="2026-01-02T00:00:00Z",
+            ),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_newer_success_overrides_failure_by_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            _run(
+                "failure",
+                workflow_id=None,
+                path=".github/workflows/ci.yml",
+                head_sha="old",
+                run_number=4,
+                created_at="2026-01-01T00:00:00Z",
+            ),
+            _run(
+                "success",
+                workflow_id=None,
+                path=".github/workflows/CI.yml",
+                head_sha="new",
+                run_number=5,
+                created_at="2026-01-02T00:00:00Z",
+            ),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_newer_success_overrides_failure_by_normalized_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            _run(
+                "failure",
+                name="Update   Repo Statuses",
+                workflow_id=None,
+                head_sha="old",
+                run_number=4,
+                created_at="2026-01-01T00:00:00Z",
+            ),
+            _run(
+                "success",
+                name="update repo statuses",
+                workflow_id=None,
+                head_sha="new",
+                run_number=5,
+                created_at="2026-01-02T00:00:00Z",
+            ),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_unrelated_name_does_not_override_current_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            _run(
+                "failure",
+                name="CI",
+                workflow_id=None,
+                head_sha="old",
+                run_number=4,
+                created_at="2026-01-01T00:00:00Z",
+                run_id=4,
+            ),
+            _run(
+                "success",
+                name="Release",
+                workflow_id=None,
+                head_sha="new",
+                run_number=5,
+                created_at="2026-01-02T00:00:00Z",
+                run_id=5,
+            ),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "CI", "https://github.com/user/repo/actions/runs/4"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_newer_different_workflow_success_does_not_hide_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            _run(
+                "failure",
+                name="CI",
+                workflow_id=1,
+                head_sha="old",
+                run_number=4,
+                created_at="2026-01-01T00:00:00Z",
+                run_id=4,
+            ),
+            _run(
+                "success",
+                name="Build",
+                workflow_id=2,
+                head_sha="new",
+                run_number=5,
+                created_at="2026-01-02T00:00:00Z",
+                run_id=5,
+            ),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "CI", "https://github.com/user/repo/actions/runs/4"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_newer_different_branch_success_does_not_override_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            _run(
+                "failure",
+                workflow_id=1,
+                head_branch="main",
+                run_number=4,
+                created_at="2026-01-01T00:00:00Z",
+                run_id=4,
+            ),
+            _run(
+                "success",
+                workflow_id=1,
+                head_branch="dev",
+                run_number=5,
+                created_at="2026-01-02T00:00:00Z",
+                run_id=5,
+            ),
+        ],
+        branch="main",
+    )
+
+    assert repo_status.fetch_repo_status_details(
+        "user/repo", branch="main", attempts=1
+    ) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "CI", "https://github.com/user/repo/actions/runs/4"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_bot_success_can_stale_normal_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bot_commit = {
+        "sha": "new",
+        "commit": {
+            "message": "chore: automated status refresh",
+            "author": {"name": "github-actions[bot]"},
+            "committer": {"name": "github-actions[bot]"},
+        },
+        "author": {"login": "github-actions[bot]"},
+        "committer": {"login": "github-actions[bot]"},
+    }
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            _run(
+                "failure",
+                workflow_id=1,
+                head_sha="old",
+                run_number=4,
+                created_at="2026-01-01T00:00:00Z",
+            ),
+            _run(
+                "success",
+                workflow_id=1,
+                head_sha="new",
+                run_number=5,
+                created_at="2026-01-02T00:00:00Z",
+            ),
+        ],
+        commits=[bot_commit, _commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_latest_failure_links_newer_run_after_older_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            _run(
+                "success",
+                workflow_id=1,
+                head_sha="old",
+                run_number=4,
+                created_at="2026-01-01T00:00:00Z",
+                run_id=4,
+            ),
+            _run(
+                "failure",
+                workflow_id=1,
+                head_sha="new",
+                run_number=5,
+                created_at="2026-01-02T00:00:00Z",
+                run_id=5,
+            ),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "CI", "https://github.com/user/repo/actions/runs/5"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_multiple_workflows_link_only_latest_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_api(
+        monkeypatch,
+        [
+            _run(
+                "failure",
+                name="CI",
+                workflow_id=1,
+                head_sha="old",
+                run_number=1,
+                created_at="2026-01-01T00:00:00Z",
+                run_id=1,
+            ),
+            _run(
+                "success",
+                name="CI",
+                workflow_id=1,
+                head_sha="new",
+                run_number=2,
+                created_at="2026-01-02T00:00:00Z",
+                run_id=2,
+            ),
+            _run(
+                "failure",
+                name="Lint",
+                workflow_id=2,
+                head_sha="new",
+                run_number=7,
+                created_at="2026-01-02T00:00:00Z",
+                run_id=7,
+            ),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Lint", "https://github.com/user/repo/actions/runs/7"
+                ),
+            ),
+        )
+    )
+
+
+def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ❌ ([Update Repo Statuses]"
+        "(https://github.com/futuroptimist/flywheel/actions/runs/27123196602)) "
+        "<!-- repo-status:failure-links --> ⭐ 2 "
+        "**[flywheel](https://github.com/futuroptimist/flywheel)** - template\n"
+    )
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        if url == "https://api.github.com/repos/futuroptimist/flywheel":
+            return DummyResp({"default_branch": "main", "stargazers_count": 2})
+        if url.startswith(
+            "https://api.github.com/repos/futuroptimist/flywheel/commits?sha=main&per_page=20"
+        ):
+            return DummyResp([_commit("new"), _commit("old")])
+        assert url == (
+            "https://api.github.com/repos/futuroptimist/flywheel/actions/runs?"
+            "per_page=100&status=completed&branch=main"
+        )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "failure",
+                        "created_at": "2026-06-08T00:00:00Z",
+                        "head_branch": "main",
+                        "head_sha": "old",
+                        "html_url": "https://github.com/futuroptimist/flywheel/actions/runs/27123196602",
+                        "name": "Update Repo Statuses",
+                        "run_attempt": 1,
+                        "run_number": 14,
+                        "updated_at": "2026-06-08T00:01:00Z",
+                        "workflow_id": 123,
+                    },
+                    {
+                        "conclusion": "success",
+                        "created_at": "2026-06-09T00:00:00Z",
+                        "head_branch": "main",
+                        "head_sha": "new",
+                        "html_url": "https://github.com/futuroptimist/flywheel/actions/runs/27199999999",
+                        "name": "Update Repo Statuses",
+                        "run_attempt": 1,
+                        "run_number": 15,
+                        "updated_at": "2026-06-09T00:01:00Z",
+                        "workflow_id": 123,
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    from datetime import datetime
+
+    repo_status.update_readme(readme, now=datetime(2026, 6, 9, 1, 2, tzinfo=UTC))
+
+    assert readme.read_text().splitlines() == [
+        "## Related Projects",
+        "_Last updated: 2026-06-09 01:02 UTC; checks hourly_",
+        "- ✅ ⭐ 2 **[flywheel](https://github.com/futuroptimist/flywheel)** - template",
+    ]
 
 
 def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- The README Related Projects updater could show a stale failing workflow run when a newer successful run of the same workflow on the same branch should have overridden it.
- Preserve the existing README outcomes (emoji, failure links, star counts, star sorting, idempotent regeneration) while making the definition of “current failure” stricter and provable.

### Description
- Add durable workflow identity and recency helpers (`_workflow_identity`, `_run_recency_key`, `_run_attempt_key`, `_latest_completed_runs_by_workflow`, and small timestamp/int coercion helpers) and use them to collapse reruns and pick the latest completed run per workflow identity.
- Change evaluation so the current status is derived from the latest completed run for each workflow identity (prefer `workflow_id`, fall back to `path`, then normalized `name`) and keep the existing latest-attempt behavior for reruns of the same run.
- Restrict branch handling and commit/bot/`[skip ci]` logic to avoid masking failures across branches while allowing a newer successful run on the same workflow identity+branch to suppress older failures.
- Preserve compatibility: `RepoStatus`, `StatusLink`, star fetching, README rendering, sorting, and the URL-only compatibility report remain unchanged; failure links are still rendered for workflows whose latest completed run is failing.

### Testing
- Ran `python -m pytest tests/test_repo_status.py -q` and it passed (all new/updated repo-status tests green).
- Ran the full test suite `python -m pytest -q` and it passed (`327 passed`, existing warnings only). 
- Ran formatting/linting checks (`black`, `ruff check --fix`) and they completed without blocking the change.
- Performed the repository secret scan (`git diff --cached | ./scripts/scan-secrets.py`) as a final automated safety check and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c73f1c64832fb0b21dfebccf1193)