### PR TITLE
Avoid mixed workflow name identity splits

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -117,7 +117,9 @@ def _workflow_identity(run: dict) -> tuple[str, object] | None:
 
     workflow_name = _normalize_run_name(run.get("workflow_name"))
     if workflow_name:
-        return ("workflow_name", workflow_name)
+        # Keep workflow_name in the weak name namespace so mixed payloads that
+        # omit workflow_name do not split the same workflow identity.
+        return ("name", workflow_name)
 
     name = _normalize_run_name(run.get("name") or run.get("display_title"))
     if name:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -685,6 +685,42 @@ def test_fetch_repo_status_newer_success_overrides_failed_workflow_name(
     )
 
 
+def test_fetch_repo_status_mixed_workflow_name_and_name_do_not_split_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="old",
+                name="CI",
+                workflow_id=None,
+                path=None,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+            ),
+            _workflow_run(
+                "success",
+                sha="new",
+                name="CI",
+                workflow_id=None,
+                path=None,
+                workflow_name="CI",
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+            ),
+        ],
+        commits=[_human_commit("new"), _human_commit("old")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
 def test_fetch_repo_status_workflow_name_precedes_run_name_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Prevent mixed GitHub run payload shapes from splitting the same workflow into two identities (e.g., `name` vs `workflow_name`) which can leave a stale failed run visible even after a newer success.

### Description
- Change `_workflow_identity` in `src/repo_status.py` to normalize `workflow_name` into the same weak-name namespace as the fallback `name`/`display_title` to avoid identity splits when payloads omit `workflow_name`.
- Add a regression test `test_fetch_repo_status_mixed_workflow_name_and_name_do_not_split_identity` to `tests/test_repo_status.py` that verifies an older failed run with only `name` is superseded by a newer successful run that includes `workflow_name`.
- Keep the normalization behavior and existing run-recency logic unchanged beyond the identity fix so workflow identity matching is more robust across payload shapes.

### Testing
- Ran the focused tests with `python -m pytest tests/test_repo_status.py -q` which passed (`66 passed`).
- Ran the full test suite with `python -m pytest -q` which passed (`335 passed`, `2 warnings`).
- Ran formatting and lint checks with `black --check` and `ruff check` on the modified files which passed, and scanned staged changes for secrets which found none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a284dd05e40832f8a8cfe77c1c313e0)