### PR TITLE
Treat versioned release/tag workflow successes as superseding stale failures

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -65,6 +65,7 @@ SKIP_COMMIT_RE = re.compile(
 RELEASE_WORKFLOW_RE = re.compile(
     r"(?i)(release|publish|package|desktop|deploy|artifact|build)"
 )
+RELEASE_TITLE_RE = re.compile(r"(?i)(release|publish|package|desktop|deploy|artifact)")
 VERSION_REF_RE = re.compile(
     r"(?ix)^(?:[a-z][a-z0-9]*[-_])?v?\d+\.\d+\.\d+" r"(?:[-+][0-9a-z.-]+)?$"
 )
@@ -141,15 +142,18 @@ def _has_version_label(value: str | None) -> bool:
 def _is_release_like_workflow(run: dict) -> bool:
     """Return whether a run is for release/build artifact work."""
 
-    values = (
-        run.get("name"),
-        run.get("workflow_name"),
-        run.get("display_title"),
-        run.get("path"),
-    )
-    return any(
-        isinstance(value, str) and RELEASE_WORKFLOW_RE.search(value) for value in values
-    )
+    identity_values = (run.get("name"), run.get("workflow_name"), run.get("path"))
+    if any(
+        isinstance(value, str) and RELEASE_WORKFLOW_RE.search(value)
+        for value in identity_values
+    ):
+        return True
+
+    # ``display_title`` usually comes from a commit or PR title.  Keep strong
+    # release words here, but avoid treating ordinary commits like
+    # ``fix build docs`` as release workflows.
+    title = run.get("display_title")
+    return isinstance(title, str) and RELEASE_TITLE_RE.search(title) is not None
 
 
 def _run_ref_values(run: dict) -> tuple[str, ...]:
@@ -641,17 +645,33 @@ def fetch_repo_status_details(
 
         if not selected_runs:
             return None, ()
-        important = [
-            r
-            for r in selected_runs
-            if keywords.search(r.get("name", ""))
-            or (
-                _is_release_like_workflow(r)
-                and (_workflow_identity(r) or ("", ""))[0] != "name"
+
+        def _is_keyword_run(run: dict) -> bool:
+            return keywords.search(run.get("name", "")) is not None
+
+        def _has_strong_identity(run: dict) -> bool:
+            return (_workflow_identity(run) or ("", ""))[0] != "name"
+
+        important_identities = {
+            identity
+            for run in selected_runs
+            for identity in [_workflow_identity(run)]
+            if identity is not None
+            and (
+                _is_keyword_run(run)
+                or (_is_release_like_workflow(run) and _has_strong_identity(run))
+                or (
+                    _normalize_conclusion(run.get("conclusion")) in failures
+                    and _has_strong_identity(run)
+                )
             )
-        ]
-        if important:
-            selected_runs = important
+        }
+        if important_identities:
+            selected_runs = [
+                run
+                for run in selected_runs
+                if _workflow_identity(run) in important_identities
+            ]
 
         selected_report = _evaluate_runs(selected_runs)
         needs_release_runs = any(
@@ -719,9 +739,10 @@ def fetch_repo_status_details(
                 return False
             candidate_sha = _run_head_sha(run)
             selected_sha = _run_head_sha(selected)
-            if candidate_sha is not None and selected_sha is not None:
-                if candidate_sha != selected_sha:
-                    return False
+            if candidate_sha is None or selected_sha is None:
+                return False
+            if candidate_sha != selected_sha:
+                return False
             candidate_conclusion = _normalize_conclusion(run.get("conclusion"))
             selected_conclusion = _normalize_conclusion(selected.get("conclusion"))
             if (

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -63,7 +63,7 @@ SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
 RELEASE_WORKFLOW_RE = re.compile(
-    r"(?i)(release|publish|package|desktop|deploy|artifact|build)"
+    r"(?i)(release|publish|package|desktop|deploy|artifact)"
 )
 VERSION_REF_RE = re.compile(
     r"(?ix)(?:^|[\s/_-])(?:[a-z][a-z0-9]*[-_])?v?\d+\.\d+\.\d+"
@@ -112,6 +112,25 @@ def _is_version_ref(value: str | None) -> bool:
     return VERSION_REF_RE.search(value.strip()) is not None
 
 
+def _is_release_version_ref(value: str | None) -> bool:
+    """Return whether ``value`` is a concrete tag/release version ref."""
+
+    if not isinstance(value, str):
+        return False
+    normalized = value.strip()
+    if not normalized:
+        return False
+    if normalized.startswith("refs/tags/"):
+        normalized = normalized.removeprefix("refs/tags/")
+    elif normalized.startswith("refs/heads/"):
+        normalized = normalized.removeprefix("refs/heads/")
+        if "/" in normalized:
+            return False
+    elif "/" in normalized:
+        return False
+    return _is_version_ref(normalized)
+
+
 def _is_release_like_workflow(run: dict) -> bool:
     """Return whether a run is for release/build artifact work."""
 
@@ -127,11 +146,10 @@ def _is_release_like_workflow(run: dict) -> bool:
 
 
 def _run_ref_values(run: dict) -> tuple[str, ...]:
-    """Return ref/title strings that may carry release labels."""
+    """Return ref strings that may carry release labels."""
 
     values = (
         run.get("head_branch"),
-        run.get("display_title"),
         run.get("head_ref"),
         run.get("ref"),
         run.get("head_ref_name"),
@@ -155,7 +173,7 @@ def _run_dashboard_scope(run: dict, selected_branch: str | None) -> str:
         return "ignored"
 
     if _is_release_like_workflow(run) and any(
-        _is_version_ref(value) for value in _run_ref_values(run)
+        _is_release_version_ref(value) for value in _run_ref_values(run)
     ):
         return "release-version"
 
@@ -235,7 +253,7 @@ def _coerce_int(value: object) -> int:
         return 0
 
 
-def _run_recency_key(run: dict) -> tuple[tuple[int, str], int, int, int, int]:
+def _run_recency_key(run: dict) -> tuple[int, int, int, tuple[int, str], int]:
     """Return a deterministic key for comparing completed workflow runs."""
 
     timestamp = max(
@@ -244,10 +262,10 @@ def _run_recency_key(run: dict) -> tuple[tuple[int, str], int, int, int, int]:
     )
     run_number = run.get("run_number")
     return (
-        timestamp,
         int(run_number is not None),
         _coerce_int(run_number),
         _coerce_int(run.get("run_attempt")),
+        timestamp,
         _coerce_int(run.get("id")),
     )
 
@@ -601,50 +619,63 @@ def fetch_repo_status_details(
         if not needs_release_runs:
             return selected_report
 
-        try:
-            all_resp = requests.get(all_runs_url, headers=headers, timeout=10)
-            all_resp.raise_for_status()
-            all_runs_data = all_resp.json()
-        except (requests.exceptions.RequestException, ValueError) as exc:
-            LOGGER.warning(
-                "Unable to fetch cross-branch workflow runs for %s@%s: %s",
-                repo,
-                branch,
-                exc,
-            )
-            return selected_report
-        if not isinstance(all_runs_data, dict):
-            LOGGER.warning(
-                "Unexpected cross-branch workflow payload for %s@%s: %r",
-                repo,
-                branch,
-                type(all_runs_data),
-            )
-            return selected_report
-
-        all_runs = all_runs_data.get("workflow_runs", [])
-        if not isinstance(all_runs, list):
-            LOGGER.warning(
-                "Unexpected cross-branch workflow run list for %s@%s: %r",
-                repo,
-                branch,
-                type(all_runs),
-            )
-            return selected_report
-
         selected_identities = {
             identity
             for run in selected_runs
             for identity in [_workflow_identity(run)]
             if identity is not None
         }
+        selected_shas = {
+            sha
+            for run in selected_runs
+            for sha in [run.get("head_sha")]
+            if isinstance(sha, str)
+        }
+
+        all_runs: list[dict] = []
+        for page in range(1, 11):
+            page_url = all_runs_url if page == 1 else f"{all_runs_url}&page={page}"
+            try:
+                all_resp = requests.get(page_url, headers=headers, timeout=10)
+                all_resp.raise_for_status()
+                all_runs_data = all_resp.json()
+            except (requests.exceptions.RequestException, ValueError) as exc:
+                LOGGER.warning(
+                    "Unable to fetch cross-branch workflow runs for %s@%s: %s",
+                    repo,
+                    branch,
+                    exc,
+                )
+                return selected_report
+            if not isinstance(all_runs_data, dict):
+                LOGGER.warning(
+                    "Unexpected cross-branch workflow payload for %s@%s: %r",
+                    repo,
+                    branch,
+                    type(all_runs_data),
+                )
+                return selected_report
+
+            page_runs = all_runs_data.get("workflow_runs", [])
+            if not isinstance(page_runs, list):
+                LOGGER.warning(
+                    "Unexpected cross-branch workflow run list for %s@%s: %r",
+                    repo,
+                    branch,
+                    type(page_runs),
+                )
+                return selected_report
+            all_runs.extend(run for run in page_runs if isinstance(run, dict))
+            if len(page_runs) < 100:
+                break
+
         release_runs = [
             run
             for run in all_runs
-            if isinstance(run, dict)
-            and _run_applies_to_dashboard(run, branch)
+            if _run_applies_to_dashboard(run, branch)
             and _run_dashboard_scope(run, branch) == "release-version"
             and _workflow_identity(run) in selected_identities
+            and run.get("head_sha") in selected_shas
         ]
         if not release_runs:
             return selected_report

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -66,8 +66,11 @@ RELEASE_WORKFLOW_RE = re.compile(
     r"(?i)(release|publish|package|desktop|deploy|artifact)"
 )
 VERSION_REF_RE = re.compile(
-    r"(?ix)(?:^|[\s/_-])(?:[a-z][a-z0-9]*[-_])?v?\d+\.\d+\.\d+"
-    r"(?:[-+][0-9a-z.-]+)?(?:$|[\s/_-])"
+    r"(?ix)^(?:[a-z][a-z0-9]*[-_])?v?\d+\.\d+\.\d+" r"(?:[-+][0-9a-z.-]+)?$"
+)
+VERSION_LABEL_RE = re.compile(
+    r"(?ix)(?:^|[\s_-])(?:[a-z][a-z0-9]*[-_])?v?\d+\.\d+\.\d+"
+    r"(?:[-+][0-9a-z.-]+)?(?:$|[\s_-])"
 )
 RELEASE_EVENTS = {"push", "release", "workflow_dispatch", "repository_dispatch"}
 
@@ -105,15 +108,7 @@ def status_to_emoji(conclusion: str | None) -> str:
 
 
 def _is_version_ref(value: str | None) -> bool:
-    """Return whether ``value`` looks like a release/version ref label."""
-
-    if not isinstance(value, str) or not value.strip():
-        return False
-    return VERSION_REF_RE.search(value.strip()) is not None
-
-
-def _is_release_version_ref(value: str | None) -> bool:
-    """Return whether ``value`` is a concrete tag/release version ref."""
+    """Return whether ``value`` is a concrete release/version ref label."""
 
     if not isinstance(value, str):
         return False
@@ -124,11 +119,23 @@ def _is_release_version_ref(value: str | None) -> bool:
         normalized = normalized.removeprefix("refs/tags/")
     elif normalized.startswith("refs/heads/"):
         normalized = normalized.removeprefix("refs/heads/")
-        if "/" in normalized:
-            return False
-    elif "/" in normalized:
+    if "/" in normalized:
         return False
-    return _is_version_ref(normalized)
+    return VERSION_REF_RE.fullmatch(normalized) is not None
+
+
+def _is_release_version_ref(value: str | None) -> bool:
+    """Return whether ``value`` is a concrete tag/release version ref."""
+
+    return _is_version_ref(value)
+
+
+def _has_version_label(value: str | None) -> bool:
+    """Return whether prose like a release title contains a version token."""
+
+    if not isinstance(value, str) or not value.strip():
+        return False
+    return VERSION_LABEL_RE.search(value.strip()) is not None
 
 
 def _is_release_like_workflow(run: dict) -> bool:
@@ -157,6 +164,34 @@ def _run_ref_values(run: dict) -> tuple[str, ...]:
     return tuple(value for value in values if isinstance(value, str) and value)
 
 
+def _run_title_values(run: dict) -> tuple[str, ...]:
+    """Return title strings that may carry dispatch/release labels."""
+
+    values = (run.get("display_title"), run.get("name"), run.get("workflow_name"))
+    return tuple(value for value in values if isinstance(value, str) and value)
+
+
+def _run_has_release_version_label(run: dict) -> bool:
+    """Return whether a run has a version label on a release ref or title."""
+
+    if any(_is_release_version_ref(value) for value in _run_ref_values(run)):
+        return True
+    event = run.get("event")
+    if event in {"release", "workflow_dispatch", "repository_dispatch"}:
+        return any(_has_version_label(value) for value in _run_title_values(run))
+    return False
+
+
+def _run_head_sha(run: dict) -> str | None:
+    """Return a run SHA from either REST or GraphQL-style payload keys."""
+
+    for key in ("head_sha", "headSha"):
+        value = run.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
 def _run_dashboard_scope(run: dict, selected_branch: str | None) -> str:
     """Classify whether a workflow run belongs to the dashboard scope."""
 
@@ -172,9 +207,7 @@ def _run_dashboard_scope(run: dict, selected_branch: str | None) -> str:
     if isinstance(event, str) and event not in RELEASE_EVENTS:
         return "ignored"
 
-    if _is_release_like_workflow(run) and any(
-        _is_release_version_ref(value) for value in _run_ref_values(run)
-    ):
+    if _is_release_like_workflow(run) and _run_has_release_version_label(run):
         return "release-version"
 
     return "ignored"
@@ -608,7 +641,15 @@ def fetch_repo_status_details(
 
         if not selected_runs:
             return None, ()
-        important = [r for r in selected_runs if keywords.search(r.get("name", ""))]
+        important = [
+            r
+            for r in selected_runs
+            if keywords.search(r.get("name", ""))
+            or (
+                _is_release_like_workflow(r)
+                and (_workflow_identity(r) or ("", ""))[0] != "name"
+            )
+        ]
         if important:
             selected_runs = important
 
@@ -619,17 +660,11 @@ def fetch_repo_status_details(
         if not needs_release_runs:
             return selected_report
 
-        selected_identities = {
-            identity
-            for run in selected_runs
+        selected_by_identity = {
+            identity: run
+            for run in _latest_completed_runs_by_workflow(selected_runs)
             for identity in [_workflow_identity(run)]
             if identity is not None
-        }
-        selected_shas = {
-            sha
-            for run in selected_runs
-            for sha in [run.get("head_sha")]
-            if isinstance(sha, str)
         }
 
         all_runs: list[dict] = []
@@ -669,14 +704,36 @@ def fetch_repo_status_details(
             if len(page_runs) < 100:
                 break
 
-        release_runs = [
-            run
-            for run in all_runs
-            if _run_applies_to_dashboard(run, branch)
-            and _run_dashboard_scope(run, branch) == "release-version"
-            and _workflow_identity(run) in selected_identities
-            and run.get("head_sha") in selected_shas
-        ]
+        def _is_applicable_release_run(run: dict) -> bool:
+            if not _run_applies_to_dashboard(run, branch):
+                return False
+            if _run_dashboard_scope(run, branch) != "release-version":
+                return False
+            identity = _workflow_identity(run)
+            if identity is None:
+                return False
+            selected = selected_by_identity.get(identity)
+            if selected is None:
+                return False
+            if _run_recency_key(run) <= _run_recency_key(selected):
+                return False
+            candidate_sha = _run_head_sha(run)
+            selected_sha = _run_head_sha(selected)
+            if candidate_sha is not None and selected_sha is not None:
+                if candidate_sha != selected_sha:
+                    return False
+            candidate_conclusion = _normalize_conclusion(run.get("conclusion"))
+            selected_conclusion = _normalize_conclusion(selected.get("conclusion"))
+            if (
+                candidate_conclusion not in passing
+                and candidate_conclusion not in failures
+            ):
+                return False
+            if selected_conclusion in failures and candidate_conclusion not in passing:
+                return candidate_conclusion in failures
+            return True
+
+        release_runs = [run for run in all_runs if _is_applicable_release_run(run)]
         if not release_runs:
             return selected_report
         return _evaluate_runs([*selected_runs, *release_runs])

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -62,6 +62,14 @@ GITHUB_MARKDOWN_LINK_RE = re.compile(
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
+RELEASE_WORKFLOW_RE = re.compile(
+    r"(?i)(release|publish|package|desktop|deploy|artifact|build)"
+)
+VERSION_REF_RE = re.compile(
+    r"(?ix)(?:^|[\s/_-])(?:[a-z][a-z0-9]*[-_])?v?\d+\.\d+\.\d+"
+    r"(?:[-+][0-9a-z.-]+)?(?:$|[\s/_-])"
+)
+RELEASE_EVENTS = {"push", "release", "workflow_dispatch", "repository_dispatch"}
 
 
 def status_to_emoji(conclusion: str | None) -> str:
@@ -94,6 +102,72 @@ def status_to_emoji(conclusion: str | None) -> str:
     }:
         return "❌"
     return "❓"
+
+
+def _is_version_ref(value: str | None) -> bool:
+    """Return whether ``value`` looks like a release/version ref label."""
+
+    if not isinstance(value, str) or not value.strip():
+        return False
+    return VERSION_REF_RE.search(value.strip()) is not None
+
+
+def _is_release_like_workflow(run: dict) -> bool:
+    """Return whether a run is for release/build artifact work."""
+
+    values = (
+        run.get("name"),
+        run.get("workflow_name"),
+        run.get("display_title"),
+        run.get("path"),
+    )
+    return any(
+        isinstance(value, str) and RELEASE_WORKFLOW_RE.search(value) for value in values
+    )
+
+
+def _run_ref_values(run: dict) -> tuple[str, ...]:
+    """Return ref/title strings that may carry release labels."""
+
+    values = (
+        run.get("head_branch"),
+        run.get("display_title"),
+        run.get("head_ref"),
+        run.get("ref"),
+        run.get("head_ref_name"),
+    )
+    return tuple(value for value in values if isinstance(value, str) and value)
+
+
+def _run_dashboard_scope(run: dict, selected_branch: str | None) -> str:
+    """Classify whether a workflow run belongs to the dashboard scope."""
+
+    run_branch = run.get("head_branch")
+    if (
+        isinstance(run_branch, str)
+        and selected_branch
+        and run_branch == selected_branch
+    ):
+        return "selected-branch"
+
+    event = run.get("event")
+    if isinstance(event, str) and event not in RELEASE_EVENTS:
+        return "ignored"
+
+    if _is_release_like_workflow(run) and any(
+        _is_version_ref(value) for value in _run_ref_values(run)
+    ):
+        return "release-version"
+
+    return "ignored"
+
+
+def _run_applies_to_dashboard(run: dict, selected_branch: str | None) -> bool:
+    """Return whether a completed run is safe to consider for README status."""
+
+    if run.get("status") not in (None, "completed"):
+        return False
+    return _run_dashboard_scope(run, selected_branch) != "ignored"
 
 
 def _normalize_run_name(value: object) -> str:
@@ -161,7 +235,7 @@ def _coerce_int(value: object) -> int:
         return 0
 
 
-def _run_recency_key(run: dict) -> tuple[int, int, int, tuple[int, str], int]:
+def _run_recency_key(run: dict) -> tuple[tuple[int, str], int, int, int, int]:
     """Return a deterministic key for comparing completed workflow runs."""
 
     timestamp = max(
@@ -170,10 +244,10 @@ def _run_recency_key(run: dict) -> tuple[int, int, int, tuple[int, str], int]:
     )
     run_number = run.get("run_number")
     return (
+        timestamp,
         int(run_number is not None),
         _coerce_int(run_number),
         _coerce_int(run.get("run_attempt")),
-        timestamp,
         _coerce_int(run.get("id")),
     )
 
@@ -300,7 +374,8 @@ def fetch_repo_status_details(
         if branch is None:
             return RepoStatus(status_to_emoji(None), stars=metadata.stars)
 
-    url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
+    all_runs_url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
+    url = all_runs_url
     if branch:
         url += f"&branch={branch}"
 
@@ -518,7 +593,62 @@ def fetch_repo_status_details(
         important = [r for r in selected_runs if keywords.search(r.get("name", ""))]
         if important:
             selected_runs = important
-        return _evaluate_runs(selected_runs)
+
+        selected_report = _evaluate_runs(selected_runs)
+        needs_release_runs = any(
+            _is_release_like_workflow(run) for run in selected_runs
+        )
+        if not needs_release_runs:
+            return selected_report
+
+        try:
+            all_resp = requests.get(all_runs_url, headers=headers, timeout=10)
+            all_resp.raise_for_status()
+            all_runs_data = all_resp.json()
+        except (requests.exceptions.RequestException, ValueError) as exc:
+            LOGGER.warning(
+                "Unable to fetch cross-branch workflow runs for %s@%s: %s",
+                repo,
+                branch,
+                exc,
+            )
+            return selected_report
+        if not isinstance(all_runs_data, dict):
+            LOGGER.warning(
+                "Unexpected cross-branch workflow payload for %s@%s: %r",
+                repo,
+                branch,
+                type(all_runs_data),
+            )
+            return selected_report
+
+        all_runs = all_runs_data.get("workflow_runs", [])
+        if not isinstance(all_runs, list):
+            LOGGER.warning(
+                "Unexpected cross-branch workflow run list for %s@%s: %r",
+                repo,
+                branch,
+                type(all_runs),
+            )
+            return selected_report
+
+        selected_identities = {
+            identity
+            for run in selected_runs
+            for identity in [_workflow_identity(run)]
+            if identity is not None
+        }
+        release_runs = [
+            run
+            for run in all_runs
+            if isinstance(run, dict)
+            and _run_applies_to_dashboard(run, branch)
+            and _run_dashboard_scope(run, branch) == "release-version"
+            and _workflow_identity(run) in selected_identities
+        ]
+        if not release_runs:
+            return selected_report
+        return _evaluate_runs([*selected_runs, *release_runs])
 
     reports = [_fetch() for _ in range(attempts)]
     conclusions = [report[0] for report in reports]

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -63,7 +63,7 @@ SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
 RELEASE_WORKFLOW_RE = re.compile(
-    r"(?i)(release|publish|package|desktop|deploy|artifact)"
+    r"(?i)(release|publish|package|desktop|deploy|artifact|build)"
 )
 VERSION_REF_RE = re.compile(
     r"(?ix)^(?:[a-z][a-z0-9]*[-_])?v?\d+\.\d+\.\d+" r"(?:[-+][0-9a-z.-]+)?$"

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -14,6 +14,7 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from itertools import count
 from pathlib import Path
 
 import requests
@@ -688,7 +689,7 @@ def fetch_repo_status_details(
         }
 
         all_runs: list[dict] = []
-        for page in range(1, 11):
+        for page in count(1):
             page_url = all_runs_url if page == 1 else f"{all_runs_url}&page={page}"
             try:
                 all_resp = requests.get(page_url, headers=headers, timeout=10)

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -105,6 +105,25 @@ def test_version_ref_detection_accepts_only_concrete_release_refs() -> None:
         assert not repo_status._is_version_ref(ref), ref
 
 
+def test_release_like_workflow_ignores_title_only_build_text() -> None:
+    assert (
+        repo_status._is_release_like_workflow(
+            {
+                "name": "Quality",
+                "path": ".github/workflows/quality.yml",
+                "display_title": "fix build docs",
+            }
+        )
+        is False
+    )
+    assert (
+        repo_status._is_release_like_workflow(
+            {"name": "Build", "path": ".github/workflows/build.yml"}
+        )
+        is True
+    )
+
+
 def test_run_dashboard_scope_requires_concrete_release_refs() -> None:
     for branch in (
         "desktop-v0.1.0",
@@ -726,6 +745,87 @@ def test_fetch_repo_status_preserves_release_workflows_with_test_workflows(
 
     assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
         repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_release_success_missing_sha_does_not_hide_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=1,
+        run_id=1,
+    )
+    release_without_sha = _workflow_run(
+        "success",
+        sha="abc",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="desktop-v1.2.3",
+    )
+    release_without_sha.pop("head_sha")
+    _mock_repo_status_requests(
+        monkeypatch,
+        [failed],
+        all_runs=[failed, release_without_sha],
+        commits=[_human_commit("abc")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Package Desktop", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_keeps_non_keyword_failure_with_title_only_build_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    title_only_build_success = _workflow_run(
+        "success",
+        sha="abc",
+        name="Quality",
+        workflow_id=77,
+        path=".github/workflows/quality.yml",
+        display_title="fix build docs",
+        run_id=1,
+    )
+    docs_failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Docs",
+        workflow_id=88,
+        path=".github/workflows/docs.yml",
+        run_id=2,
+    )
+    _mock_repo_status_requests(
+        monkeypatch,
+        [title_only_build_success, docs_failed],
+        all_runs=[title_only_build_success, docs_failed],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Docs", "https://github.com/user/repo/actions/runs/2"
+                ),
+            ),
+        )
     )
 
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -656,6 +656,36 @@ def test_fetch_repo_status_version_release_success_supersedes_selected_branch_fa
     )
 
 
+def test_fetch_repo_status_generic_build_tag_success_supersedes_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Build",
+        workflow_id=77,
+        path=".github/workflows/build.yml",
+        run_number=1,
+        run_id=1,
+    )
+    fixed = _workflow_run(
+        "success",
+        sha="abc",
+        name="Build",
+        workflow_id=77,
+        path=".github/workflows/build.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="v1.2.3",
+    )
+    _mock_repo_status_requests(monkeypatch, [failed], all_runs=[failed, fixed])
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
 def test_fetch_repo_status_preserves_release_workflows_with_test_workflows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -85,6 +85,56 @@ def test_workflow_identity_order_and_unknown_fallback() -> None:
     assert repo_status._workflow_identity({}) is None
 
 
+def test_version_ref_detection_accepts_only_concrete_release_refs() -> None:
+    release_refs = (
+        "desktop-v0.1.0",
+        "v0.1.0",
+        "cli-v1.2.3",
+        "refs/tags/desktop-v0.1.0",
+    )
+    for ref in release_refs:
+        assert repo_status._is_version_ref(ref), ref
+
+    ordinary_branches = (
+        "feature/v1.2.3",
+        "feature/desktop-v0.1.0",
+        "dependabot/npm/foo-1.2.3",
+        "codex/fix-v1.2.3-build",
+    )
+    for ref in ordinary_branches:
+        assert not repo_status._is_version_ref(ref), ref
+
+
+def test_run_dashboard_scope_requires_concrete_release_refs() -> None:
+    for branch in (
+        "desktop-v0.1.0",
+        "v0.1.0",
+        "cli-v1.2.3",
+        "refs/tags/desktop-v0.1.0",
+    ):
+        run = _workflow_run(
+            "success",
+            name="Package CLI",
+            path=".github/workflows/package.yml",
+            branch=branch,
+        )
+        assert repo_status._run_dashboard_scope(run, "main") == "release-version"
+
+    for branch in (
+        "feature/v1.2.3",
+        "feature/desktop-v0.1.0",
+        "dependabot/npm/foo-1.2.3",
+        "codex/fix-v1.2.3-build",
+    ):
+        run = _workflow_run(
+            "success",
+            name="Package CLI",
+            path=".github/workflows/package.yml",
+            branch=branch,
+        )
+        assert repo_status._run_dashboard_scope(run, "main") == "ignored"
+
+
 class DummyResp:
     def __init__(self, data, *, json_error: Exception | None = None):
         self._data = data
@@ -606,6 +656,49 @@ def test_fetch_repo_status_version_release_success_supersedes_selected_branch_fa
     )
 
 
+def test_fetch_repo_status_preserves_release_workflows_with_test_workflows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tests_passed = _workflow_run(
+        "success",
+        sha="abc",
+        name="Test Suite",
+        workflow_id=100,
+        path=".github/workflows/tests.yml",
+        run_number=5,
+        run_id=5,
+    )
+    package_failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Package CLI",
+        workflow_id=77,
+        path=".github/workflows/package.yml",
+        run_number=1,
+        run_id=1,
+    )
+    package_fixed = _workflow_run(
+        "success",
+        sha="abc",
+        name="Package CLI",
+        workflow_id=77,
+        path=".github/workflows/package.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="cli-v1.2.3",
+    )
+    _mock_repo_status_requests(
+        monkeypatch,
+        [tests_passed, package_failed],
+        all_runs=[tests_passed, package_failed, package_fixed],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
 def test_fetch_repo_status_feature_branch_success_does_not_supersede_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -685,8 +778,9 @@ def test_fetch_repo_status_release_success_different_sha_does_not_hide_failure(
     )
 
 
+@pytest.mark.parametrize("branch", ["feature/v1.2.3", "feature/desktop-v0.1.0"])
 def test_fetch_repo_status_feature_semver_branch_does_not_supersede_failure(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, branch: str
 ) -> None:
     failed = _workflow_run(
         "failure",
@@ -706,7 +800,7 @@ def test_fetch_repo_status_feature_semver_branch_does_not_supersede_failure(
         run_number=2,
         created_at="2025-09-25T13:00:00Z",
         run_id=2,
-        branch="feature/v1.2.3",
+        branch=branch,
     )
     _mock_repo_status_requests(monkeypatch, [failed], all_runs=[failed, feature])
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -937,7 +937,7 @@ def test_fetch_repo_status_feature_semver_branch_does_not_supersede_failure(
     assert repo_status.fetch_repo_status_details("user/repo", attempts=1).emoji == "❌"
 
 
-def test_fetch_repo_status_paginates_release_runs(
+def test_fetch_repo_status_paginates_release_runs_beyond_page_ten(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     failed = _workflow_run(
@@ -960,16 +960,19 @@ def test_fetch_repo_status_paginates_release_runs(
         run_id=2,
         branch="desktop-v1.2.3",
     )
-    first_page = [
-        _workflow_run(
-            "success",
-            sha=f"filler-{index}",
-            name="Test Suite",
-            workflow_id=1000 + index,
-            run_id=1000 + index,
-            branch="main",
-        )
-        for index in range(100)
+    filler_pages = [
+        [
+            _workflow_run(
+                "success",
+                sha=f"filler-{page}-{index}",
+                name="Test Suite",
+                workflow_id=100_000 + (page * 100) + index,
+                run_id=100_000 + (page * 100) + index,
+                branch="main",
+            )
+            for index in range(100)
+        ]
+        for page in range(1, 11)
     ]
     calls: list[str] = []
 
@@ -986,21 +989,22 @@ def test_fetch_repo_status_paginates_release_runs(
             "per_page=100&status=completed&branch=main"
         ):
             return DummyResp({"workflow_runs": [failed]})
-        if url == (
+        base_url = (
             "https://api.github.com/repos/user/repo/actions/runs?"
             "per_page=100&status=completed"
-        ):
-            return DummyResp({"workflow_runs": first_page})
-        assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?"
-            "per_page=100&status=completed&page=2"
         )
+        if url == base_url:
+            return DummyResp({"workflow_runs": filler_pages[0]})
+        for page in range(2, 11):
+            if url == f"{base_url}&page={page}":
+                return DummyResp({"workflow_runs": filler_pages[page - 1]})
+        assert url == f"{base_url}&page=11"
         return DummyResp({"workflow_runs": [fixed]})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
 
     assert repo_status.fetch_repo_status_details("user/repo", attempts=1).emoji == "✅"
-    assert calls[-1].endswith("&page=2")
+    assert calls[-1].endswith("&page=11")
 
 
 def test_fetch_repo_status_run_number_outranks_updated_at_retry(

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -120,6 +120,9 @@ def _workflow_run(
     workflow_id: int | str | None = 123,
     path: str | None = ".github/workflows/tests.yml",
     workflow_name: str | None = None,
+    display_title: str | None = None,
+    event: str = "push",
+    status: str = "completed",
     run_number: int = 1,
     run_attempt: int = 1,
     created_at: str = "2025-09-25T12:00:00Z",
@@ -132,6 +135,8 @@ def _workflow_run(
         "head_sha": sha,
         "head_branch": branch,
         "name": name,
+        "event": event,
+        "status": status,
         "run_number": run_number,
         "run_attempt": run_attempt,
         "created_at": created_at,
@@ -143,6 +148,8 @@ def _workflow_run(
         run["path"] = path
     if workflow_name is not None:
         run["workflow_name"] = workflow_name
+    if display_title is not None:
+        run["display_title"] = display_title
     if updated_at is not None:
         run["updated_at"] = updated_at
     if run_id is not None:
@@ -154,6 +161,7 @@ def _mock_repo_status_requests(
     monkeypatch: pytest.MonkeyPatch,
     runs: list[dict],
     *,
+    all_runs: list[dict] | None = None,
     commits: list[dict] | None = None,
     branch: str = "main",
     stars: int | None = None,
@@ -168,6 +176,13 @@ def _mock_repo_status_requests(
             f"https://api.github.com/repos/user/repo/commits?sha={branch}&per_page=20"
         ):
             return DummyResp(commits or [_human_commit("abc")])
+        if (
+            url
+            == "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed"
+        ):
+            return DummyResp(
+                {"workflow_runs": all_runs if all_runs is not None else runs}
+            )
         assert url == (
             "https://api.github.com/repos/user/repo/actions/runs?"
             f"per_page=100&status=completed&branch={branch}"
@@ -519,6 +534,234 @@ def test_fetch_repo_status_newer_success_overrides_failed_workflow_id(
     )
 
 
+def test_fetch_repo_status_token_place_release_success_supersedes_stale_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _workflow_run(
+        "failure",
+        sha="d99cb50d62672bff35d9642951679e90059ddadc",
+        name="Build Desktop App",
+        workflow_id=176183450,
+        path=".github/workflows/desktop-build.yml",
+        display_title="Merge pull request #1168 from futuroptimist/codex/add-visible-run_all…",
+        run_number=625,
+        created_at="2026-06-09T07:36:39Z",
+        updated_at="2026-06-09T07:45:55Z",
+        run_id=27191220631,
+        branch="main",
+    )
+    fixed = _workflow_run(
+        "success",
+        sha="d99cb50d62672bff35d9642951679e90059ddadc",
+        name="Build Desktop App",
+        workflow_id=176183450,
+        path=".github/workflows/desktop-build.yml",
+        display_title="Merge pull request #1168 from futuroptimist/codex/add-visible-run_all…",
+        run_number=626,
+        created_at="2026-06-09T08:02:14Z",
+        updated_at="2026-06-09T08:15:32Z",
+        run_id=27192437756,
+        branch="desktop-v0.1.0",
+    )
+    _mock_repo_status_requests(
+        monkeypatch,
+        [failed],
+        all_runs=[failed, fixed],
+        commits=[_human_commit("d99cb50d62672bff35d9642951679e90059ddadc")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_version_release_success_supersedes_selected_branch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Package CLI",
+        workflow_id=77,
+        path=".github/workflows/package.yml",
+        run_number=1,
+        run_id=1,
+    )
+    fixed = _workflow_run(
+        "success",
+        sha="abc",
+        name="Package CLI",
+        workflow_id=77,
+        path=".github/workflows/package.yml",
+        display_title="Release cli-v1.2.3",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="cli-v1.2.3",
+    )
+    _mock_repo_status_requests(monkeypatch, [failed], all_runs=[failed, fixed])
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_feature_branch_success_does_not_supersede_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Build Desktop App",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=1,
+        run_id=1,
+    )
+    feature = _workflow_run(
+        "success",
+        sha="abc",
+        name="Build Desktop App",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="feature/build-fix",
+    )
+    _mock_repo_status_requests(monkeypatch, [failed], all_runs=[failed, feature])
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Build Desktop App", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_release_success_different_workflow_does_not_hide_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Build Desktop App",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=1,
+        run_id=1,
+    )
+    other = _workflow_run(
+        "success",
+        sha="abc",
+        name="Build Desktop App",
+        workflow_id=88,
+        path=".github/workflows/desktop-build.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="v1.2.3",
+    )
+    _mock_repo_status_requests(monkeypatch, [failed], all_runs=[failed, other])
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1).emoji == "❌"
+
+
+def test_fetch_repo_status_release_success_does_not_hide_test_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Build Desktop App",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=1,
+        run_id=1,
+    )
+    tests_failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Test Suite",
+        workflow_id=99,
+        path=".github/workflows/tests.yml",
+        run_number=1,
+        run_id=3,
+    )
+    build_fixed = _workflow_run(
+        "success",
+        sha="abc",
+        name="Build Desktop App",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="v1.2.3",
+    )
+    _mock_repo_status_requests(
+        monkeypatch,
+        [build_failed, tests_failed],
+        all_runs=[build_failed, tests_failed, build_fixed],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Test Suite", "https://github.com/user/repo/actions/runs/3"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_latest_release_failure_links_latest_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch_success = _workflow_run(
+        "success",
+        sha="abc",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=1,
+        run_id=1,
+    )
+    release_failure = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="desktop-v1.2.3",
+    )
+    _mock_repo_status_requests(
+        monkeypatch,
+        [branch_success],
+        all_runs=[branch_success, release_failure],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Package Desktop", "https://github.com/user/repo/actions/runs/2"
+                ),
+            ),
+        )
+    )
+
+
 def test_fetch_repo_status_preserves_id_only_failed_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -578,7 +821,7 @@ def test_fetch_repo_status_mixed_workflow_id_types_share_identity(
     )
 
 
-def test_fetch_repo_status_run_number_beats_later_updated_at(
+def test_fetch_repo_status_timestamp_beats_later_run_number(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _mock_repo_status_requests(
@@ -607,7 +850,14 @@ def test_fetch_repo_status_run_number_beats_later_updated_at(
     )
 
     assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
-        repo_status.RepoStatus("✅")
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Test Suite", "https://github.com/user/repo/actions/runs/10"
+                ),
+            ),
+        )
     )
 
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -643,6 +643,171 @@ def test_fetch_repo_status_feature_branch_success_does_not_supersede_failure(
     )
 
 
+def test_fetch_repo_status_release_success_different_sha_does_not_hide_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=1,
+        run_id=1,
+    )
+    unrelated_release = _workflow_run(
+        "success",
+        sha="def",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="desktop-v1.2.3",
+    )
+    _mock_repo_status_requests(
+        monkeypatch,
+        [failed],
+        all_runs=[failed, unrelated_release],
+        commits=[_human_commit("abc")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Package Desktop", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_feature_semver_branch_does_not_supersede_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=1,
+        run_id=1,
+    )
+    feature = _workflow_run(
+        "success",
+        sha="abc",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="feature/v1.2.3",
+    )
+    _mock_repo_status_requests(monkeypatch, [failed], all_runs=[failed, feature])
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1).emoji == "❌"
+
+
+def test_fetch_repo_status_paginates_release_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _workflow_run(
+        "failure",
+        sha="abc",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=1,
+        run_id=1,
+    )
+    fixed = _workflow_run(
+        "success",
+        sha="abc",
+        name="Package Desktop",
+        workflow_id=77,
+        path=".github/workflows/desktop-build.yml",
+        run_number=2,
+        created_at="2025-09-25T13:00:00Z",
+        run_id=2,
+        branch="desktop-v1.2.3",
+    )
+    first_page = [
+        _workflow_run(
+            "success",
+            sha=f"filler-{index}",
+            name="Test Suite",
+            workflow_id=1000 + index,
+            run_id=1000 + index,
+            branch="main",
+        )
+        for index in range(100)
+    ]
+    calls: list[str] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append(url)
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp([_human_commit("abc")])
+        if url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            "per_page=100&status=completed&branch=main"
+        ):
+            return DummyResp({"workflow_runs": [failed]})
+        if url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            "per_page=100&status=completed"
+        ):
+            return DummyResp({"workflow_runs": first_page})
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            "per_page=100&status=completed&page=2"
+        )
+        return DummyResp({"workflow_runs": [fixed]})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1).emoji == "✅"
+    assert calls[-1].endswith("&page=2")
+
+
+def test_fetch_repo_status_run_number_outranks_updated_at_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    older_retried_failure = _workflow_run(
+        "failure",
+        sha="abc",
+        workflow_id=77,
+        run_number=1,
+        run_id=1,
+        created_at="2025-09-25T12:00:00Z",
+        updated_at="2025-09-25T14:00:00Z",
+    )
+    newer_success = _workflow_run(
+        "success",
+        sha="abc",
+        workflow_id=77,
+        run_number=2,
+        run_id=2,
+        created_at="2025-09-25T13:00:00Z",
+        updated_at="2025-09-25T13:05:00Z",
+    )
+    _mock_repo_status_requests(
+        monkeypatch,
+        [older_retried_failure, newer_success],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1).emoji == "✅"
+
+
 def test_fetch_repo_status_release_success_different_workflow_does_not_hide_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -821,7 +986,7 @@ def test_fetch_repo_status_mixed_workflow_id_types_share_identity(
     )
 
 
-def test_fetch_repo_status_timestamp_beats_later_run_number(
+def test_fetch_repo_status_later_run_number_beats_updated_at(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _mock_repo_status_requests(
@@ -850,14 +1015,7 @@ def test_fetch_repo_status_timestamp_beats_later_run_number(
     )
 
     assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
-        repo_status.RepoStatus(
-            "❌",
-            (
-                repo_status.StatusLink(
-                    "Test Suite", "https://github.com/user/repo/actions/runs/10"
-                ),
-            ),
-        )
+        repo_status.RepoStatus("✅")
     )
 
 


### PR DESCRIPTION
### Motivation
- Avoid false red Related Projects entries when an older failed run is superseded by a newer successful release/tag/dispatch run for the same workflow identity, e.g. the `token.place` desktop failure was superseded by a `desktop-v0.1.0` release run.

### Description
- Added release/version classification and helpers (`_is_version_ref`, `_is_release_like_workflow`, `_run_ref_values`, `_run_dashboard_scope`, and `_run_applies_to_dashboard`) to identify release-like workflows and version-like refs.
- Prefer reliable timestamps in `_run_recency_key` and introduce cross-branch fetch (`all_runs_url`) to merge versioned release/tag/dispatch runs that share a workflow identity with selected runs before evaluating the latest outcome.
- Only consider cross-branch release/tag runs when the selected runs are release-like and version-labeled, and explicitly guard against allowing arbitrary feature/PR branch successes or different workflows from masking real default-branch failures.
- Added and updated deterministic tests in `tests/test_repo_status.py` to cover the `token.place` regression, versioned-release superseding, feature-branch masking, different-workflow masking, and latest-release failure behavior.

### Testing
- Formatted and lint-checked the changes with `python -m black src/repo_status.py tests/test_repo_status.py` and `python -m ruff check src/repo_status.py tests/test_repo_status.py`, both succeeded.
- Ran targeted tests with `python -m pytest tests/test_repo_status.py -q`, which passed (77 passed); ran the full test suite with `python -m pytest -q`, which passed (346 passed, 2 warnings).
- Reproduced the token.place regression by inspecting the GitHub Actions run payloads for runs `27191220631` and `27192437756` via the GitHub REST API and verified `fetch_repo_status_details('futuroptimist/token.place', attempts=1)` now returns a green status `✅`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e3ea9ce8832fb3a5269c4ff7f0b5)