### PR TITLE
Fix: treat newer release/tag workflow successes as superseding stale failures

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -63,6 +63,83 @@ SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
 
+VERSION_REF_RE = re.compile(
+    r"(?i)(?:^|[\s/#:_-])(?:[a-z][a-z0-9._-]*-)?v?\d+\.\d+\.\d+"
+    r"(?:[-+][0-9a-z][0-9a-z.-]*)?(?=$|[\s/#:_-])"
+)
+RELEASE_WORKFLOW_RE = re.compile(
+    r"(?i)(release|publish|package|packag(?:e|ing)|desktop|deploy|build|artifact|"
+    r"installer|distribut(?:e|ion))"
+)
+RELEASE_EVENTS = {
+    "create",
+    "release",
+    "workflow_dispatch",
+    "push",
+    "repository_dispatch",
+}
+
+
+def _is_version_ref(value: str | None) -> bool:
+    """Return whether ``value`` contains a version-like release label."""
+
+    return bool(isinstance(value, str) and VERSION_REF_RE.search(value.strip()))
+
+
+def _is_release_like_workflow(run: dict) -> bool:
+    """Return whether run metadata describes a release/build artifact workflow."""
+
+    values = (
+        run.get("name"),
+        run.get("workflow_name"),
+        run.get("display_title"),
+        run.get("path"),
+    )
+    return any(
+        isinstance(value, str) and RELEASE_WORKFLOW_RE.search(value) for value in values
+    )
+
+
+def _run_dashboard_scope(run: dict, selected_branch: str | None) -> str:
+    """Classify whether a run belongs to the branch or release dashboard scope."""
+
+    run_branch = run.get("head_branch")
+    if (
+        selected_branch
+        and isinstance(run_branch, str)
+        and run_branch == selected_branch
+    ):
+        return "branch"
+
+    if not _is_release_like_workflow(run):
+        return "other"
+
+    version_values = (
+        run.get("head_branch"),
+        run.get("display_title"),
+        run.get("name"),
+        run.get("ref"),
+        run.get("head_ref"),
+    )
+    if not any(_is_version_ref(value) for value in version_values):
+        return "other"
+
+    event = run.get("event")
+    if isinstance(event, str) and event and event not in RELEASE_EVENTS:
+        return "other"
+
+    status = run.get("status")
+    if isinstance(status, str) and status and status != "completed":
+        return "other"
+
+    return "release"
+
+
+def _run_applies_to_dashboard(run: dict, selected_branch: str | None) -> bool:
+    """Return whether a completed run can affect the README dashboard status."""
+
+    return _run_dashboard_scope(run, selected_branch) in {"branch", "release"}
+
 
 def status_to_emoji(conclusion: str | None) -> str:
     """Return an emoji representing the run conclusion.
@@ -161,7 +238,7 @@ def _coerce_int(value: object) -> int:
         return 0
 
 
-def _run_recency_key(run: dict) -> tuple[int, int, int, tuple[int, str], int]:
+def _run_recency_key(run: dict) -> tuple[tuple[int, str], int, int, int, int]:
     """Return a deterministic key for comparing completed workflow runs."""
 
     timestamp = max(
@@ -170,10 +247,10 @@ def _run_recency_key(run: dict) -> tuple[int, int, int, tuple[int, str], int]:
     )
     run_number = run.get("run_number")
     return (
+        timestamp,
         int(run_number is not None),
         _coerce_int(run_number),
         _coerce_int(run.get("run_attempt")),
-        timestamp,
         _coerce_int(run.get("id")),
     )
 
@@ -300,9 +377,10 @@ def fetch_repo_status_details(
         if branch is None:
             return RepoStatus(status_to_emoji(None), stars=metadata.stars)
 
-    url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
+    base_runs_url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
+    branch_runs_url = base_runs_url
     if branch:
-        url += f"&branch={branch}"
+        branch_runs_url += f"&branch={branch}"
 
     keywords = re.compile(r"(test|lint|build|ci)", re.I)
     failures = {
@@ -463,7 +541,7 @@ def fetch_repo_status_details(
         commits = commits_data
 
         try:
-            resp = requests.get(url, headers=headers, timeout=10)
+            resp = requests.get(branch_runs_url, headers=headers, timeout=10)
             resp.raise_for_status()
             runs_data = resp.json()
         except (requests.exceptions.RequestException, ValueError) as exc:
@@ -490,6 +568,31 @@ def fetch_repo_status_details(
             )
             return None, ()
 
+        all_runs: list[dict] = []
+        try:
+            all_resp = requests.get(base_runs_url, headers=headers, timeout=10)
+            all_resp.raise_for_status()
+            all_runs_data = all_resp.json()
+        except (requests.exceptions.RequestException, ValueError) as exc:
+            LOGGER.warning("Unable to fetch all workflow runs for %s: %s", repo, exc)
+        else:
+            if isinstance(all_runs_data, dict):
+                all_runs_value = all_runs_data.get("workflow_runs", [])
+                if isinstance(all_runs_value, list):
+                    all_runs = all_runs_value
+                else:
+                    LOGGER.warning(
+                        "Unexpected all-workflow run list for %s: %r",
+                        repo,
+                        type(all_runs_value),
+                    )
+            else:
+                LOGGER.warning(
+                    "Unexpected all-workflow payload for %s: %r",
+                    repo,
+                    type(all_runs_data),
+                )
+
         runs_by_sha: dict[str, list[dict]] = {}
         for run in runs:
             run_branch = run.get("head_branch")
@@ -513,9 +616,28 @@ def fetch_repo_status_details(
                 continue
             break
 
+        release_runs = [
+            run
+            for run in all_runs
+            if isinstance(run, dict) and _run_dashboard_scope(run, branch) == "release"
+        ]
+        if release_runs:
+            selected_run_ids = {id(run) for run in selected_runs}
+            selected_runs.extend(
+                run for run in release_runs if id(run) not in selected_run_ids
+            )
+
         if not selected_runs:
             return None, ()
-        important = [r for r in selected_runs if keywords.search(r.get("name", ""))]
+        important = [
+            r
+            for r in selected_runs
+            if (
+                keywords.search(str(r.get("name", "")))
+                or _run_dashboard_scope(r, branch) == "release"
+                or (_is_release_like_workflow(r) and release_runs)
+            )
+        ]
         if important:
             selected_runs = important
         return _evaluate_runs(selected_runs)

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -126,6 +126,9 @@ def _workflow_run(
     updated_at: str | None = None,
     run_id: int | None = None,
     branch: str = "main",
+    display_title: str | None = None,
+    event: str | None = None,
+    status: str | None = None,
 ) -> dict:
     run: dict = {
         "conclusion": conclusion,
@@ -143,6 +146,12 @@ def _workflow_run(
         run["path"] = path
     if workflow_name is not None:
         run["workflow_name"] = workflow_name
+    if display_title is not None:
+        run["display_title"] = display_title
+    if event is not None:
+        run["event"] = event
+    if status is not None:
+        run["status"] = status
     if updated_at is not None:
         run["updated_at"] = updated_at
     if run_id is not None:
@@ -168,10 +177,12 @@ def _mock_repo_status_requests(
             f"https://api.github.com/repos/user/repo/commits?sha={branch}&per_page=20"
         ):
             return DummyResp(commits or [_human_commit("abc")])
-        assert url == (
+        assert url in {
             "https://api.github.com/repos/user/repo/actions/runs?"
-            f"per_page=100&status=completed&branch={branch}"
-        )
+            f"per_page=100&status=completed&branch={branch}",
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            "per_page=100&status=completed",
+        }
         return DummyResp({"workflow_runs": runs})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
@@ -201,9 +212,10 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
                     }
                 ]
             )
-        assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main"
-        )
+        assert url in {
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
+        }
         assert "Authorization" in headers
         data = {
             "workflow_runs": [
@@ -218,8 +230,10 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
     ]
 
 
@@ -249,9 +263,10 @@ def test_fetch_repo_status_no_runs_returns_unknown(
                     }
                 ]
             )
-        assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main"
-        )
+        assert url in {
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
+        }
         return DummyResp({"workflow_runs": []})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
@@ -260,8 +275,10 @@ def test_fetch_repo_status_no_runs_returns_unknown(
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
     ]
 
 
@@ -289,9 +306,10 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
                     }
                 ]
             )
-        assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev"
-        )
+        assert url in {
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
+        }
         return DummyResp(
             {
                 "workflow_runs": [
@@ -306,8 +324,10 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
     ]
 
 
@@ -361,9 +381,10 @@ def test_fetch_repo_status_nondeterministic(monkeypatch: pytest.MonkeyPatch) -> 
                     }
                 ]
             )
-        assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main"
-        )
+        assert url in {
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed",
+        }
         run_calls += 1
         if run_calls == 1:
             return DummyResp(
@@ -578,14 +599,14 @@ def test_fetch_repo_status_mixed_workflow_id_types_share_identity(
     )
 
 
-def test_fetch_repo_status_run_number_beats_later_updated_at(
+def test_fetch_repo_status_timestamp_beats_run_number_tiebreaker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _mock_repo_status_requests(
         monkeypatch,
         [
             _workflow_run(
-                "failure",
+                "success",
                 sha="old",
                 workflow_id=7,
                 run_number=10,
@@ -594,7 +615,7 @@ def test_fetch_repo_status_run_number_beats_later_updated_at(
                 run_id=10,
             ),
             _workflow_run(
-                "success",
+                "failure",
                 sha="new",
                 workflow_id=7,
                 run_number=11,
@@ -1122,6 +1143,265 @@ def test_fetch_repo_status_different_branch_success_does_not_override_failure(
             (
                 repo_status.StatusLink(
                     "Test Suite", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_token_place_release_success_supersedes_stale_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="release-sha",
+                name="Build Desktop App",
+                workflow_id=42,
+                run_number=12,
+                created_at="2026-06-10T01:00:00Z",
+                run_id=27191220631,
+                branch="main",
+                event="workflow_dispatch",
+                status="completed",
+            ),
+            _workflow_run(
+                "success",
+                sha="release-sha",
+                name="Build Desktop App",
+                workflow_id=42,
+                run_number=13,
+                created_at="2026-06-10T01:45:00Z",
+                run_id=27192437756,
+                branch="desktop-v0.1.0",
+                display_title="desktop-v0.1.0",
+                event="workflow_dispatch",
+                status="completed",
+            ),
+        ],
+        commits=[_human_commit("release-sha")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_release_tag_success_supersedes_selected_branch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="main-sha",
+                name="Package Desktop",
+                workflow_id=7,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+                branch="main",
+            ),
+            _workflow_run(
+                "success",
+                sha="tag-sha",
+                name="Package Desktop",
+                workflow_id=7,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+                branch="cli-v1.2.3",
+                display_title="cli-v1.2.3",
+                event="push",
+                status="completed",
+            ),
+        ],
+        commits=[_human_commit("main-sha")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
+def test_fetch_repo_status_feature_branch_success_does_not_supersede_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="main-sha",
+                name="Package Desktop",
+                workflow_id=7,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+                branch="main",
+            ),
+            _workflow_run(
+                "success",
+                sha="feature-sha",
+                name="Package Desktop",
+                workflow_id=7,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+                branch="feature/package-fix",
+                display_title="feature package fix",
+                event="push",
+                status="completed",
+            ),
+        ],
+        commits=[_human_commit("main-sha")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Package Desktop", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_release_success_different_workflow_keeps_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="main-sha",
+                name="Package Desktop",
+                workflow_id=7,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+                branch="main",
+            ),
+            _workflow_run(
+                "success",
+                sha="tag-sha",
+                name="Publish Release",
+                workflow_id=8,
+                path=".github/workflows/publish.yml",
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+                branch="v1.2.3",
+                display_title="v1.2.3",
+                event="release",
+                status="completed",
+            ),
+        ],
+        commits=[_human_commit("main-sha")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Package Desktop", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_release_success_does_not_hide_other_workflow_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "failure",
+                sha="main-sha",
+                name="Test Suite",
+                workflow_id=1,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+                branch="main",
+            ),
+            _workflow_run(
+                "success",
+                sha="tag-sha",
+                name="Package Desktop",
+                workflow_id=7,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+                branch="v1.2.3",
+                display_title="v1.2.3",
+                event="release",
+                status="completed",
+            ),
+        ],
+        commits=[_human_commit("main-sha")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Test Suite", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+        )
+    )
+
+
+def test_fetch_repo_status_latest_applicable_release_failure_links_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "success",
+                sha="main-sha",
+                name="Package Desktop",
+                workflow_id=7,
+                run_number=1,
+                created_at="2025-09-25T12:00:00Z",
+                run_id=1,
+                branch="main",
+            ),
+            _workflow_run(
+                "failure",
+                sha="tag-sha",
+                name="Package Desktop",
+                workflow_id=7,
+                run_number=2,
+                created_at="2025-09-25T13:00:00Z",
+                run_id=2,
+                branch="desktop-v1.2.3",
+                display_title="desktop-v1.2.3",
+                event="workflow_dispatch",
+                status="completed",
+            ),
+        ],
+        commits=[_human_commit("main-sha")],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=1) == (
+        repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "Package Desktop", "https://github.com/user/repo/actions/runs/2"
                 ),
             ),
         )
@@ -2275,10 +2555,12 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
             "https://api.github.com/repos/futuroptimist/flywheel/commits?sha=main&per_page=20"
         ):
             return DummyResp([_human_commit("new"), _human_commit("old")])
-        assert url == (
+        assert url in {
             "https://api.github.com/repos/futuroptimist/flywheel/actions/runs?"
-            "per_page=100&status=completed&branch=main"
-        )
+            "per_page=100&status=completed&branch=main",
+            "https://api.github.com/repos/futuroptimist/flywheel/actions/runs?"
+            "per_page=100&status=completed",
+        }
         return DummyResp(
             {
                 "workflow_runs": [


### PR DESCRIPTION
### Motivation
- Prevent Related Projects false positives where an older failed release/build workflow on the default branch is kept as the current failure even though a newer corrected release/tag/dispatch run for the same workflow identity completed successfully (example: futuroptimist/token.place desktop release). 
- Implement a general solution that recognizes release/version workflows and uses newer release-tag/dispatch runs to supersede stale failures without hard-coding any repo or run IDs. 
- Preserve existing default-branch behavior so arbitrary PR/feature-branch successes cannot mask real default-branch CI failures.

### Description
- Add release/version detection and helpers: `VERSION_REF_RE`, `RELEASE_WORKFLOW_RE`, `_is_version_ref`, `_is_release_like_workflow`, `_run_dashboard_scope`, and `_run_applies_to_dashboard` to identify release-like workflow runs and version-like refs. 
- Fetch both branch-scoped runs and all completed runs (`branch_runs_url` and `base_runs_url`), collect release-scoped runs, and merge applicable release/tag/dispatch runs into the candidate set for evaluation. 
- Change recency key ordering in `_run_recency_key` to prefer reliable timestamps before `run_number`, `run_attempt`, and `id`, and keep per-workflow identity selection logic so latest applicable completed run wins. 
- Update selection logic so release-scoped runs with version-like refs (e.g. `desktop-v0.1.0`, `v1.2.3`, `cli-v1.2.3`) can supersede older same-workflow failures even when not on the default branch, while preserving branch-specific rules that prevent unrelated feature-branch successes from masking failures. 
- Add and extend tests in `tests/test_repo_status.py` to model `display_title`, `event`, and `status` fields and cover the token.place regression and guard cases (feature-branch non-supersession, different-workflow isolation, unrelated default-branch failures, and latest release failures). 

### Testing
- Ran formatting and linting: `black src/repo_status.py tests/test_repo_status.py` and `ruff check src/repo_status.py tests/test_repo_status.py` with no lint failures. 
- Ran unit tests for the status updater: `python -m pytest tests/test_repo_status.py -q` and observed `77 passed`. 
- Ran the full test suite: `python -m pytest -q` and observed `346 passed` (2 warnings). 
- Verified the real token.place runs using a small REST inspection script (no `gh` available) and confirmed the older failed run and newer `desktop-v0.1.0` success share workflow identity and that the new logic renders the repo as healthy. 
- Ran repository checks `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` with no secrets found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e3ea9ce8832fb3a5269c4ff7f0b5)