### PR TITLE
Add merged PR counts to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 - **Open learning systems** that document the path from rough idea to reusable project.
 
 ## Related Projects
-_Last updated: 2026-06-12 05:31 UTC; checks hourly_
+_Last updated: 2026-06-12 06:29 UTC; checks hourly_
 
 Selected projects across this GitHub account, grouped as a compact portfolio map rather than a dependency list. Each entry links to its GitHub repo so the hourly status updater can keep the health marker current; failure links, when present, point directly to the run or artifact worth inspecting.
 
-Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows GitHub stars. Projects sort by stars descending, then alphabetically for ties; unknown star counts sort last.
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows GitHub stars; 🔀 shows total merged pull requests. Projects sort by stars descending, then alphabetically for ties; unknown star counts sort last.
 
-- ✅ ⭐ 6 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ✅ ⭐ 3 **[DSPACE](https://democratized.space)** @main – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/main))
-- ✅ ⭐ 2 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
-- ✅ ⭐ 1 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
-- ✅ ⭐ 1 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
-- ✅ ⭐ 0 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
-- ✅ ⭐ 0 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ ⭐ 0 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
-- ❌ ([Build Docker Image](https://github.com/futuroptimist/gabriel/actions/runs/27260062738), [Deploy MkDocs Site](https://github.com/futuroptimist/gabriel/actions/runs/27260062675)) <!-- repo-status:failure-links --> ⭐ 0 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
-- ✅ ⭐ 0 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
-- ✅ ⭐ 0 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
-- ✅ ⭐ 0 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
-- ✅ ⭐ 0 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
-- ✅ ⭐ 0 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
+- ✅ ⭐ 6 🔀 656 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+- ✅ ⭐ 3 🔀 2357 **[DSPACE](https://democratized.space)** @main – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/main))
+- ✅ ⭐ 2 🔀 480 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
+- ✅ ⭐ 1 🔀 125 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ ⭐ 1 🔀 162 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
+- ✅ ⭐ 0 🔀 201 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
+- ✅ ⭐ 0 🔀 440 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ ⭐ 0 🔀 334 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
+- ❌ ([Build Docker Image](https://github.com/futuroptimist/gabriel/actions/runs/27260062738), [Deploy MkDocs Site](https://github.com/futuroptimist/gabriel/actions/runs/27260062675)) <!-- repo-status:failure-links --> ⭐ 0 🔀 167 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ ⭐ 0 🔀 187 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
+- ✅ ⭐ 0 🔀 754 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 0 🔀 48 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
+- ✅ ⭐ 0 🔀 1432 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ ⭐ 0 🔀 274 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
 
 
 ## Values

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -36,6 +36,7 @@ class RepoMetadata:
 
     default_branch: str | None = None
     stars: int | None = None
+    merged_prs: int | None = None
 
 
 @dataclass(frozen=True)
@@ -45,6 +46,7 @@ class RepoStatus:
     emoji: str
     failure_links: tuple[StatusLink, ...] = field(default_factory=tuple)
     stars: int | None = None
+    merged_prs: int | None = None
 
 
 @dataclass(frozen=True)
@@ -374,12 +376,52 @@ def _latest_completed_runs_by_workflow(runs: Iterable[dict]) -> list[dict]:
     )
 
 
-def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
-    """Fetch default branch and star count for ``repo`` without raising."""
+def _github_headers(token: str | None = None) -> dict[str, str]:
+    """Return shared GitHub REST API headers."""
 
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_merged_pr_count(repo: str, token: str | None = None) -> int | None:
+    """Fetch the total merged pull-request count for ``repo`` without raising."""
+
+    try:
+        resp = requests.get(
+            f"https://api.github.com/search/issues?q=repo:{repo}+is:pr+is:merged",
+            headers=_github_headers(token),
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except (requests.exceptions.RequestException, ValueError) as exc:
+        LOGGER.warning(
+            "Unable to fetch merged pull request count for %s: %s", repo, exc
+        )
+        return None
+
+    if not isinstance(data, dict):
+        LOGGER.warning(
+            "Unexpected merged pull request payload for %s: %r", repo, type(data)
+        )
+        return None
+
+    total_count = data.get("total_count")
+    if type(total_count) is not int:
+        LOGGER.warning(
+            "Unexpected merged pull request count for %s: %r", repo, total_count
+        )
+        return None
+    return total_count
+
+
+def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
+    """Fetch default branch, star count, and merged PR count for ``repo``."""
+
+    headers = _github_headers(token)
+    merged_prs = fetch_merged_pr_count(repo, token)
 
     try:
         repo_resp = requests.get(
@@ -389,13 +431,13 @@ def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
         repo_data = repo_resp.json()
     except (requests.exceptions.RequestException, ValueError) as exc:
         LOGGER.warning("Unable to fetch repository metadata for %s: %s", repo, exc)
-        return RepoMetadata()
+        return RepoMetadata(merged_prs=merged_prs)
 
     if not isinstance(repo_data, dict):
         LOGGER.warning(
             "Unexpected repository payload for %s: %r", repo, type(repo_data)
         )
-        return RepoMetadata()
+        return RepoMetadata(merged_prs=merged_prs)
 
     default_branch = repo_data.get("default_branch")
     if not isinstance(default_branch, str) or not default_branch:
@@ -403,7 +445,9 @@ def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
 
     stars_value = repo_data.get("stargazers_count")
     stars = stars_value if type(stars_value) is int else None
-    return RepoMetadata(default_branch=default_branch, stars=stars)
+    return RepoMetadata(
+        default_branch=default_branch, stars=stars, merged_prs=merged_prs
+    )
 
 
 def fetch_repo_status_details(
@@ -428,7 +472,11 @@ def fetch_repo_status_details(
     if branch is None:
         branch = metadata.default_branch
         if branch is None:
-            return RepoStatus(status_to_emoji(None), stars=metadata.stars)
+            return RepoStatus(
+                status_to_emoji(None),
+                stars=metadata.stars,
+                merged_prs=metadata.merged_prs,
+            )
 
     all_runs_url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     url = all_runs_url
@@ -772,7 +820,10 @@ def fetch_repo_status_details(
             if link not in failure_links:
                 failure_links.append(link)
     return RepoStatus(
-        status_to_emoji(conclusions[0]), tuple(failure_links), metadata.stars
+        status_to_emoji(conclusions[0]),
+        tuple(failure_links),
+        metadata.stars,
+        metadata.merged_prs,
     )
 
 
@@ -822,6 +873,12 @@ def format_star_count(stars: int | None) -> str:
     return f"⭐ {stars}" if stars is not None else "⭐ ?"
 
 
+def format_merged_pr_count(count: int | None) -> str:
+    """Format a compact merged pull-request count marker."""
+
+    return f"🔀 {count}" if count is not None else "🔀 ?"
+
+
 GENERATED_ACTION_RUN_LINK_RE = (
     r"\[(?:\\.|[^\]\\])+\]"
     r"\(https://github\.com/[\w.-]+/[\w.-]+/actions/runs/[^)]*\)"
@@ -844,15 +901,16 @@ LEGACY_GENERATED_ACTION_RUN_LINK_RE = (
 )
 LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
-    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:\*\*?\[[^\]]+\]\(|\[[^\]]+\]\())",
+    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:🔀\s*(?:\?|[\d,]+)\s*)?(?:\*\*?\[[^\]]+\]\(|\[[^\]]+\]\())",
     re.IGNORECASE,
 )
 LEGACY_KEYWORDED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
-    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?)",
+    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:🔀\s*(?:\?|[\d,]+)\s*)?https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?)",
     re.IGNORECASE,
 )
 STAR_PREFIX_RE = re.compile(r"^⭐\s*(?:\?|[\d,]+)\s*")
+MERGED_PR_PREFIX_RE = re.compile(r"^🔀\s*(?:\?|[\d,]+)\s*")
 LEGACY_FAILING_RUNS_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
 
 
@@ -882,6 +940,7 @@ def strip_project_prefix(line: str) -> str:
         content = _strip_legacy_failure_links_before_markdown_repo(content)
         content = _strip_keyworded_legacy_failure_links_before_raw_repo(content)
         content = STAR_PREFIX_RE.sub("", content, count=1).lstrip()
+        content = MERGED_PR_PREFIX_RE.sub("", content, count=1).lstrip()
         if content == original:
             return LEGACY_FAILING_RUNS_RE.sub("", content)
 
@@ -1010,7 +1069,8 @@ def render_project_item(item: RelatedProjectItem, details: RepoStatus) -> list[s
     link_suffix = _format_failure_links(details.failure_links)
     first = (
         f"- {details.emoji}{link_suffix} "
-        f"{format_star_count(details.stars)} {item.cleaned_first_line}"
+        f"{format_star_count(details.stars)} "
+        f"{format_merged_pr_count(details.merged_prs)} {item.cleaned_first_line}"
     )
     return [first, *item.lines[1:]]
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1,4 +1,4 @@
-from datetime import UTC
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -236,6 +236,8 @@ def _mock_repo_status_requests(
     stars: int | None = None,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             data: dict = {"default_branch": branch}
             if stars is not None:
@@ -266,6 +268,8 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -299,6 +303,7 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", token="abc") == "✅"
     assert calls == [
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
@@ -314,6 +319,8 @@ def test_fetch_repo_status_no_runs_returns_unknown(
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -341,6 +348,7 @@ def test_fetch_repo_status_no_runs_returns_unknown(
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "❓"
     assert calls == [
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
@@ -354,6 +362,8 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main", "stargazers_count": 42})
         if url.startswith(
@@ -387,6 +397,7 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
@@ -397,6 +408,8 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_fetch_repo_status_request_error(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         raise repo_status.requests.exceptions.ConnectionError("boom")
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
@@ -407,6 +420,8 @@ def test_fetch_repo_status_invalid_commit_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -424,6 +439,8 @@ def test_fetch_repo_status_nondeterministic(monkeypatch: pytest.MonkeyPatch) -> 
     run_calls = 0
 
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         nonlocal run_calls
         calls.append(url)
         if url == "https://api.github.com/repos/user/repo":
@@ -480,6 +497,8 @@ def test_fetch_repo_status_ignores_non_ci_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -524,6 +543,8 @@ def test_fetch_repo_status_prefers_latest_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -977,6 +998,8 @@ def test_fetch_repo_status_paginates_release_runs_beyond_page_ten(
     calls: list[str] = []
 
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         calls.append(url)
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
@@ -1856,6 +1879,8 @@ def test_fetch_repo_status_skips_bot_commit(monkeypatch: pytest.MonkeyPatch) -> 
     calls: list[str] = []
 
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         calls.append(url)
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
@@ -1907,6 +1932,8 @@ def test_fetch_repo_status_skips_bot_commit(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_fetch_repo_status_skip_ci_message(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -1980,7 +2007,7 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ ⭐ 2 https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ 2 🔀 ? https://github.com/user/repo"
 
 
 def test_update_readme_uses_current_time(
@@ -2014,7 +2041,7 @@ def test_update_readme_uses_current_time(
     repo_status.update_readme(readme)
     lines = readme.read_text().splitlines()
     assert lines[1] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[2] == "- ✅ ⭐ ? https://github.com/user/repo"
+    assert lines[2] == "- ✅ ⭐ ? 🔀 ? https://github.com/user/repo"
 
 
 def test_update_readme_existing_timestamp(
@@ -2049,13 +2076,15 @@ def test_update_readme_existing_timestamp(
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ ⭐ ? https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ ? 🔀 ? https://github.com/user/repo"
 
 
 def test_fetch_repo_status_details_includes_failed_run_link(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2104,6 +2133,8 @@ def test_fetch_repo_status_details_orders_multiple_failure_links(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2163,6 +2194,8 @@ def test_fetch_repo_status_details_falls_back_to_actions_run_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2211,6 +2244,8 @@ def test_fetch_repo_status_details_omits_unlinkable_failed_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2249,6 +2284,8 @@ def test_fetch_repo_status_details_links_only_failed_workflows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2303,6 +2340,8 @@ def test_fetch_repo_status_details_success_and_unknown_have_no_links(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2354,6 +2393,8 @@ def test_fetch_repo_status_details_prefers_latest_attempt_without_stale_link(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2414,7 +2455,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         "## Related Projects\n"
         "_Last updated: 1999-01-01 00:00 UTC; checks hourly_\n"
         "_Last updated: 1998-01-01 00:00 UTC; checks hourly_\n"
-        "- ✅ ⭐ ? https://github.com/user/repo (failing runs: https://old.example/run)\n"
+        "- ✅ ⭐ ? 🔀 ? https://github.com/user/repo (failing runs: https://old.example/run)\n"
     )
     readme = tmp_path / "README.md"
     readme.write_text(content)
@@ -2446,7 +2487,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         (
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
-            "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
+            "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo"
         ),
     ]
 
@@ -2495,7 +2536,7 @@ def test_update_readme_strips_linked_failure_prefixes_idempotently(
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
             "<!-- repo-status:failure-links --> "
-            "⭐ ? **[repo](https://github.com/user/repo)** - description"
+            "⭐ ? 🔀 ? **[repo](https://github.com/user/repo)** - description"
         ),
     ]
 
@@ -2529,7 +2570,7 @@ def test_update_readme_uses_status_details_not_compatibility_report(
 
     assert (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo"
     ) in readme.read_text().splitlines()
 
 
@@ -2537,6 +2578,8 @@ def test_fetch_repo_status_report_returns_url_strings_for_compatibility(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2585,6 +2628,8 @@ def test_fetch_repo_status_details_collapses_renamed_latest_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2642,6 +2687,8 @@ def test_fetch_repo_status_details_disambiguates_same_name_and_run_number(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2710,7 +2757,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -2737,7 +2784,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo",
     ]
 
 
@@ -2748,7 +2795,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -2775,7 +2822,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo",
     ]
 
 
@@ -2813,7 +2860,7 @@ def test_update_readme_migrates_legacy_unmarked_failure_links_before_raw_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo",
     ]
 
 
@@ -2849,10 +2896,10 @@ def test_update_readme_preserves_hand_authored_leading_notes(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ 3 (archived) **[repo](https://github.com/user/repo)** - desc",
-        "- ✅ ⭐ 2 ([docs](https://example.com)) "
+        "- ✅ ⭐ 3 🔀 ? (archived) **[repo](https://github.com/user/repo)** - desc",
+        "- ✅ ⭐ 2 🔀 ? ([docs](https://example.com)) "
         "**[docs-repo](https://github.com/user/docs-repo)** - desc",
-        "- ✅ ⭐ 1 ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
+        "- ✅ ⭐ 1 🔀 ? ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
         "**[debug-repo](https://github.com/user/debug-repo)** - desc",
     ]
 
@@ -2883,7 +2930,7 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
+        "- ✅ ⭐ ? 🔀 ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
         "https://github.com/user/repo - desc",
     ]
 
@@ -2905,6 +2952,8 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
     )
 
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/futuroptimist/flywheel":
             return DummyResp({"default_branch": "main", "stargazers_count": 9})
         if url.startswith(
@@ -2950,9 +2999,10 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
 
     rendered = readme.read_text(encoding="utf-8")
     assert (
-        "- ✅ ⭐ 9 **[flywheel](https://github.com/futuroptimist/flywheel)** - automate the loop"
+        "- ✅ ⭐ 9 🔀 ? **[flywheel](https://github.com/futuroptimist/flywheel)**"
         in rendered
     )
+    assert "automate the loop" in rendered
     assert "27123196602" not in rendered
     assert "repo-status:failure-links" not in rendered
 
@@ -2971,6 +3021,7 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
         in section
     )
     assert "⭐ shows GitHub stars" in section
+    assert "🔀 shows total merged pull requests" in section
     assert "Projects sort by stars descending" in section
     assert readme.count("docs/repository-guide.md") == 1
 
@@ -2978,12 +3029,15 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
     assert project_lines
     assert all(repo_status.GITHUB_RE.search(line) for line in project_lines)
     assert all("⭐" in line for line in project_lines)
+    assert all("🔀" in line for line in project_lines)
 
 
 def test_fetch_repo_status_details_includes_star_count(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if url.startswith("https://api.github.com/search/issues?q=repo:"):
+            return DummyResp({"total_count": None})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main", "stargazers_count": 42})
         if url.startswith(
@@ -3064,10 +3118,10 @@ def test_update_readme_sorts_by_stars_then_name_and_unknowns_last(
     repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
 
     assert readme.read_text().splitlines()[2:] == [
-        "- ✅ ⭐ 5 **[alpha](https://github.com/user/alpha)** - same stars",
-        "- ✅ ⭐ 5 **[Beta](https://github.com/user/beta)** - same stars",
-        "- ✅ ⭐ 0 **[Zero](https://github.com/user/zero)** - zero stars",
-        "- ✅ ⭐ ? **[Unknown](https://github.com/user/unknown)** - unknown stars",
+        "- ✅ ⭐ 5 🔀 ? **[alpha](https://github.com/user/alpha)** - same stars",
+        "- ✅ ⭐ 5 🔀 ? **[Beta](https://github.com/user/beta)** - same stars",
+        "- ✅ ⭐ 0 🔀 ? **[Zero](https://github.com/user/zero)** - zero stars",
+        "- ✅ ⭐ ? 🔀 ? **[Unknown](https://github.com/user/unknown)** - unknown stars",
     ]
 
 
@@ -3104,7 +3158,7 @@ def test_update_readme_star_and_failure_prefix_is_idempotent(
     assert readme.read_text() == first
     assert readme.read_text().splitlines()[2] == (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ 7 "
+        "<!-- repo-status:failure-links --> ⭐ 7 🔀 ? "
         "**[repo](https://github.com/user/repo)** - desc"
     )
 
@@ -3138,10 +3192,10 @@ def test_update_readme_preserves_multiline_and_external_display_links(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "Intro stays put.",
-        "- ✅ ⭐ 10 **[token.place](https://token.place)** - external first "
+        "- ✅ ⭐ 10 🔀 ? **[token.place](https://token.place)** - external first "
         "([repo](https://github.com/futuroptimist/token.place))",
         "  continuation stays with token.place",
-        "- ✅ ⭐ 1 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub",
+        "- ✅ ⭐ 1 🔀 ? **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub",
     ]
 
 
@@ -3172,9 +3226,9 @@ def test_update_readme_uses_repo_link_from_continuation_line(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ 10 **[external](https://example.com)** - homepage first",
+        "- ✅ ⭐ 10 🔀 ? **[external](https://example.com)** - homepage first",
         "  ([repo](https://github.com/user/external/tree/main))",
-        "- ✅ ⭐ 1 **[local](https://github.com/user/local)** - repo first",
+        "- ✅ ⭐ 1 🔀 ? **[local](https://github.com/user/local)** - repo first",
     ]
 
 
@@ -3205,7 +3259,7 @@ def test_update_readme_ignores_issue_action_and_note_links_before_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ 9 ([note](https://github.com/user/notes)) "
+        "- ✅ ⭐ 9 🔀 ? ([note](https://github.com/user/notes)) "
         "([issue](https://github.com/user/issue-tracker/issues/7)) "
         "([run](https://github.com/user/automation/actions/runs/99)) "
         "**[Site](https://example.com)** - external display "
@@ -3248,7 +3302,7 @@ def test_update_readme_strips_arbitrary_label_legacy_failure_link_before_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([Production](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ 4 "
+        "<!-- repo-status:failure-links --> ⭐ 4 🔀 ? "
         "**[repo](https://github.com/user/repo)** - desc",
     ]
 
@@ -3286,7 +3340,7 @@ def test_update_readme_strips_legacy_deploy_failure_link_before_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([Deploy](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? "
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? "
         "**[repo](https://github.com/user/repo)** - desc",
     ]
 
@@ -3312,4 +3366,136 @@ def test_update_readme_branch_url_uses_branch_for_status_and_repo_for_stars(
     repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
 
     assert calls == [("democratizedspace/dspace", "main")]
-    assert "- ✅ ⭐ 12 **[DSPACE](https://democratized.space)**" in readme.read_text()
+    assert (
+        "- ✅ ⭐ 12 🔀 ? **[DSPACE](https://democratized.space)**" in readme.read_text()
+    )
+
+
+def test_fetch_repo_metadata_includes_merged_pr_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append(url)
+        assert headers["Authorization"] == "Bearer token"
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({"total_count": 42})
+        assert url == "https://api.github.com/repos/user/repo"
+        return DummyResp({"default_branch": "main", "stargazers_count": 6})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_metadata("user/repo", token="token") == (
+        repo_status.RepoMetadata(default_branch="main", stars=6, merged_prs=42)
+    )
+    assert calls == [
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
+        "https://api.github.com/repos/user/repo",
+    ]
+
+
+@pytest.mark.parametrize("payload", [{}, {"total_count": "42"}, []])
+def test_fetch_merged_pr_count_invalid_payload_is_unknown(
+    monkeypatch: pytest.MonkeyPatch, payload: object
+) -> None:
+    monkeypatch.setattr(
+        repo_status.requests,
+        "get",
+        lambda url, headers, timeout: DummyResp(payload),
+    )
+
+    assert repo_status.fetch_merged_pr_count("user/repo") is None
+
+
+def test_fetch_merged_pr_count_request_error_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        raise repo_status.requests.exceptions.RequestException("rate limited")
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_merged_pr_count("user/repo") is None
+
+
+def test_format_merged_pr_count_handles_unknowns() -> None:
+    assert repo_status.format_merged_pr_count(42) == "🔀 42"
+    assert repo_status.format_merged_pr_count(None) == "🔀 ?"
+
+
+def test_update_readme_renders_known_stars_with_known_merged_prs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n- **[repo](https://github.com/user/repo)** - desc\n"
+    )
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "✅", stars=6, merged_prs=42
+        ),
+    )
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text().splitlines()[2] == (
+        "- ✅ ⭐ 6 🔀 42 **[repo](https://github.com/user/repo)** - desc"
+    )
+
+
+def test_update_readme_renders_unknown_stars_with_known_merged_prs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n- **[repo](https://github.com/user/repo)** - desc\n"
+    )
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "❓", stars=None, merged_prs=42
+        ),
+    )
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert readme.read_text().splitlines()[2] == (
+        "- ❓ ⭐ ? 🔀 42 **[repo](https://github.com/user/repo)** - desc"
+    )
+
+
+def test_update_readme_replaces_stale_merged_pr_prefix_idempotently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ✅ ⭐ 1 🔀 999 **[repo](https://github.com/user/repo)** - desc\n"
+    )
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "✅", stars=6, merged_prs=42
+        ),
+    )
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=now)
+
+    assert readme.read_text() == first
+    assert first.splitlines()[2] == (
+        "- ✅ ⭐ 6 🔀 42 **[repo](https://github.com/user/repo)** - desc"
+    )


### PR DESCRIPTION
### Motivation
- Surface a second, useful repository signal (total merged pull requests) alongside stars in the profile "Related Projects" list so readers and automation can see activity beyond stars.
- Keep existing behavior (status emoji, failure links, branch-specific status checks, star sorting, and idempotent prefix stripping) while extending the metadata model and README formatting.

### Description
- Extend `RepoMetadata` and `RepoStatus` with a new `merged_prs: int | None` field and add `fetch_merged_pr_count(repo, token=None) -> int | None` that queries GitHub Search (`/search/issues?q=repo:{owner}/{repo}+is:pr+is:merged`) and returns `total_count` or `None` on error. (See `src/repo_status.py`.)
- Add `_github_headers(token)` helper, `format_merged_pr_count(count)` and include the merged-PR marker when rendering bullets so items now render as `⭐ N 🔀 M` (or `🔀 ?` when unknown). Rendering happens via `render_project_item`.
- Update project-prefix stripping to remove stale `🔀` markers (add `MERGED_PR_PREFIX_RE`) and extend legacy lookaheads to tolerate both `⭐` and `🔀` when migrating older formats.
- Update README legend to explain `🔀` and update the generated Related Projects entries to show merged PR counts.
- Add and update tests in `tests/test_repo_status.py` covering merged-PR fetch success, invalid/error handling, formatting, README rendering, idempotency, and integration with existing status/failure-link behavior.
- Keep sorting unchanged (still sorts by stars descending, unknowns last); merged PRs are only displayed, not used for sorting.

### Testing
- Ran `python -m pytest tests/test_repo_status.py -q` (focused tests) and they passed locally.
- Ran `python -m ruff check --fix src/repo_status.py tests/test_repo_status.py` to apply/fix lint suggestions; linter checks passed after fixes.
- Ran full suite `python -m pytest -q` after installing dev deps (`python -m pip install -e '.[dev]'`) and all tests passed (367 passed, 2 warnings from existing FastAPI/httpx deprecation and a runpy import warning). 
- Performed repository hygiene checks: `git diff --cached | ./scripts/scan-secrets.py` (no secrets) and committed changes as `Add merged PR counts to related projects`.

Notes and risks: GitHub Search requests add one extra API call per repo and may hit rate limits on large runs; failures fall back to a `None` value rendered as `🔀 ?` to keep behavior robust and idempotent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ba559b72c832f8c47a658dcc9a984)