### PR TITLE
Add merged PR counts to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 - **Open learning systems** that document the path from rough idea to reusable project.
 
 ## Related Projects
-_Last updated: 2026-06-12 05:31 UTC; checks hourly_
+_Last updated: 2026-06-12 06:27 UTC; checks hourly_
 
 Selected projects across this GitHub account, grouped as a compact portfolio map rather than a dependency list. Each entry links to its GitHub repo so the hourly status updater can keep the health marker current; failure links, when present, point directly to the run or artifact worth inspecting.
 
-Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows GitHub stars. Projects sort by stars descending, then alphabetically for ties; unknown star counts sort last.
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows GitHub stars; 🔀 shows total merged pull requests. Projects sort by stars descending, then alphabetically for ties; unknown star counts sort last.
 
-- ✅ ⭐ 6 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ✅ ⭐ 3 **[DSPACE](https://democratized.space)** @main – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/main))
-- ✅ ⭐ 2 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
-- ✅ ⭐ 1 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
-- ✅ ⭐ 1 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
-- ✅ ⭐ 0 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
-- ✅ ⭐ 0 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ ⭐ 0 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
-- ❌ ([Build Docker Image](https://github.com/futuroptimist/gabriel/actions/runs/27260062738), [Deploy MkDocs Site](https://github.com/futuroptimist/gabriel/actions/runs/27260062675)) <!-- repo-status:failure-links --> ⭐ 0 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
-- ✅ ⭐ 0 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
-- ✅ ⭐ 0 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
-- ✅ ⭐ 0 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
-- ✅ ⭐ 0 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
-- ✅ ⭐ 0 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
+- ❓ ⭐ 6 🔀 655 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+- ✅ ⭐ 3 🔀 2357 **[DSPACE](https://democratized.space)** @main – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/main))
+- ✅ ⭐ 2 🔀 480 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
+- ✅ ⭐ 1 🔀 125 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ ⭐ 1 🔀 162 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
+- ✅ ⭐ 0 🔀 201 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
+- ✅ ⭐ 0 🔀 440 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ ⭐ 0 🔀 334 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
+- ❌ ([Build Docker Image](https://github.com/futuroptimist/gabriel/actions/runs/27260062738), [Deploy MkDocs Site](https://github.com/futuroptimist/gabriel/actions/runs/27260062675)) <!-- repo-status:failure-links --> ⭐ 0 🔀 167 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ ⭐ 0 🔀 187 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
+- ✅ ⭐ 0 🔀 754 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 0 🔀 48 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
+- ✅ ⭐ 0 🔀 1432 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ ⭐ 0 🔀 274 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
 
 
 ## Values

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -36,6 +36,7 @@ class RepoMetadata:
 
     default_branch: str | None = None
     stars: int | None = None
+    merged_prs: int | None = None
 
 
 @dataclass(frozen=True)
@@ -45,6 +46,7 @@ class RepoStatus:
     emoji: str
     failure_links: tuple[StatusLink, ...] = field(default_factory=tuple)
     stars: int | None = None
+    merged_prs: int | None = None
 
 
 @dataclass(frozen=True)
@@ -374,16 +376,55 @@ def _latest_completed_runs_by_workflow(runs: Iterable[dict]) -> list[dict]:
     )
 
 
-def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
-    """Fetch default branch and star count for ``repo`` without raising."""
+def _github_headers(token: str | None = None) -> dict[str, str]:
+    """Return common GitHub REST API headers."""
 
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_merged_pr_count(repo: str, token: str | None = None) -> int | None:
+    """Fetch the total number of merged pull requests for ``repo`` without raising."""
+
+    try:
+        resp = requests.get(
+            f"https://api.github.com/search/issues?q=repo:{repo}+is:pr+is:merged",
+            headers=_github_headers(token),
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except (requests.exceptions.RequestException, ValueError) as exc:
+        LOGGER.warning(
+            "Unable to fetch merged pull request count for %s: %s", repo, exc
+        )
+        return None
+
+    if not isinstance(data, dict):
+        LOGGER.warning(
+            "Unexpected merged pull request payload for %s: %r", repo, type(data)
+        )
+        return None
+
+    total_count = data.get("total_count")
+    if type(total_count) is not int:
+        LOGGER.warning(
+            "Unexpected merged pull request count for %s: %r", repo, total_count
+        )
+        return None
+    return total_count
+
+
+def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
+    """Fetch default branch, star count, and merged PR count for ``repo`` without raising."""
 
     try:
         repo_resp = requests.get(
-            f"https://api.github.com/repos/{repo}", headers=headers, timeout=10
+            f"https://api.github.com/repos/{repo}",
+            headers=_github_headers(token),
+            timeout=10,
         )
         repo_resp.raise_for_status()
         repo_data = repo_resp.json()
@@ -403,7 +444,12 @@ def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
 
     stars_value = repo_data.get("stargazers_count")
     stars = stars_value if type(stars_value) is int else None
-    return RepoMetadata(default_branch=default_branch, stars=stars)
+    merged_prs = (
+        fetch_merged_pr_count(repo, token) if "stargazers_count" in repo_data else None
+    )
+    return RepoMetadata(
+        default_branch=default_branch, stars=stars, merged_prs=merged_prs
+    )
 
 
 def fetch_repo_status_details(
@@ -420,15 +466,17 @@ def fetch_repo_status_details(
     ``RuntimeError`` so the calling workflow fails loudly.
     """
 
-    headers = {"Accept": "application/vnd.github+json"}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    headers = _github_headers(token)
 
     metadata = fetch_repo_metadata(repo, token)
     if branch is None:
         branch = metadata.default_branch
         if branch is None:
-            return RepoStatus(status_to_emoji(None), stars=metadata.stars)
+            return RepoStatus(
+                status_to_emoji(None),
+                stars=metadata.stars,
+                merged_prs=metadata.merged_prs,
+            )
 
     all_runs_url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     url = all_runs_url
@@ -772,7 +820,10 @@ def fetch_repo_status_details(
             if link not in failure_links:
                 failure_links.append(link)
     return RepoStatus(
-        status_to_emoji(conclusions[0]), tuple(failure_links), metadata.stars
+        status_to_emoji(conclusions[0]),
+        tuple(failure_links),
+        metadata.stars,
+        metadata.merged_prs,
     )
 
 
@@ -822,6 +873,12 @@ def format_star_count(stars: int | None) -> str:
     return f"⭐ {stars}" if stars is not None else "⭐ ?"
 
 
+def format_merged_pr_count(count: int | None) -> str:
+    """Format a compact merged pull request count marker."""
+
+    return f"🔀 {count}" if count is not None else "🔀 ?"
+
+
 GENERATED_ACTION_RUN_LINK_RE = (
     r"\[(?:\\.|[^\]\\])+\]"
     r"\(https://github\.com/[\w.-]+/[\w.-]+/actions/runs/[^)]*\)"
@@ -844,15 +901,16 @@ LEGACY_GENERATED_ACTION_RUN_LINK_RE = (
 )
 LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
-    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:\*\*?\[[^\]]+\]\(|\[[^\]]+\]\())",
+    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:🔀\s*(?:\?|[\d,]+)\s*)?(?:\*\*?\[[^\]]+\]\(|\[[^\]]+\]\())",
     re.IGNORECASE,
 )
 LEGACY_KEYWORDED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
-    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?)",
+    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:🔀\s*(?:\?|[\d,]+)\s*)?https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?)",
     re.IGNORECASE,
 )
 STAR_PREFIX_RE = re.compile(r"^⭐\s*(?:\?|[\d,]+)\s*")
+MERGED_PR_PREFIX_RE = re.compile(r"^🔀\s*(?:\?|[\d,]+)\s*")
 LEGACY_FAILING_RUNS_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
 
 
@@ -882,6 +940,7 @@ def strip_project_prefix(line: str) -> str:
         content = _strip_legacy_failure_links_before_markdown_repo(content)
         content = _strip_keyworded_legacy_failure_links_before_raw_repo(content)
         content = STAR_PREFIX_RE.sub("", content, count=1).lstrip()
+        content = MERGED_PR_PREFIX_RE.sub("", content, count=1).lstrip()
         if content == original:
             return LEGACY_FAILING_RUNS_RE.sub("", content)
 
@@ -1010,7 +1069,8 @@ def render_project_item(item: RelatedProjectItem, details: RepoStatus) -> list[s
     link_suffix = _format_failure_links(details.failure_links)
     first = (
         f"- {details.emoji}{link_suffix} "
-        f"{format_star_count(details.stars)} {item.cleaned_first_line}"
+        f"{format_star_count(details.stars)} "
+        f"{format_merged_pr_count(details.merged_prs)} {item.cleaned_first_line}"
     )
     return [first, *item.lines[1:]]
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -373,6 +373,11 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
                     }
                 ]
             )
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({"total_count": 13})
         assert url == (
             "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev"
         )
@@ -388,6 +393,7 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
         "https://api.github.com/repos/user/repo",
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
@@ -1980,7 +1986,7 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ ⭐ 2 https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ 2 🔀 ? https://github.com/user/repo"
 
 
 def test_update_readme_uses_current_time(
@@ -2014,7 +2020,7 @@ def test_update_readme_uses_current_time(
     repo_status.update_readme(readme)
     lines = readme.read_text().splitlines()
     assert lines[1] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[2] == "- ✅ ⭐ ? https://github.com/user/repo"
+    assert lines[2] == "- ✅ ⭐ ? 🔀 ? https://github.com/user/repo"
 
 
 def test_update_readme_existing_timestamp(
@@ -2049,7 +2055,7 @@ def test_update_readme_existing_timestamp(
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ ⭐ ? https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ ? 🔀 ? https://github.com/user/repo"
 
 
 def test_fetch_repo_status_details_includes_failed_run_link(
@@ -2414,7 +2420,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         "## Related Projects\n"
         "_Last updated: 1999-01-01 00:00 UTC; checks hourly_\n"
         "_Last updated: 1998-01-01 00:00 UTC; checks hourly_\n"
-        "- ✅ ⭐ ? https://github.com/user/repo (failing runs: https://old.example/run)\n"
+        "- ✅ ⭐ ? 🔀 ? https://github.com/user/repo (failing runs: https://old.example/run)\n"
     )
     readme = tmp_path / "README.md"
     readme.write_text(content)
@@ -2446,7 +2452,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         (
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
-            "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
+            "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo"
         ),
     ]
 
@@ -2495,7 +2501,7 @@ def test_update_readme_strips_linked_failure_prefixes_idempotently(
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
             "<!-- repo-status:failure-links --> "
-            "⭐ ? **[repo](https://github.com/user/repo)** - description"
+            "⭐ ? 🔀 ? **[repo](https://github.com/user/repo)** - description"
         ),
     ]
 
@@ -2529,7 +2535,7 @@ def test_update_readme_uses_status_details_not_compatibility_report(
 
     assert (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo"
     ) in readme.read_text().splitlines()
 
 
@@ -2710,7 +2716,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -2737,7 +2743,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo",
     ]
 
 
@@ -2748,7 +2754,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -2775,7 +2781,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo",
     ]
 
 
@@ -2813,7 +2819,7 @@ def test_update_readme_migrates_legacy_unmarked_failure_links_before_raw_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo",
     ]
 
 
@@ -2849,10 +2855,10 @@ def test_update_readme_preserves_hand_authored_leading_notes(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ 3 (archived) **[repo](https://github.com/user/repo)** - desc",
-        "- ✅ ⭐ 2 ([docs](https://example.com)) "
+        "- ✅ ⭐ 3 🔀 ? (archived) **[repo](https://github.com/user/repo)** - desc",
+        "- ✅ ⭐ 2 🔀 ? ([docs](https://example.com)) "
         "**[docs-repo](https://github.com/user/docs-repo)** - desc",
-        "- ✅ ⭐ 1 ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
+        "- ✅ ⭐ 1 🔀 ? ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
         "**[debug-repo](https://github.com/user/debug-repo)** - desc",
     ]
 
@@ -2883,7 +2889,7 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
+        "- ✅ ⭐ ? 🔀 ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
         "https://github.com/user/repo - desc",
     ]
 
@@ -2907,6 +2913,11 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
     def fake_get(url: str, headers: dict, timeout: int):
         if url == "https://api.github.com/repos/futuroptimist/flywheel":
             return DummyResp({"default_branch": "main", "stargazers_count": 9})
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:futuroptimist/flywheel+is:pr+is:merged"
+        ):
+            return DummyResp({"total_count": 99})
         if url.startswith(
             "https://api.github.com/repos/futuroptimist/flywheel/commits?sha=main&per_page=20"
         ):
@@ -2950,7 +2961,8 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
 
     rendered = readme.read_text(encoding="utf-8")
     assert (
-        "- ✅ ⭐ 9 **[flywheel](https://github.com/futuroptimist/flywheel)** - automate the loop"
+        "- ✅ ⭐ 9 🔀 99 "
+        "**[flywheel](https://github.com/futuroptimist/flywheel)** - automate the loop"
         in rendered
     )
     assert "27123196602" not in rendered
@@ -2971,6 +2983,7 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
         in section
     )
     assert "⭐ shows GitHub stars" in section
+    assert "🔀 shows total merged pull requests" in section
     assert "Projects sort by stars descending" in section
     assert readme.count("docs/repository-guide.md") == 1
 
@@ -2978,6 +2991,7 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
     assert project_lines
     assert all(repo_status.GITHUB_RE.search(line) for line in project_lines)
     assert all("⭐" in line for line in project_lines)
+    assert all("🔀" in line for line in project_lines)
 
 
 def test_fetch_repo_status_details_includes_star_count(
@@ -3064,10 +3078,10 @@ def test_update_readme_sorts_by_stars_then_name_and_unknowns_last(
     repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
 
     assert readme.read_text().splitlines()[2:] == [
-        "- ✅ ⭐ 5 **[alpha](https://github.com/user/alpha)** - same stars",
-        "- ✅ ⭐ 5 **[Beta](https://github.com/user/beta)** - same stars",
-        "- ✅ ⭐ 0 **[Zero](https://github.com/user/zero)** - zero stars",
-        "- ✅ ⭐ ? **[Unknown](https://github.com/user/unknown)** - unknown stars",
+        "- ✅ ⭐ 5 🔀 ? **[alpha](https://github.com/user/alpha)** - same stars",
+        "- ✅ ⭐ 5 🔀 ? **[Beta](https://github.com/user/beta)** - same stars",
+        "- ✅ ⭐ 0 🔀 ? **[Zero](https://github.com/user/zero)** - zero stars",
+        "- ✅ ⭐ ? 🔀 ? **[Unknown](https://github.com/user/unknown)** - unknown stars",
     ]
 
 
@@ -3104,7 +3118,7 @@ def test_update_readme_star_and_failure_prefix_is_idempotent(
     assert readme.read_text() == first
     assert readme.read_text().splitlines()[2] == (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ 7 "
+        "<!-- repo-status:failure-links --> ⭐ 7 🔀 ? "
         "**[repo](https://github.com/user/repo)** - desc"
     )
 
@@ -3138,10 +3152,10 @@ def test_update_readme_preserves_multiline_and_external_display_links(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "Intro stays put.",
-        "- ✅ ⭐ 10 **[token.place](https://token.place)** - external first "
+        "- ✅ ⭐ 10 🔀 ? **[token.place](https://token.place)** - external first "
         "([repo](https://github.com/futuroptimist/token.place))",
         "  continuation stays with token.place",
-        "- ✅ ⭐ 1 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub",
+        "- ✅ ⭐ 1 🔀 ? **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub",
     ]
 
 
@@ -3172,9 +3186,9 @@ def test_update_readme_uses_repo_link_from_continuation_line(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ 10 **[external](https://example.com)** - homepage first",
+        "- ✅ ⭐ 10 🔀 ? **[external](https://example.com)** - homepage first",
         "  ([repo](https://github.com/user/external/tree/main))",
-        "- ✅ ⭐ 1 **[local](https://github.com/user/local)** - repo first",
+        "- ✅ ⭐ 1 🔀 ? **[local](https://github.com/user/local)** - repo first",
     ]
 
 
@@ -3205,7 +3219,7 @@ def test_update_readme_ignores_issue_action_and_note_links_before_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ 9 ([note](https://github.com/user/notes)) "
+        "- ✅ ⭐ 9 🔀 ? ([note](https://github.com/user/notes)) "
         "([issue](https://github.com/user/issue-tracker/issues/7)) "
         "([run](https://github.com/user/automation/actions/runs/99)) "
         "**[Site](https://example.com)** - external display "
@@ -3248,7 +3262,7 @@ def test_update_readme_strips_arbitrary_label_legacy_failure_link_before_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([Production](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ 4 "
+        "<!-- repo-status:failure-links --> ⭐ 4 🔀 ? "
         "**[repo](https://github.com/user/repo)** - desc",
     ]
 
@@ -3286,7 +3300,7 @@ def test_update_readme_strips_legacy_deploy_failure_link_before_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([Deploy](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? "
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? "
         "**[repo](https://github.com/user/repo)** - desc",
     ]
 
@@ -3312,4 +3326,107 @@ def test_update_readme_branch_url_uses_branch_for_status_and_repo_for_stars(
     repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
 
     assert calls == [("democratizedspace/dspace", "main")]
-    assert "- ✅ ⭐ 12 **[DSPACE](https://democratized.space)**" in readme.read_text()
+    assert (
+        "- ✅ ⭐ 12 🔀 ? **[DSPACE](https://democratized.space)**" in readme.read_text()
+    )
+
+
+def test_fetch_repo_status_details_includes_merged_pr_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append(url)
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main", "stargazers_count": 6})
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({"total_count": 42})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp([_human_commit("abc")])
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "success", "head_sha": "abc", "name": "tests"}
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_status_details(
+        "user/repo", attempts=1
+    ) == repo_status.RepoStatus("✅", stars=6, merged_prs=42)
+    assert (
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged" in calls
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "json_error"),
+    [({}, None), ({"total_count": "42"}, None), (None, ValueError("bad json"))],
+)
+def test_fetch_merged_pr_count_invalid_payload_is_unknown(
+    monkeypatch: pytest.MonkeyPatch, payload: object, json_error: Exception | None
+) -> None:
+    monkeypatch.setattr(
+        repo_status.requests,
+        "get",
+        lambda url, headers, timeout: DummyResp(payload, json_error=json_error),
+    )
+
+    assert repo_status.fetch_merged_pr_count("user/repo") is None
+
+
+def test_fetch_merged_pr_count_request_error_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        raise repo_status.requests.exceptions.ConnectionError("boom")
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_merged_pr_count("user/repo") is None
+
+
+def test_format_merged_pr_count_handles_unknowns() -> None:
+    assert repo_status.format_merged_pr_count(42) == "🔀 42"
+    assert repo_status.format_merged_pr_count(None) == "🔀 ?"
+
+
+def test_update_readme_replaces_stale_merged_pr_prefix_idempotently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ✅ ⭐ 6 🔀 999 🔀 123 **[repo](https://github.com/user/repo)** - desc\n"
+        "- ✅ ⭐ ? **[unknown-stars](https://github.com/user/unknown-stars)** - desc\n"
+    )
+
+    details = {
+        "user/repo": repo_status.RepoStatus("✅", stars=6, merged_prs=42),
+        "user/unknown-stars": repo_status.RepoStatus("❓", stars=None, merged_prs=5),
+    }
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: details[repo],
+    )
+    from datetime import datetime
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=now)
+
+    assert readme.read_text() == first
+    assert readme.read_text().splitlines()[2:] == [
+        "- ✅ ⭐ 6 🔀 42 **[repo](https://github.com/user/repo)** - desc",
+        "- ❓ ⭐ ? 🔀 5 **[unknown-stars](https://github.com/user/unknown-stars)** - desc",
+    ]


### PR DESCRIPTION
### Motivation
- Surface repository activity in the profile README by showing total merged pull requests next to GitHub stars so readers can quickly see recent contribution volume.
- Preserve existing behavior (status emoji, failure links, branch-specific status checks, star-based sorting, and idempotent prefix stripping) while extending the status model to carry merged PR totals.

### Description
- Extend metadata and status shapes by adding `merged_prs: int | None` to `RepoMetadata` and `RepoStatus` and keep public APIs like `fetch_repo_status(...)` unchanged.
- Implement `fetch_merged_pr_count(repo, token)` that queries the GitHub REST search API (`/search/issues?q=repo:{owner}/{repo}+is:pr+is:merged`) and returns `total_count` or `None` on errors or unexpected payloads, reusing the repository auth header helper.
- Update rendering and parsing so each Related Projects bullet writes a compact `⭐ <stars> 🔀 <merged-prs>` marker (with `🔀 ?` for unknown), and extend prefix stripping to remove stale or duplicated merged-PR markers idempotently.
- Update README legend and tests: add `format_merged_pr_count`, wire merged counts through `fetch_repo_metadata` → `fetch_repo_status_details` → `render_project_item`, and add/adjust tests covering success, invalid/error payloads, formatting, idempotent replacement, rendering, and sorting behavior.

### Testing
- Ran formatter and linters: `python -m black --target-version py311 src/repo_status.py tests/test_repo_status.py` and `python -m ruff check src/repo_status.py tests/test_repo_status.py`, which completed successfully.
- Ran the focused tests: `python -m pytest tests/test_repo_status.py -q`, which passed (new tests for merged-PR count included).
- Ran the full test suite: `python -m pytest -q`, which initially reported import errors due to missing optional deps, then after `python -m pip install -e '.[dev]'` the full suite passed (all tests green); final test runs reported success.
- Verified idempotency and no secret leaks with `git diff --cached | ./scripts/scan-secrets.py` which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ba570c324832fbb9f4956169e92e2)