### PR TITLE
Show merged PR counts in Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ Repo internals: automation, scripts, metadata, subtitles, and MCP service detail
 - **Open learning systems** that document the path from rough idea to reusable project.
 
 ## Related Projects
-_Last updated: 2026-06-12 05:31 UTC; checks hourly_
+_Last updated: 2026-06-12 06:30 UTC; checks hourly_
 
 Selected projects across this GitHub account, grouped as a compact portfolio map rather than a dependency list. Each entry links to its GitHub repo so the hourly status updater can keep the health marker current; failure links, when present, point directly to the run or artifact worth inspecting.
 
-Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows GitHub stars. Projects sort by stars descending, then alphabetically for ties; unknown star counts sort last.
+Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows GitHub stars; 🔀 shows total merged pull requests. Projects sort by stars descending, then alphabetically for ties; unknown star counts sort last.
 
-- ✅ ⭐ 6 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ✅ ⭐ 3 **[DSPACE](https://democratized.space)** @main – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/main))
-- ✅ ⭐ 2 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
-- ✅ ⭐ 1 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
-- ✅ ⭐ 1 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
-- ✅ ⭐ 0 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
-- ✅ ⭐ 0 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
-- ✅ ⭐ 0 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
-- ❌ ([Build Docker Image](https://github.com/futuroptimist/gabriel/actions/runs/27260062738), [Deploy MkDocs Site](https://github.com/futuroptimist/gabriel/actions/runs/27260062675)) <!-- repo-status:failure-links --> ⭐ 0 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
-- ✅ ⭐ 0 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
-- ✅ ⭐ 0 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
-- ✅ ⭐ 0 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
-- ✅ ⭐ 0 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
-- ✅ ⭐ 0 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
+- ✅ ⭐ 6 🔀 656 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
+- ✅ ⭐ 3 🔀 2357 **[DSPACE](https://democratized.space)** @main – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/main))
+- ✅ ⭐ 2 🔀 480 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
+- ✅ ⭐ 1 🔀 125 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
+- ✅ ⭐ 1 🔀 162 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure
+- ✅ ⭐ 0 🔀 201 **[axel](https://github.com/futuroptimist/axel)** – LLM-powered quest tracker that analyzes repositories and suggests next steps for side-project momentum
+- ✅ ⭐ 0 🔀 440 **[danielsmith.io](https://github.com/futuroptimist/danielsmith.io)** – Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene
+- ✅ ⭐ 0 🔀 334 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
+- ❌ ([Build Docker Image](https://github.com/futuroptimist/gabriel/actions/runs/27260062738), [Deploy MkDocs Site](https://github.com/futuroptimist/gabriel/actions/runs/27260062675)) <!-- repo-status:failure-links --> ⭐ 0 🔀 167 **[gabriel](https://github.com/futuroptimist/gabriel)** – privacy-first “guardian angel” LLM concept for local, actionable security coaching
+- ✅ ⭐ 0 🔀 187 **[gitshelves](https://github.com/futuroptimist/gitshelves)** – 3D-printable Gridfinity blocks generated from GitHub contribution patterns
+- ✅ ⭐ 0 🔀 754 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
+- ✅ ⭐ 0 🔀 48 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
+- ✅ ⭐ 0 🔀 1432 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
+- ✅ ⭐ 0 🔀 274 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
 
 
 ## Values

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -12,7 +12,7 @@ import logging
 import os
 import re
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from itertools import count
 from pathlib import Path
@@ -390,7 +390,8 @@ def fetch_merged_pr_count(repo: str, token: str | None = None) -> int | None:
 
     try:
         resp = requests.get(
-            "https://api.github.com/search/issues?" f"q=repo:{repo}+is:pr+is:merged",
+            "https://api.github.com/search/issues?"
+            f"q=repo:{repo}+is:pr+is:merged&per_page=1",
             headers=_github_headers(token),
             timeout=10,
         )
@@ -402,6 +403,10 @@ def fetch_merged_pr_count(repo: str, token: str | None = None) -> int | None:
 
     if not isinstance(data, dict):
         LOGGER.warning("Unexpected merged PR payload for %s: %r", repo, type(data))
+        return None
+
+    if data.get("incomplete_results") is True:
+        LOGGER.warning("Incomplete merged PR search results for %s", repo)
         return None
 
     total_count = data.get("total_count")
@@ -916,7 +921,42 @@ class RelatedProjectItem:
     branch: str | None
     name: str
     start_index: int = 0
+    existing_merged_prs: int | None = None
     status: RepoStatus | None = None
+
+
+def _parse_count_marker_value(value: str) -> int | None:
+    """Parse a generated compact count marker value, preserving unknowns."""
+
+    if value == "?":
+        return None
+    try:
+        return int(value.replace(",", ""))
+    except ValueError:  # pragma: no cover - guarded by marker regexes
+        return None
+
+
+def existing_merged_pr_count(line: str) -> int | None:
+    """Return the generated merged-PR prefix count already present on a bullet."""
+
+    content = line[2:].lstrip() if line.startswith("- ") else line.lstrip()
+    while True:
+        original = content
+        content = re.sub(r"^[✅❌❓]\s*", "", content, count=1).lstrip()
+        content = GENERATED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
+        content = GENERATED_LEADING_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
+        content = LEGACY_STACKED_FAILURE_LINKS_RE.sub("", content, count=1).lstrip()
+        content = _strip_legacy_failure_links_before_markdown_repo(content)
+        content = _strip_keyworded_legacy_failure_links_before_raw_repo(content)
+        content = STAR_PREFIX_RE.sub("", content, count=1).lstrip()
+        marker = MERGED_PR_PREFIX_RE.match(content)
+        if marker:
+            value_match = re.search(r"(?:\?|[\d,]+)", marker.group(0))
+            if value_match:
+                return _parse_count_marker_value(value_match.group(0))
+            return None
+        if content == original:
+            return None
 
 
 def strip_project_prefix(line: str) -> str:
@@ -1036,6 +1076,7 @@ def parse_related_project_items(lines: list[str]) -> list[RelatedProjectItem]:
             index += 1
         while block and block[-1] == "":
             block.pop()
+        existing_merged_prs = existing_merged_pr_count(line)
         cleaned = strip_project_prefix(line)
         searchable_block = "\n".join([cleaned, *block[1:]])
         selected_repo = select_project_repo_url(searchable_block)
@@ -1050,6 +1091,7 @@ def parse_related_project_items(lines: list[str]) -> list[RelatedProjectItem]:
                 branch,
                 _project_name(cleaned, repo),
                 start_index=start_index,
+                existing_merged_prs=existing_merged_prs,
             )
         )
     return items
@@ -1078,15 +1120,9 @@ def _update_related_section(lines: list[str], token: str | None) -> list[str]:
     project_items = parse_related_project_items(lines)
     for item in project_items:
         status = fetch_repo_status_details(item.repo, token, item.branch)
-        items_by_start[item.start_index] = RelatedProjectItem(
-            item.lines,
-            item.cleaned_first_line,
-            item.repo,
-            item.branch,
-            item.name,
-            item.start_index,
-            status,
-        )
+        if status.merged_prs is None and item.existing_merged_prs is not None:
+            status = replace(status, merged_prs=item.existing_merged_prs)
+        items_by_start[item.start_index] = replace(item, status=status)
 
     sorted_items = sorted(items_by_start.values(), key=_sort_key)
     sorted_iter = iter(sorted_items)

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -36,6 +36,7 @@ class RepoMetadata:
 
     default_branch: str | None = None
     stars: int | None = None
+    merged_prs: int | None = None
 
 
 @dataclass(frozen=True)
@@ -45,6 +46,7 @@ class RepoStatus:
     emoji: str
     failure_links: tuple[StatusLink, ...] = field(default_factory=tuple)
     stars: int | None = None
+    merged_prs: int | None = None
 
 
 @dataclass(frozen=True)
@@ -374,12 +376,46 @@ def _latest_completed_runs_by_workflow(runs: Iterable[dict]) -> list[dict]:
     )
 
 
-def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
-    """Fetch default branch and star count for ``repo`` without raising."""
+def _github_headers(token: str | None = None) -> dict[str, str]:
+    """Return GitHub REST headers with optional bearer-token auth."""
 
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_merged_pr_count(repo: str, token: str | None = None) -> int | None:
+    """Fetch the total merged pull request count for ``repo`` without raising."""
+
+    try:
+        resp = requests.get(
+            "https://api.github.com/search/issues?" f"q=repo:{repo}+is:pr+is:merged",
+            headers=_github_headers(token),
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except (requests.exceptions.RequestException, ValueError) as exc:
+        LOGGER.warning("Unable to fetch merged PR count for %s: %s", repo, exc)
+        return None
+
+    if not isinstance(data, dict):
+        LOGGER.warning("Unexpected merged PR payload for %s: %r", repo, type(data))
+        return None
+
+    total_count = data.get("total_count")
+    if type(total_count) is not int:
+        LOGGER.warning("Unexpected merged PR total_count for %s: %r", repo, total_count)
+        return None
+    return total_count
+
+
+def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
+    """Fetch default branch, star count, and merged PR count without raising."""
+
+    headers = _github_headers(token)
+    merged_prs = fetch_merged_pr_count(repo, token)
 
     try:
         repo_resp = requests.get(
@@ -389,13 +425,13 @@ def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
         repo_data = repo_resp.json()
     except (requests.exceptions.RequestException, ValueError) as exc:
         LOGGER.warning("Unable to fetch repository metadata for %s: %s", repo, exc)
-        return RepoMetadata()
+        return RepoMetadata(merged_prs=merged_prs)
 
     if not isinstance(repo_data, dict):
         LOGGER.warning(
             "Unexpected repository payload for %s: %r", repo, type(repo_data)
         )
-        return RepoMetadata()
+        return RepoMetadata(merged_prs=merged_prs)
 
     default_branch = repo_data.get("default_branch")
     if not isinstance(default_branch, str) or not default_branch:
@@ -403,7 +439,9 @@ def fetch_repo_metadata(repo: str, token: str | None = None) -> RepoMetadata:
 
     stars_value = repo_data.get("stargazers_count")
     stars = stars_value if type(stars_value) is int else None
-    return RepoMetadata(default_branch=default_branch, stars=stars)
+    return RepoMetadata(
+        default_branch=default_branch, stars=stars, merged_prs=merged_prs
+    )
 
 
 def fetch_repo_status_details(
@@ -420,15 +458,17 @@ def fetch_repo_status_details(
     ``RuntimeError`` so the calling workflow fails loudly.
     """
 
-    headers = {"Accept": "application/vnd.github+json"}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    headers = _github_headers(token)
 
     metadata = fetch_repo_metadata(repo, token)
     if branch is None:
         branch = metadata.default_branch
         if branch is None:
-            return RepoStatus(status_to_emoji(None), stars=metadata.stars)
+            return RepoStatus(
+                status_to_emoji(None),
+                stars=metadata.stars,
+                merged_prs=metadata.merged_prs,
+            )
 
     all_runs_url = f"https://api.github.com/repos/{repo}/actions/runs?per_page=100&status=completed"
     url = all_runs_url
@@ -772,7 +812,10 @@ def fetch_repo_status_details(
             if link not in failure_links:
                 failure_links.append(link)
     return RepoStatus(
-        status_to_emoji(conclusions[0]), tuple(failure_links), metadata.stars
+        status_to_emoji(conclusions[0]),
+        tuple(failure_links),
+        metadata.stars,
+        metadata.merged_prs,
     )
 
 
@@ -822,6 +865,12 @@ def format_star_count(stars: int | None) -> str:
     return f"⭐ {stars}" if stars is not None else "⭐ ?"
 
 
+def format_merged_pr_count(count: int | None) -> str:
+    """Format a compact merged pull request count marker."""
+
+    return f"🔀 {count}" if count is not None else "🔀 ?"
+
+
 GENERATED_ACTION_RUN_LINK_RE = (
     r"\[(?:\\.|[^\]\\])+\]"
     r"\(https://github\.com/[\w.-]+/[\w.-]+/actions/runs/[^)]*\)"
@@ -844,15 +893,16 @@ LEGACY_GENERATED_ACTION_RUN_LINK_RE = (
 )
 LEGACY_UNMARKED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
-    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:\*\*?\[[^\]]+\]\(|\[[^\]]+\]\())",
+    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:🔀\s*(?:\?|[\d,]+)\s*)?(?:\*\*?\[[^\]]+\]\(|\[[^\]]+\]\())",
     re.IGNORECASE,
 )
 LEGACY_KEYWORDED_FAILURE_LINKS_BEFORE_REPO_RE = re.compile(
     rf"^\((?:{LEGACY_GENERATED_ACTION_RUN_LINK_RE}(?:,\s*)?)+\)\s*"
-    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?)",
+    r"(?=(?:⭐\s*(?:\?|[\d,]+)\s*)?(?:🔀\s*(?:\?|[\d,]+)\s*)?https://github\.com/[\w.-]+/[\w.-]+(?:/tree/[\w./-]+)?)",
     re.IGNORECASE,
 )
 STAR_PREFIX_RE = re.compile(r"^⭐\s*(?:\?|[\d,]+)\s*")
+MERGED_PR_PREFIX_RE = re.compile(r"^🔀\s*(?:\?|[\d,]+)\s*")
 LEGACY_FAILING_RUNS_RE = re.compile(r"\s+\(failing runs: [^)]*\)$")
 
 
@@ -882,6 +932,7 @@ def strip_project_prefix(line: str) -> str:
         content = _strip_legacy_failure_links_before_markdown_repo(content)
         content = _strip_keyworded_legacy_failure_links_before_raw_repo(content)
         content = STAR_PREFIX_RE.sub("", content, count=1).lstrip()
+        content = MERGED_PR_PREFIX_RE.sub("", content, count=1).lstrip()
         if content == original:
             return LEGACY_FAILING_RUNS_RE.sub("", content)
 
@@ -1010,7 +1061,8 @@ def render_project_item(item: RelatedProjectItem, details: RepoStatus) -> list[s
     link_suffix = _format_failure_links(details.failure_links)
     first = (
         f"- {details.emoji}{link_suffix} "
-        f"{format_star_count(details.stars)} {item.cleaned_first_line}"
+        f"{format_star_count(details.stars)} "
+        f"{format_merged_pr_count(details.merged_prs)} {item.cleaned_first_line}"
     )
     return [first, *item.lines[1:]]
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -234,10 +234,19 @@ def _mock_repo_status_requests(
     commits: list[dict] | None = None,
     branch: str = "main",
     stars: int | None = None,
+    merged_prs: int | None = None,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            data: dict = {}
+            if merged_prs is not None:
+                data["total_count"] = merged_prs
+            return DummyResp(data)
         if url == "https://api.github.com/repos/user/repo":
-            data: dict = {"default_branch": branch}
+            data = {"default_branch": branch}
             if stars is not None:
                 data["stargazers_count"] = stars
             return DummyResp(data)
@@ -266,6 +275,11 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -299,6 +313,7 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", token="abc") == "✅"
     assert calls == [
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
@@ -314,6 +329,11 @@ def test_fetch_repo_status_no_runs_returns_unknown(
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -341,6 +361,7 @@ def test_fetch_repo_status_no_runs_returns_unknown(
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "❓"
     assert calls == [
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
@@ -354,6 +375,11 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main", "stargazers_count": 42})
         if url.startswith(
@@ -387,6 +413,7 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
@@ -407,6 +434,11 @@ def test_fetch_repo_status_invalid_commit_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -426,6 +458,11 @@ def test_fetch_repo_status_nondeterministic(monkeypatch: pytest.MonkeyPatch) -> 
     def fake_get(url: str, headers: dict, timeout: int):
         nonlocal run_calls
         calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -480,6 +517,11 @@ def test_fetch_repo_status_ignores_non_ci_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -524,6 +566,11 @@ def test_fetch_repo_status_prefers_latest_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -978,6 +1025,11 @@ def test_fetch_repo_status_paginates_release_runs_beyond_page_ten(
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -1857,6 +1909,11 @@ def test_fetch_repo_status_skips_bot_commit(monkeypatch: pytest.MonkeyPatch) -> 
 
     def fake_get(url: str, headers: dict, timeout: int):
         calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -1907,6 +1964,11 @@ def test_fetch_repo_status_skips_bot_commit(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_fetch_repo_status_skip_ci_message(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -1980,7 +2042,7 @@ def test_update_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ ⭐ 2 https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ 2 🔀 ? https://github.com/user/repo"
 
 
 def test_update_readme_uses_current_time(
@@ -2014,7 +2076,7 @@ def test_update_readme_uses_current_time(
     repo_status.update_readme(readme)
     lines = readme.read_text().splitlines()
     assert lines[1] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[2] == "- ✅ ⭐ ? https://github.com/user/repo"
+    assert lines[2] == "- ✅ ⭐ ? 🔀 ? https://github.com/user/repo"
 
 
 def test_update_readme_existing_timestamp(
@@ -2049,13 +2111,18 @@ def test_update_readme_existing_timestamp(
 
     lines = readme.read_text().splitlines()
     assert lines[3] == "_Last updated: 2020-01-02 03:04 UTC; checks hourly_"
-    assert lines[4] == "- ✅ ⭐ ? https://github.com/user/repo"
+    assert lines[4] == "- ✅ ⭐ ? 🔀 ? https://github.com/user/repo"
 
 
 def test_fetch_repo_status_details_includes_failed_run_link(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2104,6 +2171,11 @@ def test_fetch_repo_status_details_orders_multiple_failure_links(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2163,6 +2235,11 @@ def test_fetch_repo_status_details_falls_back_to_actions_run_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2211,6 +2288,11 @@ def test_fetch_repo_status_details_omits_unlinkable_failed_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2249,6 +2331,11 @@ def test_fetch_repo_status_details_links_only_failed_workflows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2303,6 +2390,11 @@ def test_fetch_repo_status_details_success_and_unknown_have_no_links(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2354,6 +2446,11 @@ def test_fetch_repo_status_details_prefers_latest_attempt_without_stale_link(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2414,7 +2511,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         "## Related Projects\n"
         "_Last updated: 1999-01-01 00:00 UTC; checks hourly_\n"
         "_Last updated: 1998-01-01 00:00 UTC; checks hourly_\n"
-        "- ✅ ⭐ ? https://github.com/user/repo (failing runs: https://old.example/run)\n"
+        "- ✅ ⭐ ? 🔀 ? https://github.com/user/repo (failing runs: https://old.example/run)\n"
     )
     readme = tmp_path / "README.md"
     readme.write_text(content)
@@ -2446,7 +2543,7 @@ def test_update_readme_includes_failure_links_and_removes_duplicates(
         (
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
-            "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
+            "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo"
         ),
     ]
 
@@ -2495,7 +2592,7 @@ def test_update_readme_strips_linked_failure_prefixes_idempotently(
             "- ❌ ([tests](https://github.com/user/repo/actions/runs/1), "
             "[lint](https://github.com/user/repo/actions/runs/2)) "
             "<!-- repo-status:failure-links --> "
-            "⭐ ? **[repo](https://github.com/user/repo)** - description"
+            "⭐ ? 🔀 ? **[repo](https://github.com/user/repo)** - description"
         ),
     ]
 
@@ -2529,7 +2626,7 @@ def test_update_readme_uses_status_details_not_compatibility_report(
 
     assert (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo"
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo"
     ) in readme.read_text().splitlines()
 
 
@@ -2537,6 +2634,11 @@ def test_fetch_repo_status_report_returns_url_strings_for_compatibility(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2585,6 +2687,11 @@ def test_fetch_repo_status_details_collapses_renamed_latest_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2642,6 +2749,11 @@ def test_fetch_repo_status_details_disambiguates_same_name_and_run_number(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main"})
         if url.startswith(
@@ -2710,7 +2822,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -2737,7 +2849,7 @@ def test_update_readme_strips_escaped_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([bad\\]name](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo",
     ]
 
 
@@ -2748,7 +2860,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
     readme.write_text(
         "## Related Projects\n"
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/0)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo\n"
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo\n"
     )
 
     monkeypatch.setattr(
@@ -2775,7 +2887,7 @@ def test_update_readme_strips_bracketed_failure_label_idempotently(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([CI [lint\\]](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo",
     ]
 
 
@@ -2813,7 +2925,7 @@ def test_update_readme_migrates_legacy_unmarked_failure_links_before_raw_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? https://github.com/user/repo",
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? https://github.com/user/repo",
     ]
 
 
@@ -2849,10 +2961,10 @@ def test_update_readme_preserves_hand_authored_leading_notes(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ 3 (archived) **[repo](https://github.com/user/repo)** - desc",
-        "- ✅ ⭐ 2 ([docs](https://example.com)) "
+        "- ✅ ⭐ 3 🔀 ? (archived) **[repo](https://github.com/user/repo)** - desc",
+        "- ✅ ⭐ 2 🔀 ? ([docs](https://example.com)) "
         "**[docs-repo](https://github.com/user/docs-repo)** - desc",
-        "- ✅ ⭐ 1 ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
+        "- ✅ ⭐ 1 🔀 ? ([debug run](https://github.com/user/debug-repo/actions/runs/123)) "
         "**[debug-repo](https://github.com/user/debug-repo)** - desc",
     ]
 
@@ -2883,7 +2995,7 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
+        "- ✅ ⭐ ? 🔀 ? ([debug run](https://github.com/user/repo/actions/runs/123)) "
         "https://github.com/user/repo - desc",
     ]
 
@@ -2905,6 +3017,11 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
     )
 
     def fake_get(url: str, headers: dict, timeout: int):
+        if url == (
+            "https://api.github.com/search/issues?"
+            "q=repo:futuroptimist/flywheel+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/futuroptimist/flywheel":
             return DummyResp({"default_branch": "main", "stargazers_count": 9})
         if url.startswith(
@@ -2950,9 +3067,10 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
 
     rendered = readme.read_text(encoding="utf-8")
     assert (
-        "- ✅ ⭐ 9 **[flywheel](https://github.com/futuroptimist/flywheel)** - automate the loop"
+        "- ✅ ⭐ 9 🔀 ? **[flywheel](https://github.com/futuroptimist/flywheel)**"
         in rendered
     )
+    assert "automate the loop" in rendered
     assert "27123196602" not in rendered
     assert "repo-status:failure-links" not in rendered
 
@@ -2971,6 +3089,7 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
         in section
     )
     assert "⭐ shows GitHub stars" in section
+    assert "🔀 shows total merged pull requests" in section
     assert "Projects sort by stars descending" in section
     assert readme.count("docs/repository-guide.md") == 1
 
@@ -2978,12 +3097,18 @@ def test_profile_readme_related_projects_copy_is_parseable() -> None:
     assert project_lines
     assert all(repo_status.GITHUB_RE.search(line) for line in project_lines)
     assert all("⭐" in line for line in project_lines)
+    assert all("🔀" in line for line in project_lines)
 
 
 def test_fetch_repo_status_details_includes_star_count(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
             return DummyResp({"default_branch": "main", "stargazers_count": 42})
         if url.startswith(
@@ -3023,6 +3148,73 @@ def test_format_star_count_handles_unknowns() -> None:
     assert repo_status.format_star_count(None) == "⭐ ?"
 
 
+def test_fetch_repo_metadata_includes_merged_pr_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append((url, headers))
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+        ):
+            return DummyResp({"total_count": 42})
+        assert url == "https://api.github.com/repos/user/repo"
+        return DummyResp({"default_branch": "main", "stargazers_count": 6})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_repo_metadata(
+        "user/repo", token="secret"
+    ) == repo_status.RepoMetadata(default_branch="main", stars=6, merged_prs=42)
+    assert calls == [
+        (
+            "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
+            {"Accept": "application/vnd.github+json", "Authorization": "Bearer secret"},
+        ),
+        (
+            "https://api.github.com/repos/user/repo",
+            {"Accept": "application/vnd.github+json", "Authorization": "Bearer secret"},
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"total_count": "42"},
+        {"total_count": True},
+        [],
+    ],
+)
+def test_fetch_merged_pr_count_invalid_payload_is_unknown(
+    monkeypatch: pytest.MonkeyPatch, payload: object
+) -> None:
+    monkeypatch.setattr(
+        repo_status.requests, "get", lambda url, headers, timeout: DummyResp(payload)
+    )
+
+    assert repo_status.fetch_merged_pr_count("user/repo") is None
+
+
+def test_fetch_merged_pr_count_request_error_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, headers: dict, timeout: int):
+        raise repo_status.requests.exceptions.RequestException("rate limited")
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_merged_pr_count("user/repo") is None
+
+
+def test_format_merged_pr_count_handles_unknowns() -> None:
+    assert repo_status.format_merged_pr_count(42) == "🔀 42"
+    assert repo_status.format_merged_pr_count(None) == "🔀 ?"
+
+
 def test_fetch_repo_metadata_invalid_star_count_is_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3037,6 +3229,45 @@ def test_fetch_repo_metadata_invalid_star_count_is_unknown(
     assert repo_status.fetch_repo_metadata("user/repo") == repo_status.RepoMetadata(
         default_branch="main", stars=None
     )
+
+
+def test_update_readme_upgrades_and_replaces_merged_pr_prefixes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ✅ ⭐ 1 **[old-star](https://github.com/user/old-star)** - needs PR marker\n"
+        "- ✅ ⭐ 2 🔀 999 **[stale](https://github.com/user/stale)** - stale count\n"
+        "- **[unknown-stars](https://github.com/user/unknown-stars)** - known PRs\n"
+        "- **[unknown-prs](https://github.com/user/unknown-prs)** - known stars\n"
+    )
+
+    details = {
+        "user/old-star": repo_status.RepoStatus("✅", stars=1, merged_prs=11),
+        "user/stale": repo_status.RepoStatus("✅", stars=2, merged_prs=22),
+        "user/unknown-stars": repo_status.RepoStatus("❓", stars=None, merged_prs=33),
+        "user/unknown-prs": repo_status.RepoStatus("✅", stars=4, merged_prs=None),
+    }
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: details[repo],
+    )
+    from datetime import datetime
+
+    now = datetime(2020, 1, 2, 3, 4, tzinfo=UTC)
+    repo_status.update_readme(readme, now=now)
+    first = readme.read_text()
+    repo_status.update_readme(readme, now=now)
+
+    assert readme.read_text() == first
+    assert readme.read_text().splitlines()[2:] == [
+        "- ✅ ⭐ 4 🔀 ? **[unknown-prs](https://github.com/user/unknown-prs)** - known stars",
+        "- ✅ ⭐ 2 🔀 22 **[stale](https://github.com/user/stale)** - stale count",
+        "- ✅ ⭐ 1 🔀 11 **[old-star](https://github.com/user/old-star)** - needs PR marker",
+        "- ❓ ⭐ ? 🔀 33 **[unknown-stars](https://github.com/user/unknown-stars)** - known PRs",
+    ]
 
 
 def test_update_readme_sorts_by_stars_then_name_and_unknowns_last(
@@ -3064,10 +3295,10 @@ def test_update_readme_sorts_by_stars_then_name_and_unknowns_last(
     repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
 
     assert readme.read_text().splitlines()[2:] == [
-        "- ✅ ⭐ 5 **[alpha](https://github.com/user/alpha)** - same stars",
-        "- ✅ ⭐ 5 **[Beta](https://github.com/user/beta)** - same stars",
-        "- ✅ ⭐ 0 **[Zero](https://github.com/user/zero)** - zero stars",
-        "- ✅ ⭐ ? **[Unknown](https://github.com/user/unknown)** - unknown stars",
+        "- ✅ ⭐ 5 🔀 ? **[alpha](https://github.com/user/alpha)** - same stars",
+        "- ✅ ⭐ 5 🔀 ? **[Beta](https://github.com/user/beta)** - same stars",
+        "- ✅ ⭐ 0 🔀 ? **[Zero](https://github.com/user/zero)** - zero stars",
+        "- ✅ ⭐ ? 🔀 ? **[Unknown](https://github.com/user/unknown)** - unknown stars",
     ]
 
 
@@ -3104,7 +3335,7 @@ def test_update_readme_star_and_failure_prefix_is_idempotent(
     assert readme.read_text() == first
     assert readme.read_text().splitlines()[2] == (
         "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ 7 "
+        "<!-- repo-status:failure-links --> ⭐ 7 🔀 ? "
         "**[repo](https://github.com/user/repo)** - desc"
     )
 
@@ -3138,10 +3369,10 @@ def test_update_readme_preserves_multiline_and_external_display_links(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "Intro stays put.",
-        "- ✅ ⭐ 10 **[token.place](https://token.place)** - external first "
+        "- ✅ ⭐ 10 🔀 ? **[token.place](https://token.place)** - external first "
         "([repo](https://github.com/futuroptimist/token.place))",
         "  continuation stays with token.place",
-        "- ✅ ⭐ 1 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub",
+        "- ✅ ⭐ 1 🔀 ? **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub",
     ]
 
 
@@ -3172,9 +3403,9 @@ def test_update_readme_uses_repo_link_from_continuation_line(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ 10 **[external](https://example.com)** - homepage first",
+        "- ✅ ⭐ 10 🔀 ? **[external](https://example.com)** - homepage first",
         "  ([repo](https://github.com/user/external/tree/main))",
-        "- ✅ ⭐ 1 **[local](https://github.com/user/local)** - repo first",
+        "- ✅ ⭐ 1 🔀 ? **[local](https://github.com/user/local)** - repo first",
     ]
 
 
@@ -3205,7 +3436,7 @@ def test_update_readme_ignores_issue_action_and_note_links_before_repo(
     assert readme.read_text().splitlines() == [
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
-        "- ✅ ⭐ 9 ([note](https://github.com/user/notes)) "
+        "- ✅ ⭐ 9 🔀 ? ([note](https://github.com/user/notes)) "
         "([issue](https://github.com/user/issue-tracker/issues/7)) "
         "([run](https://github.com/user/automation/actions/runs/99)) "
         "**[Site](https://example.com)** - external display "
@@ -3248,7 +3479,7 @@ def test_update_readme_strips_arbitrary_label_legacy_failure_link_before_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([Production](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ 4 "
+        "<!-- repo-status:failure-links --> ⭐ 4 🔀 ? "
         "**[repo](https://github.com/user/repo)** - desc",
     ]
 
@@ -3286,7 +3517,7 @@ def test_update_readme_strips_legacy_deploy_failure_link_before_repo(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "- ❌ ([Deploy](https://github.com/user/repo/actions/runs/1)) "
-        "<!-- repo-status:failure-links --> ⭐ ? "
+        "<!-- repo-status:failure-links --> ⭐ ? 🔀 ? "
         "**[repo](https://github.com/user/repo)** - desc",
     ]
 
@@ -3312,4 +3543,6 @@ def test_update_readme_branch_url_uses_branch_for_status_and_repo_for_stars(
     repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
 
     assert calls == [("democratizedspace/dspace", "main")]
-    assert "- ✅ ⭐ 12 **[DSPACE](https://democratized.space)**" in readme.read_text()
+    assert (
+        "- ✅ ⭐ 12 🔀 ? **[DSPACE](https://democratized.space)**" in readme.read_text()
+    )

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -3148,6 +3148,28 @@ def test_format_star_count_handles_unknowns() -> None:
     assert repo_status.format_star_count(None) == "⭐ ?"
 
 
+def test_fetch_merged_pr_count_success_uses_search_endpoint_and_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict, int]] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append((url, headers, timeout))
+        return DummyResp({"total_count": 12, "incomplete_results": False})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+
+    assert repo_status.fetch_merged_pr_count("user/repo", token="secret") == 12
+    assert calls == [
+        (
+            "https://api.github.com/search/issues?"
+            "q=repo:user/repo+is:pr+is:merged&per_page=1",
+            {"Accept": "application/vnd.github+json", "Authorization": "Bearer secret"},
+            10,
+        )
+    ]
+
+
 def test_fetch_repo_metadata_includes_merged_pr_count(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3289,15 +3311,19 @@ def test_update_readme_upgrades_and_replaces_merged_pr_prefixes(
     readme.write_text(
         "## Related Projects\n"
         "- ✅ ⭐ 1 **[old-star](https://github.com/user/old-star)** - needs PR marker\n"
+        "- ✅ ⭐ ? **[old-q](https://github.com/user/old-q)** - needs PR marker\n"
         "- ✅ ⭐ 2 🔀 999 **[stale](https://github.com/user/stale)** - stale count\n"
+        "- ✅ ⭐ ? 🔀 888 **[stale-q](https://github.com/user/stale-q)** - stale count\n"
+        "- ✅ ⭐ 4 🔀 ? **[unknown-prs](https://github.com/user/unknown-prs)** - known stars\n"
         "- **[unknown-stars](https://github.com/user/unknown-stars)** - known PRs\n"
-        "- **[unknown-prs](https://github.com/user/unknown-prs)** - known stars\n"
     )
 
     details = {
         "user/old-star": repo_status.RepoStatus("✅", stars=1, merged_prs=11),
+        "user/old-q": repo_status.RepoStatus("✅", stars=None, merged_prs=12),
         "user/stale": repo_status.RepoStatus("✅", stars=2, merged_prs=22),
-        "user/unknown-stars": repo_status.RepoStatus("❓", stars=None, merged_prs=33),
+        "user/stale-q": repo_status.RepoStatus("✅", stars=None, merged_prs=33),
+        "user/unknown-stars": repo_status.RepoStatus("❓", stars=None, merged_prs=44),
         "user/unknown-prs": repo_status.RepoStatus("✅", stars=4, merged_prs=None),
     }
     monkeypatch.setattr(
@@ -3313,12 +3339,58 @@ def test_update_readme_upgrades_and_replaces_merged_pr_prefixes(
     repo_status.update_readme(readme, now=now)
 
     assert readme.read_text() == first
-    assert readme.read_text().splitlines()[2:] == [
+    rendered_lines = readme.read_text().splitlines()[2:]
+    assert rendered_lines == [
         "- ✅ ⭐ 4 🔀 ? **[unknown-prs](https://github.com/user/unknown-prs)** - known stars",
         "- ✅ ⭐ 2 🔀 22 **[stale](https://github.com/user/stale)** - stale count",
         "- ✅ ⭐ 1 🔀 11 **[old-star](https://github.com/user/old-star)** - needs PR marker",
-        "- ❓ ⭐ ? 🔀 33 **[unknown-stars](https://github.com/user/unknown-stars)** - known PRs",
+        "- ✅ ⭐ ? 🔀 12 **[old-q](https://github.com/user/old-q)** - needs PR marker",
+        "- ✅ ⭐ ? 🔀 33 **[stale-q](https://github.com/user/stale-q)** - stale count",
+        "- ❓ ⭐ ? 🔀 44 **[unknown-stars](https://github.com/user/unknown-stars)** - known PRs",
     ]
+    assert all(
+        line.count("⭐") == 1 and line.count("🔀") == 1 for line in rendered_lines
+    )
+    assert "🔀 888" not in readme.read_text()
+    assert "🔀 999" not in readme.read_text()
+
+
+def test_update_readme_replaces_stale_pr_prefix_after_failure_links_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ❌ ([old tests](https://github.com/user/repo/actions/runs/0)) "
+        "<!-- repo-status:failure-links --> ⭐ 8 🔀 1 "
+        "**[repo](https://github.com/user/repo)** - desc\n"
+    )
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "❌",
+            (
+                repo_status.StatusLink(
+                    "tests", "https://github.com/user/repo/actions/runs/1"
+                ),
+            ),
+            stars=9,
+            merged_prs=2,
+        ),
+    )
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+    rendered = readme.read_text()
+
+    assert rendered.splitlines()[2] == (
+        "- ❌ ([tests](https://github.com/user/repo/actions/runs/1)) "
+        "<!-- repo-status:failure-links --> ⭐ 9 🔀 2 "
+        "**[repo](https://github.com/user/repo)** - desc"
+    )
+    assert rendered.count("<!-- repo-status:failure-links -->") == 1
+    assert "🔀 1" not in rendered
 
 
 def test_update_readme_sorts_by_stars_then_name_and_unknowns_last(
@@ -3404,12 +3476,15 @@ def test_update_readme_preserves_multiline_and_external_display_links(
         "- **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub\n"
     )
 
-    stars = {"futuroptimist/token.place": 10, "futuroptimist/futuroptimist": 1}
+    metadata = {
+        "futuroptimist/token.place": (10, 1),
+        "futuroptimist/futuroptimist": (1, 99),
+    }
     monkeypatch.setattr(
         repo_status,
         "fetch_repo_status_details",
         lambda repo, token=None, branch=None: repo_status.RepoStatus(
-            "✅", stars=stars[repo]
+            "✅", stars=metadata[repo][0], merged_prs=metadata[repo][1]
         ),
     )
     from datetime import datetime
@@ -3420,10 +3495,10 @@ def test_update_readme_preserves_multiline_and_external_display_links(
         "## Related Projects",
         "_Last updated: 2020-01-02 03:04 UTC; checks hourly_",
         "Intro stays put.",
-        "- ✅ ⭐ 10 🔀 ? **[token.place](https://token.place)** - external first "
+        "- ✅ ⭐ 10 🔀 1 **[token.place](https://token.place)** - external first "
         "([repo](https://github.com/futuroptimist/token.place))",
         "  continuation stays with token.place",
-        "- ✅ ⭐ 1 🔀 ? **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub",
+        "- ✅ ⭐ 1 🔀 99 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** - hub",
     ]
 
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1,4 +1,4 @@
-from datetime import UTC
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -239,7 +239,7 @@ def _mock_repo_status_requests(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             data: dict = {}
             if merged_prs is not None:
@@ -277,7 +277,7 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
         calls.append(url)
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -313,7 +313,7 @@ def test_fetch_repo_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", token="abc") == "✅"
     assert calls == [
-        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
@@ -331,7 +331,7 @@ def test_fetch_repo_status_no_runs_returns_unknown(
         calls.append(url)
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -361,7 +361,7 @@ def test_fetch_repo_status_no_runs_returns_unknown(
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "❓"
     assert calls == [
-        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
@@ -377,7 +377,7 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
         calls.append(url)
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -413,7 +413,7 @@ def test_fetch_repo_status_with_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo", branch="dev") == "✅"
     assert calls == [
-        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
+        "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=dev&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=dev",
@@ -436,7 +436,7 @@ def test_fetch_repo_status_invalid_commit_payload(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -460,7 +460,7 @@ def test_fetch_repo_status_nondeterministic(monkeypatch: pytest.MonkeyPatch) -> 
         calls.append(url)
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -519,7 +519,7 @@ def test_fetch_repo_status_ignores_non_ci_runs(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -568,7 +568,7 @@ def test_fetch_repo_status_prefers_latest_attempt(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -1027,7 +1027,7 @@ def test_fetch_repo_status_paginates_release_runs_beyond_page_ten(
         calls.append(url)
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -1911,7 +1911,7 @@ def test_fetch_repo_status_skips_bot_commit(monkeypatch: pytest.MonkeyPatch) -> 
         calls.append(url)
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -1966,7 +1966,7 @@ def test_fetch_repo_status_skip_ci_message(monkeypatch: pytest.MonkeyPatch) -> N
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2120,7 +2120,7 @@ def test_fetch_repo_status_details_includes_failed_run_link(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2173,7 +2173,7 @@ def test_fetch_repo_status_details_orders_multiple_failure_links(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2237,7 +2237,7 @@ def test_fetch_repo_status_details_falls_back_to_actions_run_url(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2290,7 +2290,7 @@ def test_fetch_repo_status_details_omits_unlinkable_failed_run(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2333,7 +2333,7 @@ def test_fetch_repo_status_details_links_only_failed_workflows(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2392,7 +2392,7 @@ def test_fetch_repo_status_details_success_and_unknown_have_no_links(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2448,7 +2448,7 @@ def test_fetch_repo_status_details_prefers_latest_attempt_without_stale_link(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2636,7 +2636,7 @@ def test_fetch_repo_status_report_returns_url_strings_for_compatibility(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2689,7 +2689,7 @@ def test_fetch_repo_status_details_collapses_renamed_latest_attempt(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -2751,7 +2751,7 @@ def test_fetch_repo_status_details_disambiguates_same_name_and_run_number(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -3019,7 +3019,7 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
     def fake_get(url: str, headers: dict, timeout: int):
         if url == (
             "https://api.github.com/search/issues?"
-            "q=repo:futuroptimist/flywheel+is:pr+is:merged"
+            "q=repo:futuroptimist/flywheel+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/futuroptimist/flywheel":
@@ -3106,7 +3106,7 @@ def test_fetch_repo_status_details_includes_star_count(
     def fake_get(url: str, headers: dict, timeout: int):
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({})
         if url == "https://api.github.com/repos/user/repo":
@@ -3157,7 +3157,7 @@ def test_fetch_repo_metadata_includes_merged_pr_count(
         calls.append((url, headers))
         if (
             url
-            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged"
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
         ):
             return DummyResp({"total_count": 42})
         assert url == "https://api.github.com/repos/user/repo"
@@ -3170,7 +3170,7 @@ def test_fetch_repo_metadata_includes_merged_pr_count(
     ) == repo_status.RepoMetadata(default_branch="main", stars=6, merged_prs=42)
     assert calls == [
         (
-            "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged",
+            "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1",
             {"Accept": "application/vnd.github+json", "Authorization": "Bearer secret"},
         ),
         (
@@ -3186,6 +3186,7 @@ def test_fetch_repo_metadata_includes_merged_pr_count(
         {},
         {"total_count": "42"},
         {"total_count": True},
+        {"total_count": 42, "incomplete_results": True},
         [],
     ],
 )
@@ -3228,6 +3229,56 @@ def test_fetch_repo_metadata_invalid_star_count_is_unknown(
 
     assert repo_status.fetch_repo_metadata("user/repo") == repo_status.RepoMetadata(
         default_branch="main", stars=None
+    )
+
+
+def test_update_readme_preserves_existing_merged_pr_count_when_fetch_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ✅ ⭐ 8 🔀 123 **[repo](https://github.com/user/repo)** - existing count\n"
+    )
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "✅", stars=9, merged_prs=None
+        ),
+    )
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert (
+        "- ✅ ⭐ 9 🔀 123 **[repo](https://github.com/user/repo)** - existing count"
+        in readme.read_text()
+    )
+
+
+def test_update_readme_replaces_existing_merged_pr_count_when_fetch_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Related Projects\n"
+        "- ✅ ⭐ 8 🔀 123 **[repo](https://github.com/user/repo)** - stale count\n"
+    )
+
+    monkeypatch.setattr(
+        repo_status,
+        "fetch_repo_status_details",
+        lambda repo, token=None, branch=None: repo_status.RepoStatus(
+            "✅", stars=9, merged_prs=456
+        ),
+    )
+
+    repo_status.update_readme(readme, now=datetime(2020, 1, 2, 3, 4, tzinfo=UTC))
+
+    assert (
+        "- ✅ ⭐ 9 🔀 456 **[repo](https://github.com/user/repo)** - stale count"
+        in readme.read_text()
     )
 
 


### PR DESCRIPTION
### Motivation
- Surface an additional quality signal (total merged pull requests) next to GitHub stars in the profile README Related Projects so readers see recent contribution volume at a glance.
- Preserve all existing behavior: failure-link handling, branch-specific status checks, star-based sorting, and idempotent prefix stripping while adding the new metric.

### Description
- Added `merged_prs: int | None` to `RepoMetadata` and `RepoStatus`, and introduced `fetch_merged_pr_count(repo, token)` which queries the GitHub Search API (`search/issues?q=repo:{owner}/{repo}+is:pr+is:merged`) with the same optional auth headers and robust error handling returning `None` on problems. (`src/repo_status.py`)
- Added `_github_headers()` helper and `format_merged_pr_count()` to format the compact marker `🔀 <count>` (or `🔀 ?` for unknown) and wired the new field into status construction. (`src/repo_status.py`)
- Updated rendering to emit `⭐ <stars> 🔀 <merged-prs>` immediately after the status/failure-links prefix, and extended prefix-stripping (and legacy-migration regexes) so repeated runs upgrade/replace old star-only or stale PR prefixes idempotently. (`src/repo_status.py`)
- Updated README legend and regenerated the Related Projects block so each entry now shows the merged-PR marker after stars. (`README.md`)
- Added and adapted tests covering merged-PR fetch success/error cases, formatting, README rendering and idempotency, stale-prefix upgrades, and README parseability; updated `tests/test_repo_status.py` accordingly. (`tests/test_repo_status.py`)

### Testing
- Ran unit tests for the modified module with `python -m pytest tests/test_repo_status.py -q` and observed `97 passed`.
- Ran the full test suite with `python -m pytest -q` and observed `366 passed` (2 warnings); formatting checks with `black` and `ruff` also passed.
- Ran repository checks (`git diff --check` and `./scripts/scan-secrets.py` on the staged diff) with no issues reported.
- Note: running `python src/repo_status.py` against live GitHub can hit the existing non-determinism guard when remote workflows return inconsistent conclusions across attempts; the code preserves that guard and will raise `RuntimeError` in that rare case (the README updater run in CI/workflow should keep `attempts` behavior to avoid silent mismatches).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ba57dcb9c832f9f23b8def1ea4f8c)