### PR TITLE
Add canonical video script schema, formatter, Prompter exporter, and Sugarkube production plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ footage/
 footage_index.json
 assets_index.json
 video_scripts/20240101_dummy/
+video_scripts/**/prompter.txt
 
 # Adobe Premiere Pro project files and caches
 *.prproj

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
         entry: python scripts/validate_outages.py
         language: system
         pass_filenames: false
+      - id: video-script-format
+        name: validate canonical video scripts
+        entry: python src/video_script_format.py --check video_scripts
+        language: system
+        pass_filenames: false
       - id: ruff
         name: ruff
         entry: python -m ruff check --fix .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,12 +58,12 @@ instead of collecting them at the end.
 - Leave a blank line between narration and visual lines so Markdown renders them as separate paragraphs.
 - When importing transcripts from `.srt` files, strip prefix markers like `- [Narrator]` and split sentences into individual `[NARRATOR]` lines for clarity.
 - Break long transcript sentences at punctuation boundaries so each `[NARRATOR]` line contains a single, complete thought.
-- Start each script with a level-one heading containing the video title,
-  followed by a blockquote referencing the YouTube ID and a `## Script` section header.
+- Treat `script.md` as canonical and follow `video_scripts/README.md`: one H1, one canonical draft/transcript video-ID blockquote, optional `## Outline`, then `## Script`; separate every one-line section, narrator, and visual block with one blank line. Run `make check_scripts` before committing.
+- Treat `prompter.txt` as ignored generated output. The exporter turns blank-line-separated narration runs into chapters, groups Sugarkube narration by visual beat, and rejects unresolved spoken placeholders unless rehearsal mode is explicit.
 - Each script folder must include a `metadata.json` file conforming to `schemas/video_metadata.schema.json`. Optional fields like `slug`, `thumbnail`, `transcript_file`, and `summary` enrich automation but aren't required.
 - Each script folder may include an `assets.json` file conforming to `schemas/assets_manifest.schema.json` that lists associated `footage/` directories, optional label files, tags, and capture date.
 - Each script folder may include a `sources.txt` file with one URL per line. Any downloaded articles or clips are for reference only—check usage rights and cite sources in **APA style** rather than redistributing content.
-- Each script folder may also contain a `footage.md` checklist to track B-roll or CGI shots to gather. Note existing archive vs new footage, and flag generative AI segments so they don't look like "AI slop".
+- Each script folder may also contain a canonical `footage.md` production index linked to detailed `production/` plans. Raw media remains in the ignored top-level `footage/` tree; record licensing and clearly identify any generative-media policy for the production.
 - Large photos or video files belong in a local `footage/` folder (ignored by git).
   Run `python src/index_local_media.py` whenever assets change to rebuild
   `footage_index.json` for quick lookup during editing. Use `--exclude PATH`
@@ -149,4 +149,3 @@ Tests under `tests/` cover folder naming (`test_folder_names.py`), schema valida
 
 ---
 *For creative context, tone, and thematic constraints refer to [`llms.txt`](llms.txt).* 
-

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ format_scripts:
 	$(PY) src/video_script_format.py --write video_scripts
 
 prompter:
-	@if [ -z "$(SLUG)" ]; then echo "Usage: make prompter SLUG=YYYYMMDD_slug [OUTPUT=path] [ALLOW_PLACEHOLDERS=1]"; exit 1; fi
+	$(if $(strip $(SLUG)),,$(error Usage: make prompter SLUG=YYYYMMDD_slug [OUTPUT=path] [ALLOW_PLACEHOLDERS=1]))
 	$(PY) video_scripts/export_prompter.py --slug $(SLUG) $(if $(OUTPUT),--output $(OUTPUT),) $(if $(filter 1,$(ALLOW_PLACEHOLDERS)),--allow-placeholders,)
 
 # Convert images and videos in one command. Optionally limit to a slug:

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ PIP := uv pip
 
 # NOTE: Keep recipe indentation as tabs; GNU Make treats spaces as errors.
 .PHONY: help setup test subtitles clean fmt index_footage index_assets describe_images \
-        convert_assets verify_assets convert_missing convert_all report_funnel newsletter \
-        process update_metadata scripts_from_subtitles assets_manifest render upload_video \
-        format lint typecheck serve serve-http
+	convert_assets verify_assets convert_missing convert_all report_funnel newsletter \
+	process update_metadata scripts_from_subtitles assets_manifest render upload_video \
+	format lint typecheck serve serve-http check_scripts format_scripts prompter
 
 help:
 	@echo "Targets:"
@@ -32,12 +32,15 @@ help:
 	@echo "  verify_assets  Verify converted/ matches originals/ dimensions/aspect"
 	@echo "  convert_missing Convert only missing items from verify_report.json"
 	@echo "  scripts_from_subtitles Generate script.md files from subtitles"
-        @echo "  convert_all    Convert images+videos for all footage (or SLUG=...)"
-        @echo "  report_funnel  Write selections.json for a slug (use SLUG=...)"
-        @echo "  assets_manifest Generate assets.json from footage (SLUG=... OVERWRITE=1)"
-        @echo "  newsletter    Generate newsletter markdown (SINCE=YYYY-MM-DD STATUS=live OUTPUT=path)"
+	@echo "  convert_all    Convert images+videos for all footage (or SLUG=...)"
+	@echo "  report_funnel  Write selections.json for a slug (use SLUG=...)"
+	@echo "  assets_manifest Generate assets.json from footage (SLUG=... OVERWRITE=1)"
+	@echo "  newsletter    Generate newsletter markdown (SINCE=YYYY-MM-DD STATUS=live OUTPUT=path)"
 	@echo "  update_metadata  Refresh metadata via YouTube API (SLUG=...)"
 	@echo "  process       One-command: convert+verify+report (requires SLUG=...)"
+	@echo "  check_scripts Validate canonical video script formatting"
+	@echo "  format_scripts Canonically format every video script"
+	@echo "  prompter      Export narration (requires SLUG=...)"
 
 setup:
 	python -m venv $(VENV)
@@ -50,16 +53,16 @@ subtitles:
 	$(PY) src/fetch_subtitles.py
 
 fmt:
-        $(PY) -m black .
-        $(PY) -m ruff check --fix .
+	$(PY) -m black .
+	$(PY) -m ruff check --fix .
 
 format: fmt
 
 lint:
-        $(PY) -m ruff check tools/youtube_mcp tests
+	$(PY) -m ruff check tools/youtube_mcp tests
 
 typecheck:
-        $(PY) -m mypy tools/youtube_mcp
+	$(PY) -m mypy tools/youtube_mcp
 
 clean:
 	@$(REMOVE) $(VENV) 2>/dev/null || true
@@ -86,6 +89,16 @@ convert_missing:
 scripts_from_subtitles:
 	$(PY) src/generate_scripts_from_subtitles.py
 
+check_scripts:
+	$(PY) src/video_script_format.py --check video_scripts
+
+format_scripts:
+	$(PY) src/video_script_format.py --write video_scripts
+
+prompter:
+	@if [ -z "$(SLUG)" ]; then echo "Usage: make prompter SLUG=YYYYMMDD_slug [OUTPUT=path] [ALLOW_PLACEHOLDERS=1]"; exit 1; fi
+	$(PY) video_scripts/export_prompter.py --slug $(SLUG) $(if $(OUTPUT),--output $(OUTPUT),) $(if $(filter 1,$(ALLOW_PLACEHOLDERS)),--allow-placeholders,)
+
 # Convert images and videos in one command. Optionally limit to a slug:
 #   make convert_all SLUG=20251001_indoor-aquariums-tour
 CONVERT_SLUG:=$(if $(SLUG),--slug $(SLUG),)
@@ -100,16 +113,16 @@ report_funnel:
 	$(PY) src/report_funnel.py --slug $(SLUG) $(if $(SELECTS),--selects-file $(SELECTS),)
 
 assets_manifest:
-        $(PY) src/generate_assets_manifest.py \
-                $(if $(SLUG),--slug $(SLUG),) \
-                $(if $(FOOTAGE),--footage-root $(FOOTAGE),) \
-                $(if $(OVERWRITE),--overwrite,) \
-                $(if $(DRY_RUN),--dry-run,)
+	$(PY) src/generate_assets_manifest.py \
+	        $(if $(SLUG),--slug $(SLUG),) \
+	        $(if $(FOOTAGE),--footage-root $(FOOTAGE),) \
+	        $(if $(OVERWRITE),--overwrite,) \
+	        $(if $(DRY_RUN),--dry-run,)
 
 newsletter:
-        $(PY) src/newsletter_builder.py \
-                $(if $(OUTPUT),--output $(OUTPUT),) \
-                $(if $(SINCE),--since $(SINCE),) \
+	$(PY) src/newsletter_builder.py \
+	        $(if $(OUTPUT),--output $(OUTPUT),) \
+	        $(if $(SINCE),--since $(SINCE),) \
 		$(if $(STATUS),--status $(STATUS),) \
 		$(if $(LIMIT),--limit $(LIMIT),) \
 		$(if $(DATE),--date $(DATE),)
@@ -123,23 +136,23 @@ process:
 	$(PY) src/report_funnel.py --slug $(SLUG) $(if $(SELECTS),--selects-file $(SELECTS),)
 
 render:
-        @if [ -z "$(VIDEO)" ]; then echo "Usage: make render VIDEO=YYYYMMDD_slug [CAPTIONS=path]"; exit 1; fi
-        $(PY) src/render_video.py \
-                --slug $(VIDEO) \
-                $(if $(FOOTAGE),--footage-root $(FOOTAGE),) \
-                $(if $(OUTPUT),--output-dir $(OUTPUT),) \
-                $(if $(CAPTIONS),--captions $(CAPTIONS),)
+	@if [ -z "$(VIDEO)" ]; then echo "Usage: make render VIDEO=YYYYMMDD_slug [CAPTIONS=path]"; exit 1; fi
+	$(PY) src/render_video.py \
+	        --slug $(VIDEO) \
+	        $(if $(FOOTAGE),--footage-root $(FOOTAGE),) \
+	        $(if $(OUTPUT),--output-dir $(OUTPUT),) \
+	        $(if $(CAPTIONS),--captions $(CAPTIONS),)
 
 upload_video:
-        @if [ -z "$(SLUG)" ]; then echo "Usage: make upload_video SLUG=YYYYMMDD_slug [VIDEO=path] [CLIENT=client.json] [TOKEN=token.json]"; exit 1; fi
-        $(PY) src/upload_to_youtube.py \
-                --slug $(SLUG) \
-                $(if $(VIDEO),--video $(VIDEO),) \
-                $(if $(CLIENT),--client-secrets $(CLIENT),) \
-                $(if $(TOKEN),--credentials $(TOKEN),)
+	@if [ -z "$(SLUG)" ]; then echo "Usage: make upload_video SLUG=YYYYMMDD_slug [VIDEO=path] [CLIENT=client.json] [TOKEN=token.json]"; exit 1; fi
+	$(PY) src/upload_to_youtube.py \
+	        --slug $(SLUG) \
+	        $(if $(VIDEO),--video $(VIDEO),) \
+	        $(if $(CLIENT),--client-secrets $(CLIENT),) \
+	        $(if $(TOKEN),--credentials $(TOKEN),)
 
 serve:
-        $(PY) tools/youtube_mcp/mcp_server.py
+	$(PY) tools/youtube_mcp/mcp_server.py
 
 serve-http:
-        $(PY) -m tools.youtube_mcp $(if $(HOST),--host $(HOST),) $(if $(PORT),--port $(PORT),)
+	$(PY) -m tools.youtube_mcp $(if $(HOST),--host $(HOST),) $(if $(PORT),--port $(PORT),)

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -90,6 +90,8 @@ Video folders under `video_scripts/` use `metadata.json` plus Markdown script fi
 - Optional `sources.txt` files list one URL per line for reference collection; downloaded materials are for citation/reference only.
 - Optional `footage.md` files track archive clips, new footage, CGI, and generative AI shots.
 
+`script.md` is canonical and `prompter.txt` is ignored generated output. Validate with `make check_scripts`, migrate structure with `make format_scripts`, and export with `make prompter SLUG=...` (optionally `OUTPUT=... ALLOW_PLACEHOLDERS=1`). Blank lines delimit Prompter chapters: visual scripts group narration by the following visual beat, while transcript-only scripts use one narration segment per chapter. Sugarkube production planning uses `footage.md` plus linked `production/` files; raw media remains in the ignored top-level `footage/` tree.
+
 Subtitle and transcript helpers:
 
 - `make subtitles` / `python src/fetch_subtitles.py` downloads captions into `subtitles/`.

--- a/llms.txt
+++ b/llms.txt
@@ -46,12 +46,12 @@ Script format:
 - `prepare_youtube_upload.py` builds a YouTube-ready payload by resolving local thumbnails and
   mapping Futuroptimist metadata onto upload snippets (see
   `tests/test_prepare_youtube_upload.py`).
-- `[NARRATOR]:` spoken lines.
-- `[VISUAL]:` cues right after the dialogue they support.
-- Leave a blank line between narration and visuals.
+- `script.md` is canonical: use one H1, one canonical draft/transcript video-ID blockquote, optional `## Outline`, then `## Script`.
+- `[NARRATOR]:` spoken lines and `[VISUAL]:` cues are one physical line each; place cues after supporting dialogue and separate every script-body block with one blank line. Run `make check_scripts` before committing.
+- `prompter.txt` is ignored generated output. Its blank-line-separated chapters group Sugarkube narration by visual beat; unresolved spoken placeholders are rejected except for explicit rehearsal exports.
 - Each script folder includes a `metadata.json` validated against `schemas/video_metadata.schema.json`.
 - Each script folder may also contain a `sources.txt` file with one URL per line. Downloaded articles or clips are for citation/reference only—check usage rights and cite in **APA style** rather than redistributing.
-- Each script folder may also have a `footage.md` file listing required shots (archive vs new, CGI or generative). Mark generative items to avoid obvious "AI slop".
+- Each script folder may have a canonical `footage.md` production index linked to detailed `production/` plans. Raw media stays in ignored top-level `footage/`; record licensing and clearly identify the production's generative-media policy.
 - Run `python src/index_local_media.py` to rebuild `footage_index.json`, which lists
   file paths, UTC modification times, file sizes, **and a `kind`
   classification (`image`, `video`, `audio`, or `other`)** for assets stored

--- a/schemas/video_script.schema.json
+++ b/schemas/video_script.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "VideoScript",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "title", "kind", "video_id", "segments"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "title": {"type": "string", "minLength": 1},
+    "kind": {"enum": ["draft", "transcript"]},
+    "video_id": {"type": "string", "minLength": 1},
+    "outline": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "segments": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "type": "object", "additionalProperties": false,
+            "required": ["type", "text"],
+            "properties": {"type": {"const": "section"}, "text": {"type": "string", "minLength": 1}}
+          },
+          {
+            "type": "object", "additionalProperties": false,
+            "required": ["type", "text"],
+            "properties": {
+              "type": {"const": "narrator"}, "text": {"type": "string", "minLength": 1},
+              "timing": {
+                "type": "object", "additionalProperties": false,
+                "required": ["start", "end"],
+                "properties": {"start": {"type": "string", "minLength": 1}, "end": {"type": "string", "minLength": 1}}
+              }
+            }
+          },
+          {
+            "type": "object", "additionalProperties": false,
+            "required": ["type", "text"],
+            "properties": {"type": {"const": "visual"}, "text": {"type": "string", "minLength": 1}}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/generate_scripts_from_subtitles.py
+++ b/src/generate_scripts_from_subtitles.py
@@ -86,10 +86,6 @@ def generate_scripts(
         entries = srt_to_markdown.parse_srt(transcript_path)
         title = str(data.get("title") or slug_dir.name.replace("_", " ").title())
         markdown = srt_to_markdown.to_markdown(entries, title, youtube_id)
-        if not markdown.endswith("\n"):
-            markdown += "\n"
-        if not markdown.endswith("\n\n"):
-            markdown += "\n"
         if dry_run:
             written.append(script_path)
             continue

--- a/src/scaffold_videos.py
+++ b/src/scaffold_videos.py
@@ -17,6 +17,7 @@ TEMPLATE_MD = """# {title}
 ## Script
 
 [NARRATOR]: <!-- narrator lines here -->
+
 [VISUAL]: <!-- b-roll, graphics, or stage directions -->
 """
 

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -124,6 +124,8 @@ def _split_sentences(text: str) -> List[str]:
 def to_markdown(
     entries: List[Tuple[str, str, str]], title: str, youtube_id: str
 ) -> str:
+    if not any(_split_sentences(text) for _, _, text in entries):
+        raise ValueError("SRT contains no usable narrator sentences")
     parts = []
     if title:
         parts.append(f"# {title}")

--- a/src/srt_to_markdown.py
+++ b/src/srt_to_markdown.py
@@ -137,7 +137,7 @@ def to_markdown(
         for sentence in _split_sentences(text):
             parts.append(f"[NARRATOR]: {sentence}  <!-- {start} -> {end} -->")
             parts.append("")
-    return "\n".join(parts)
+    return "\n".join(parts).rstrip() + "\n"
 
 
 def generate_script_for_slug(

--- a/src/video_script_format.py
+++ b/src/video_script_format.py
@@ -1,0 +1,213 @@
+"""Parse, validate, and canonically format Futuroptimist video scripts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "schemas" / "video_script.schema.json"
+SOURCE_RE = re.compile(r"^> (Draft script|Transcript) for video `([^`]+)`$")
+LEGACY_SOURCE_RE = re.compile(r"^> YouTube ID:\s*(\S+)\s*$")
+TAG_RE = re.compile(r"^\[(NARRATOR|VISUAL)\]:(?: (.*))?$")
+TIMING_RE = re.compile(r"\s*<!--\s*(.*?)\s*(?:->|→)\s*(.*?)\s*-->\s*$")
+
+
+class ScriptFormatError(ValueError):
+    """A line-oriented script format error."""
+
+    def __init__(self, message: str, line: int = 1):
+        super().__init__(message)
+        self.line = line
+
+
+def parse_script(text: str, *, migrate: bool = False) -> dict:
+    """Parse Markdown into the normalized schema object."""
+    lines = text.splitlines()
+    if not lines or not lines[0].startswith("# ") or not lines[0][2:].strip():
+        raise ScriptFormatError("expected one nonempty H1 title at the start", 1)
+    title = lines[0][2:].strip()
+    i = 1
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+    if i >= len(lines):
+        raise ScriptFormatError("missing canonical source blockquote", i + 1)
+    match = SOURCE_RE.fullmatch(lines[i])
+    if not match and migrate:
+        legacy = LEGACY_SOURCE_RE.fullmatch(lines[i])
+        if legacy:
+            match_values = ("Draft script", legacy.group(1))
+        else:
+            match_values = None
+    else:
+        match_values = match.groups() if match else None
+    if not match_values:
+        raise ScriptFormatError(
+            "expected canonical source '> Draft script for video `id`' or transcript header",
+            i + 1,
+        )
+    source, video_id = match_values
+    kind = "draft" if source == "Draft script" else "transcript"
+    i += 1
+    outline: list[str] = []
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+    if migrate and i < len(lines) and lines[i].strip() == "> Draft outline":
+        i += 1
+        while i < len(lines) and lines[i].strip() != "## Script":
+            value = lines[i].strip()
+            if value.startswith(">"):
+                value = value[1:].strip()
+                if value:
+                    outline.append(value)
+            elif value:
+                raise ScriptFormatError("invalid legacy outline line", i + 1)
+            i += 1
+    elif i < len(lines) and lines[i].strip() == "## Outline":
+        i += 1
+        while i < len(lines) and lines[i].strip() != "## Script":
+            value = lines[i].strip()
+            if value:
+                if not value.startswith("- ") or not value[2:].strip():
+                    raise ScriptFormatError(
+                        "outline entries must be nonempty '- ' items", i + 1
+                    )
+                outline.append(value[2:])
+            i += 1
+    if i >= len(lines) or lines[i].strip() != "## Script":
+        raise ScriptFormatError("missing ## Script heading", i + 1)
+    i += 1
+    segments: list[dict] = []
+    while i < len(lines):
+        raw = lines[i]
+        value = raw.strip()
+        if not value:
+            i += 1
+            continue
+        if value.startswith("### ") and value[4:].strip():
+            segments.append({"type": "section", "text": value[4:].strip()})
+        elif migrate and value.startswith(">") and value[1:].strip():
+            segments.append({"type": "section", "text": value[1:].strip()})
+        else:
+            tag = TAG_RE.fullmatch(raw)
+            if not tag:
+                raise ScriptFormatError(
+                    "script body must be ###, [NARRATOR]:, or [VISUAL]:", i + 1
+                )
+            segment_type = tag.group(1).lower()
+            segment_text = tag.group(2) or ""
+            if not segment_text.strip():
+                raise ScriptFormatError(f"empty {segment_type} segment", i + 1)
+            segment = {"type": segment_type, "text": segment_text}
+            if segment_type == "narrator":
+                timing = TIMING_RE.search(segment_text)
+                if timing:
+                    segment["timing"] = {
+                        "start": timing.group(1),
+                        "end": timing.group(2),
+                    }
+            segments.append(segment)
+        i += 1
+    document = {"schema_version": 1, "title": title, "kind": kind, "video_id": video_id}
+    if outline:
+        document["outline"] = outline
+    document["segments"] = segments
+    return document
+
+
+def validate_document(document: dict) -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = sorted(
+        Draft7Validator(schema).iter_errors(document),
+        key=lambda error: list(error.path),
+    )
+    if errors:
+        raise ScriptFormatError("schema: " + errors[0].message)
+
+
+def format_document(document: dict) -> str:
+    """Render a normalized document with exactly one blank line between blocks."""
+    source = "Draft script" if document["kind"] == "draft" else "Transcript"
+    blocks = [
+        f"# {document['title']}",
+        f"> {source} for video `{document['video_id']}`",
+    ]
+    if document.get("outline"):
+        blocks.extend(
+            ["## Outline", "\n".join(f"- {item}" for item in document["outline"])]
+        )
+    blocks.append("## Script")
+    for segment in document["segments"]:
+        if segment["type"] == "section":
+            blocks.append(f"### {segment['text']}")
+        else:
+            blocks.append(f"[{segment['type'].upper()}]: {segment['text']}")
+    return "\n\n".join(blocks) + "\n"
+
+
+def validate_metadata(path: Path, document: dict) -> None:
+    metadata_path = path.with_name("metadata.json")
+    if not metadata_path.exists():
+        return
+    youtube_id = str(
+        json.loads(metadata_path.read_text(encoding="utf-8")).get("youtube_id", "")
+    ).strip()
+    if youtube_id and document["video_id"] not in {youtube_id, "draft", "<youtube_id>"}:
+        raise ScriptFormatError(
+            f"video id {document['video_id']!r} does not match metadata {youtube_id!r}",
+            3,
+        )
+
+
+def process(path: Path, *, write: bool) -> bool:
+    original = path.read_text(encoding="utf-8")
+    document = parse_script(original, migrate=write)
+    validate_document(document)
+    validate_metadata(path, document)
+    canonical = format_document(document)
+    if write:
+        if original != canonical:
+            path.write_text(canonical, encoding="utf-8")
+            return True
+    elif original != canonical:
+        raise ScriptFormatError("not canonically formatted; run with --write", 1)
+    return False
+
+
+def discover(paths: list[Path]) -> list[Path]:
+    found: set[Path] = set()
+    for path in paths:
+        if path.is_dir():
+            found.update(path.rglob("script.md"))
+        elif path.name == "script.md":
+            found.add(path)
+    return sorted(found)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true")
+    mode.add_argument("--write", action="store_true")
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+    failed = False
+    for path in discover(args.paths):
+        try:
+            changed = process(path, write=args.write)
+            if changed:
+                print(f"Formatted {path}")
+        except (ScriptFormatError, json.JSONDecodeError) as error:
+            line = getattr(error, "line", 1)
+            print(f"{path}:{line}: {error}", file=sys.stderr)
+            failed = True
+    return int(failed)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/video_script_format.py
+++ b/src/video_script_format.py
@@ -16,6 +16,11 @@ SOURCE_RE = re.compile(r"^> (Draft script|Transcript) for video `([^`]+)`$")
 LEGACY_SOURCE_RE = re.compile(r"^> YouTube ID:\s*(\S+)\s*$")
 TAG_RE = re.compile(r"^\[(NARRATOR|VISUAL)\]:(?: (.*))?$")
 TIMING_RE = re.compile(r"\s*<!--\s*(.*?)\s*(?:->|→)\s*(.*?)\s*-->\s*$")
+TIMED_SECTION_RE = re.compile(
+    r"^\d{1,2}:\d{2}(?::\d{2})?\s*(?:-|–|—|→)\s*"
+    r"\d{1,2}:\d{2}(?::\d{2})?\s*:\s*\S.*$"
+)
+SENTINEL_VIDEO_IDS = {"draft", "<youtube_id>"}
 
 
 class ScriptFormatError(ValueError):
@@ -92,7 +97,14 @@ def parse_script(text: str, *, migrate: bool = False) -> dict:
         if value.startswith("### ") and value[4:].strip():
             segments.append({"type": "section", "text": value[4:].strip()})
         elif migrate and value.startswith(">") and value[1:].strip():
-            segments.append({"type": "section", "text": value[1:].strip()})
+            section_text = value[1:].strip()
+            if not TIMED_SECTION_RE.fullmatch(section_text):
+                raise ScriptFormatError(
+                    "cannot migrate body blockquote; expected a timed section label "
+                    "such as '> 0:01-0:02: Section title'",
+                    i + 1,
+                )
+            segments.append({"type": "section", "text": section_text})
         else:
             tag = TAG_RE.fullmatch(raw)
             if not tag:
@@ -154,10 +166,16 @@ def validate_metadata(path: Path, document: dict) -> None:
     metadata_path = path.with_name("metadata.json")
     if not metadata_path.exists():
         return
-    youtube_id = str(
-        json.loads(metadata_path.read_text(encoding="utf-8")).get("youtube_id", "")
-    ).strip()
-    if youtube_id and document["video_id"] != youtube_id:
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    if not isinstance(metadata, dict):
+        raise ScriptFormatError("metadata.json must contain a JSON object")
+    metadata_youtube_id = metadata.get("youtube_id", "")
+    youtube_id = "" if metadata_youtube_id is None else str(metadata_youtube_id).strip()
+    if (
+        youtube_id
+        and youtube_id not in SENTINEL_VIDEO_IDS
+        and document["video_id"] != youtube_id
+    ):
         raise ScriptFormatError(
             f"video id {document['video_id']!r} does not match metadata {youtube_id!r}",
             3,
@@ -197,12 +215,30 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("paths", nargs="+", type=Path)
     args = parser.parse_args(argv)
     failed = False
-    for path in discover(args.paths):
+    scripts: set[Path] = set()
+    for path in args.paths:
+        if not path.exists():
+            print(f"{path}:1: input does not exist", file=sys.stderr)
+            failed = True
+        elif path.is_dir():
+            discovered = set(path.rglob("script.md"))
+            if not discovered:
+                print(
+                    f"{path}:1: directory contains no script.md files", file=sys.stderr
+                )
+                failed = True
+            scripts.update(discovered)
+        elif path.name == "script.md":
+            scripts.add(path)
+        else:
+            print(f"{path}:1: input is not a script.md file", file=sys.stderr)
+            failed = True
+    for path in sorted(scripts):
         try:
             changed = process(path, write=args.write)
             if changed:
                 print(f"Formatted {path}")
-        except (ScriptFormatError, json.JSONDecodeError) as error:
+        except (OSError, ScriptFormatError, json.JSONDecodeError) as error:
             line = getattr(error, "line", 1)
             print(f"{path}:{line}: {error}", file=sys.stderr)
             failed = True

--- a/src/video_script_format.py
+++ b/src/video_script_format.py
@@ -157,7 +157,7 @@ def validate_metadata(path: Path, document: dict) -> None:
     youtube_id = str(
         json.loads(metadata_path.read_text(encoding="utf-8")).get("youtube_id", "")
     ).strip()
-    if youtube_id and document["video_id"] not in {youtube_id, "draft", "<youtube_id>"}:
+    if youtube_id and document["video_id"] != youtube_id:
         raise ScriptFormatError(
             f"video id {document['video_id']!r} does not match metadata {youtube_id!r}",
             3,

--- a/tests/test_export_prompter.py
+++ b/tests/test_export_prompter.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from video_scripts import export_prompter
 
 
@@ -23,6 +25,12 @@ def test_visual_grouping_and_markdown_cleanup(tmp_path: Path) -> None:
     output = tmp_path / "out.txt"
     assert export_prompter.export(script, output) == (2, 3)
     assert output.read_text() == "Hello site code. Next.\n\nEnd.\n"
+
+
+def test_markdown_cleanup_preserves_identifier_underscores() -> None:
+    assert export_prompter.plain_text("Use `foo_bar` and foo_bar, not _italics_.") == (
+        "Use foo_bar and foo_bar, not italics."
+    )
 
 
 def test_transcript_fallback_has_one_chapter_per_segment(tmp_path: Path) -> None:
@@ -49,6 +57,18 @@ def test_placeholder_failure_leaves_existing_output_untouched(
         )
         == 0
     )
+
+
+def test_empty_cleaned_narration_requires_rehearsal_mode(tmp_path: Path) -> None:
+    script = tmp_path / "script.md"
+    _write(script, "[NARRATOR]: <!-- narrator lines here -->\n")
+    output = tmp_path / "prompter.txt"
+    output.write_text("old\n")
+
+    with pytest.raises(ValueError, match="narration is empty"):
+        export_prompter.export(script, output)
+    assert output.read_text() == "old\n"
+    assert export_prompter.export(script, output, allow_placeholders=True) == (1, 1)
 
 
 def test_sugarkube_invariant(tmp_path: Path) -> None:

--- a/tests/test_export_prompter.py
+++ b/tests/test_export_prompter.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from video_scripts import export_prompter
+
+
+def _write(path: Path, body: str) -> None:
+    path.write_text("# T\n\n> Draft script for video `draft`\n\n## Script\n\n" + body)
+
+
+def test_visual_grouping_and_markdown_cleanup(tmp_path: Path) -> None:
+    script = tmp_path / "script.md"
+    body = """[NARRATOR]: **Hello** [site](https://x) `code`. <!-- 0 -> 1 -->
+
+[NARRATOR]: Next.
+
+[VISUAL]: Shot.
+
+[NARRATOR]: End.
+
+[VISUAL]: End shot.
+"""
+    _write(script, body)
+    output = tmp_path / "out.txt"
+    assert export_prompter.export(script, output) == (2, 3)
+    assert output.read_text() == "Hello site code. Next.\n\nEnd.\n"
+
+
+def test_transcript_fallback_has_one_chapter_per_segment(tmp_path: Path) -> None:
+    script = tmp_path / "script.md"
+    _write(script, "[NARRATOR]: One.\n\n[NARRATOR]: Two.\n")
+    output = tmp_path / "out.txt"
+    assert export_prompter.export(script, output) == (2, 2)
+    assert output.read_text() == "One.\n\nTwo.\n"
+
+
+def test_placeholder_failure_leaves_existing_output_untouched(
+    tmp_path: Path, capsys
+) -> None:
+    script = tmp_path / "script.md"
+    _write(script, "[NARRATOR]: Values <watts> and <watts>.\n")
+    output = tmp_path / "prompter.txt"
+    output.write_text("old\n")
+    assert export_prompter.main(["--script", str(script), "--output", str(output)]) == 1
+    assert output.read_text() == "old\n"
+    assert "<watts>" in capsys.readouterr().err
+    assert (
+        export_prompter.main(
+            ["--script", str(script), "--output", str(output), "--allow-placeholders"]
+        )
+        == 0
+    )
+
+
+def test_sugarkube_invariant(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1]
+    output = tmp_path / "prompter.txt"
+    result = export_prompter.export(
+        root / "video_scripts/20260901_sugarkube/script.md",
+        output,
+        allow_placeholders=True,
+    )
+    assert result == (42, 109)
+    text = output.read_text()
+    assert all(
+        marker not in text for marker in ("[NARRATOR]", "[VISUAL]", "<!--", "##")
+    )
+    assert text.endswith("\n") and not text.endswith("\n\n")

--- a/tests/test_export_prompter.py
+++ b/tests/test_export_prompter.py
@@ -27,10 +27,11 @@ def test_visual_grouping_and_markdown_cleanup(tmp_path: Path) -> None:
     assert output.read_text() == "Hello site code. Next.\n\nEnd.\n"
 
 
-def test_markdown_cleanup_preserves_identifier_underscores() -> None:
-    assert export_prompter.plain_text("Use `foo_bar` and foo_bar, not _italics_.") == (
-        "Use foo_bar and foo_bar, not italics."
-    )
+def test_markdown_cleanup_only_removes_actual_markup() -> None:
+    assert export_prompter.plain_text(
+        "Use `some_file_name`, 2 * 3, [the docs](https://x), **bold**, "
+        "_italics_, and ~~removed~~; keep x~y."
+    ) == ("Use some_file_name, 2 * 3, the docs, bold, italics, and removed; keep x~y.")
 
 
 def test_transcript_fallback_has_one_chapter_per_segment(tmp_path: Path) -> None:
@@ -59,7 +60,7 @@ def test_placeholder_failure_leaves_existing_output_untouched(
     )
 
 
-def test_empty_cleaned_narration_requires_rehearsal_mode(tmp_path: Path) -> None:
+def test_empty_cleaned_narration_is_always_rejected(tmp_path: Path) -> None:
     script = tmp_path / "script.md"
     _write(script, "[NARRATOR]: <!-- narrator lines here -->\n")
     output = tmp_path / "prompter.txt"
@@ -68,7 +69,41 @@ def test_empty_cleaned_narration_requires_rehearsal_mode(tmp_path: Path) -> None
     with pytest.raises(ValueError, match="narration is empty"):
         export_prompter.export(script, output)
     assert output.read_text() == "old\n"
-    assert export_prompter.export(script, output, allow_placeholders=True) == (1, 1)
+    with pytest.raises(ValueError, match="narration is empty"):
+        export_prompter.export(script, output, allow_placeholders=True)
+    assert output.read_text() == "old\n"
+
+
+def test_repeated_placeholders_are_reported_once(tmp_path: Path) -> None:
+    script = tmp_path / "script.md"
+    _write(script, "[NARRATOR]: <value> then <value>.\n")
+    output = tmp_path / "prompter.txt"
+    with pytest.raises(ValueError) as error:
+        export_prompter.export(script, output)
+    assert str(error.value).count("<value>") == 1
+    assert not output.exists()
+
+
+def test_cli_script_custom_and_default_output(tmp_path: Path, capsys) -> None:
+    script = tmp_path / "script.md"
+    _write(script, "[NARRATOR]: Hello.\n")
+    custom = tmp_path / "custom.txt"
+    assert export_prompter.main(["--script", str(script), "--output", str(custom)]) == 0
+    assert capsys.readouterr().out == f"Wrote {custom} (1 chapters)\n"
+    assert export_prompter.main(["--script", str(script)]) == 0
+    assert (tmp_path / "prompter.txt").read_text() == "Hello.\n"
+
+
+def test_cli_slug_uses_default_output(tmp_path: Path, monkeypatch, capsys) -> None:
+    root = tmp_path
+    script = root / "video_scripts" / "demo" / "script.md"
+    script.parent.mkdir(parents=True)
+    _write(script, "[NARRATOR]: Hello.\n")
+    monkeypatch.setattr(export_prompter, "REPO_ROOT", root)
+    assert export_prompter.main(["--slug", "demo"]) == 0
+    output = script.parent / "prompter.txt"
+    assert output.read_text() == "Hello.\n"
+    assert capsys.readouterr().out == f"Wrote {output} (1 chapters)\n"
 
 
 def test_sugarkube_invariant(tmp_path: Path) -> None:

--- a/tests/test_srt_to_markdown.py
+++ b/tests/test_srt_to_markdown.py
@@ -4,7 +4,21 @@ import runpy
 import sys
 import warnings
 
+import pytest
+
 import src.srt_to_markdown as stm
+
+
+def test_to_markdown_rejects_empty_input():
+    with pytest.raises(ValueError, match="no usable narrator sentences"):
+        stm.to_markdown([], "Title", "XYZ")
+
+
+def test_non_dialogue_only_srt_cannot_generate_script(tmp_path):
+    path = tmp_path / "music.srt"
+    path.write_text("1\n00:00:00,000 --> 00:00:01,000\n[Music]\n")
+    with pytest.raises(ValueError, match="no usable narrator sentences"):
+        stm.to_markdown(stm.parse_srt(path), "Title", "XYZ")
 
 
 def test_parse_and_convert(tmp_path):

--- a/tests/test_sugarkube_production_assets.py
+++ b/tests/test_sugarkube_production_assets.py
@@ -1,0 +1,28 @@
+import re
+from pathlib import Path
+
+
+def test_sugarkube_production_asset_coverage() -> None:
+    root = Path(__file__).resolve().parents[1] / "video_scripts/20260901_sugarkube"
+    footage = (root / "footage.md").read_text()
+    detail_paths = [
+        root / "production/broll.md",
+        root / "production/stock.md",
+        root / "production/graphics.md",
+    ]
+    for path in detail_paths:
+        assert f"production/{path.name}" in footage
+    mapped = re.findall(r"^\| (V\d{2}) \| ([A-Z0-9, ]+) \|", footage, re.MULTILINE)
+    assert [cue for cue, _ in mapped] == [f"V{i:02}" for i in range(1, 43)]
+    definitions = []
+    for path in detail_paths:
+        definitions.extend(
+            re.findall(
+                r"^- \[ \] \*\*([ABCTG]\d{2})\*\* —", path.read_text(), re.MULTILINE
+            )
+        )
+    assert len(definitions) == len(set(definitions))
+    references = {
+        asset for _, assets in mapped for asset in re.findall(r"[ABCTG]\d{2}", assets)
+    }
+    assert references <= set(definitions)

--- a/tests/test_sugarkube_production_assets.py
+++ b/tests/test_sugarkube_production_assets.py
@@ -18,7 +18,9 @@ def test_sugarkube_production_asset_coverage() -> None:
     for path in detail_paths:
         definitions.extend(
             re.findall(
-                r"^- \[ \] \*\*([ABCTG]\d{2})\*\* —", path.read_text(), re.MULTILINE
+                r"^- \[[ x!\-]\] \*\*([ABCTG]\d{2})\*\* —",
+                path.read_text(),
+                re.MULTILINE,
             )
         )
     assert len(definitions) == len(set(definitions))

--- a/tests/test_video_script_format.py
+++ b/tests/test_video_script_format.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src import video_script_format as vsf
+
+
+def test_parse_valid_full_document() -> None:
+    text = """# Title
+
+> Draft script for video `draft`
+
+## Outline
+
+- Hook
+
+## Script
+
+### Opening
+
+[NARRATOR]: *Hello*. <!-- 00:00:00,000 -> 00:00:01,000 -->
+
+[VISUAL]: A shot.
+"""
+    document = vsf.parse_script(text)
+    vsf.validate_document(document)
+    assert document["outline"] == ["Hook"]
+    assert document["segments"][1]["timing"] == {
+        "start": "00:00:00,000",
+        "end": "00:00:01,000",
+    }
+    assert vsf.format_document(document) == text
+
+
+def test_transcript_only_is_valid() -> None:
+    document = vsf.parse_script(
+        "# Title\n\n> Transcript for video `abc`\n\n## Script\n\n[NARRATOR]: Hello.\n"
+    )
+    vsf.validate_document(document)
+    assert document["kind"] == "transcript"
+
+
+@pytest.mark.parametrize(
+    ("text", "message"),
+    [
+        ("", "H1"),
+        ("# Title\n\n## Script\n", "source"),
+        ("# Title\n\n> Draft script for video `x`\n", "## Script"),
+        (
+            "# Title\n\n> Draft script for video `x`\n\n## Script\n\n[NARRATOR]:\n",
+            "empty",
+        ),
+        (
+            "# Title\n\n> Draft script for video `x`\n\n## Script\n\n[AUDIO]: Hi\n",
+            "must be",
+        ),
+        (
+            "# Title\n\n> Draft script for video `x`\n\n## Script\n\nplain prose\n",
+            "must be",
+        ),
+    ],
+)
+def test_invalid_documents(text: str, message: str) -> None:
+    with pytest.raises(vsf.ScriptFormatError, match=message):
+        vsf.parse_script(text)
+
+
+def test_schema_rejects_mutated_object() -> None:
+    with pytest.raises(vsf.ScriptFormatError, match="schema"):
+        vsf.validate_document(
+            {
+                "schema_version": 1,
+                "title": "T",
+                "kind": "draft",
+                "video_id": "x",
+                "segments": [],
+            }
+        )
+
+
+def test_legacy_migration_is_idempotent_and_preserves_text() -> None:
+    legacy = """# Title
+> YouTube ID: draft
+
+> Draft outline
+> Hook
+
+## Script
+[NARRATOR]: **Exact** text. <!-- 0:00 -> 0:01 -->
+[VISUAL]: Exact visual!
+> 0:01-0:02: Next
+"""
+    canonical = vsf.format_document(vsf.parse_script(legacy, migrate=True))
+    assert "## Outline\n\n- Hook" in canonical
+    assert "### 0:01-0:02: Next" in canonical
+    assert "**Exact** text. <!-- 0:00 -> 0:01 -->" in canonical
+    assert vsf.format_document(vsf.parse_script(canonical)) == canonical
+
+
+def test_metadata_mismatch(tmp_path: Path) -> None:
+    script = tmp_path / "script.md"
+    script.write_text(
+        "# T\n\n> Transcript for video `wrong`\n\n## Script\n\n[NARRATOR]: Hi.\n"
+    )
+    (tmp_path / "metadata.json").write_text(json.dumps({"youtube_id": "right"}))
+    with pytest.raises(vsf.ScriptFormatError, match="does not match"):
+        vsf.process(script, write=False)
+
+
+def test_check_is_read_only_and_write_migrates_recursively(tmp_path: Path) -> None:
+    script = tmp_path / "drafts" / "demo" / "script.md"
+    script.parent.mkdir(parents=True)
+    script.write_text("# T\n> YouTube ID: draft\n## Script\n[NARRATOR]: Hi.\n")
+    original = script.read_text()
+    assert vsf.main(["--check", str(tmp_path)]) == 1
+    assert script.read_text() == original
+    assert vsf.main(["--write", str(tmp_path)]) == 0
+    assert vsf.main(["--check", str(tmp_path)]) == 0
+
+
+def test_all_committed_scripts_are_canonical() -> None:
+    root = Path(__file__).resolve().parents[1]
+    assert vsf.main(["--check", str(root / "video_scripts")]) == 0

--- a/tests/test_video_script_format.py
+++ b/tests/test_video_script_format.py
@@ -110,6 +110,18 @@ def test_metadata_mismatch(tmp_path: Path) -> None:
         vsf.process(script, write=False)
 
 
+@pytest.mark.parametrize("placeholder", ["draft", "<youtube_id>"])
+def test_metadata_rejects_stale_placeholder(tmp_path: Path, placeholder: str) -> None:
+    script = tmp_path / "script.md"
+    script.write_text(
+        f"# T\n\n> Draft script for video `{placeholder}`\n\n"
+        "## Script\n\n[NARRATOR]: Hi.\n"
+    )
+    (tmp_path / "metadata.json").write_text(json.dumps({"youtube_id": "assigned-id"}))
+    with pytest.raises(vsf.ScriptFormatError, match="does not match"):
+        vsf.process(script, write=True)
+
+
 def test_check_is_read_only_and_write_migrates_recursively(tmp_path: Path) -> None:
     script = tmp_path / "drafts" / "demo" / "script.md"
     script.parent.mkdir(parents=True)

--- a/tests/test_video_script_format.py
+++ b/tests/test_video_script_format.py
@@ -100,6 +100,35 @@ def test_legacy_migration_is_idempotent_and_preserves_text() -> None:
     assert vsf.format_document(vsf.parse_script(canonical)) == canonical
 
 
+@pytest.mark.parametrize(
+    "comment",
+    [
+        "<!--  00:00:00,000   ->  00:00:01,000  -->",
+        "<!-- 00:00:00,000 → 00:00:01,000 -->",
+    ],
+)
+def test_migration_preserves_exact_timing_comment(comment: str) -> None:
+    legacy = (
+        "# T\n> YouTube ID: draft\n## Script\n"
+        f"[NARRATOR]: Exact timing.  {comment}\n"
+    )
+    assert comment in vsf.format_document(vsf.parse_script(legacy, migrate=True))
+
+
+def test_write_rejects_editorial_body_blockquote_without_modifying_file(
+    tmp_path: Path, capsys
+) -> None:
+    script = tmp_path / "script.md"
+    original = (
+        "# T\n> YouTube ID: draft\n## Script\n"
+        "[NARRATOR]: Hi.\n> Editor note: revise this.\n"
+    )
+    script.write_text(original)
+    assert vsf.main(["--write", str(script)]) == 1
+    assert script.read_text() == original
+    assert f"{script}:5: cannot migrate body blockquote" in capsys.readouterr().err
+
+
 def test_metadata_mismatch(tmp_path: Path) -> None:
     script = tmp_path / "script.md"
     script.write_text(
@@ -108,6 +137,39 @@ def test_metadata_mismatch(tmp_path: Path) -> None:
     (tmp_path / "metadata.json").write_text(json.dumps({"youtube_id": "right"}))
     with pytest.raises(vsf.ScriptFormatError, match="does not match"):
         vsf.process(script, write=False)
+
+
+@pytest.mark.parametrize("metadata_id", [None, "", "draft", "<youtube_id>"])
+def test_metadata_sentinels_allow_script_sentinels(
+    tmp_path: Path, metadata_id: str | None
+) -> None:
+    script = tmp_path / "script.md"
+    script.write_text(
+        "# T\n\n> Draft script for video `draft`\n\n" "## Script\n\n[NARRATOR]: Hi.\n"
+    )
+    (tmp_path / "metadata.json").write_text(json.dumps({"youtube_id": metadata_id}))
+    assert vsf.process(script, write=False) is False
+
+
+def test_non_object_metadata_is_clean_cli_error(tmp_path: Path, capsys) -> None:
+    script = tmp_path / "script.md"
+    script.write_text(
+        "# T\n\n> Draft script for video `draft`\n\n" "## Script\n\n[NARRATOR]: Hi.\n"
+    )
+    (tmp_path / "metadata.json").write_text("[]")
+    assert vsf.main(["--check", str(script)]) == 1
+    assert "metadata.json must contain a JSON object" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("kind", ["missing", "empty_directory"])
+def test_invalid_input_is_clean_cli_error(tmp_path: Path, capsys, kind: str) -> None:
+    path = tmp_path / kind
+    if kind == "empty_directory":
+        path.mkdir()
+    assert vsf.main(["--check", str(path)]) == 1
+    error = capsys.readouterr().err
+    assert str(path) in error
+    assert "does not exist" in error or "contains no script.md" in error
 
 
 @pytest.mark.parametrize("placeholder", ["draft", "<youtube_id>"])

--- a/video_scripts/20210917_how-tesla-bots-could-benefit-humanity/script.md
+++ b/video_scripts/20210917_how-tesla-bots-could-benefit-humanity/script.md
@@ -4,7 +4,6 @@
 
 ## Script
 
-
 [NARRATOR]: Elon Musk unveiled Tesla's upcoming humanoid robot, dubbed Tesla Bot, at Tesla AI Day on August 19th, 2021.
 
 [NARRATOR]: While the bot is only a concept right now, they'll supposedly have a prototype arrive as soon as 2022.

--- a/video_scripts/20211001_why-tesla-s-full-self-driving-is-taking-so-long/script.md
+++ b/video_scripts/20211001_why-tesla-s-full-self-driving-is-taking-so-long/script.md
@@ -157,4 +157,3 @@
 [NARRATOR]: That's it for this video. I'd greatly appreciate if you smashed that subscribe button and let me know in the comments if you have any criticisms or suggestions for future videos.
 
 [NARRATOR]: I'll see you in the next one.
-

--- a/video_scripts/20211015_things-we-need-to-figure-out-before-sending-humans-to-mars-starship-microgravity-and-radiation/script.md
+++ b/video_scripts/20211015_things-we-need-to-figure-out-before-sending-humans-to-mars-starship-microgravity-and-radiation/script.md
@@ -1,76 +1,147 @@
 # Things we need to figure out before sending humans to Mars - Starship, microgravity, and radiation
+
 > Transcript for video `whafgZUxj0Q`
 
 ## Script
 
 [NARRATOR]: Every single human that's ever lived has been limited to this one pale blue dot in a universe teeming with mystery and opportunity.
+
 [NARRATOR]: In order to expand the scope of human consciousness, we must journey beyond the orbit of our planet and become multiplanetary.
+
 [NARRATOR]: For a variety of reasons, the planet Mars is the next logical step in our cosmic journey, and we'll likely see the first human boot on Mars before the end of the decade.
+
 [NARRATOR]: However, before we make the difficult journey to the red planet, there are a number of challenges that must be solved, and I'll talk about most of them in this video.
+
 [NARRATOR]: This is not an exhaustive list, but I'll attempt to cover as much ground as possible.
+
 [NARRATOR]: We'll talk about the transportation side, the hazards humans will face along the way, as well as what we'll need to do to ensure a return trip.
+
 [NARRATOR]: Let's start with the very obvious first step, SpaceX's Starship rocket, which is likely to be the first rocket to get humans to Mars.
+
 [NARRATOR]: The Starship system is most notably going to be the world's first rapidly and fully reusable orbital rocket, which, in Elon's words, is the fundamental technology revolution needed to make life multiplanetary.
+
 [NARRATOR]: We're currently still waiting for the first orbital flight of the Starship system, consisting of the first stage, named B4, and the second stage, named S20.
+
 [NARRATOR]: S20 recently underwent a Cryo Proof test and is awaiting static fires along with B4, and we're still blocked on the FAA's Environmental Assessment of the launch site.
+
 [NARRATOR]: However, B5 and S21 are already nearing completion, and the momentum at Starbase, Texas, doesn't seem like it's going to stop anytime soon.
+
 [NARRATOR]: Once Starship is able to achieve orbit, reentry, and landing, the next milestone for the program is orbital refueling.
+
 [NARRATOR]: This is critical for getting a non-trivial amount of payload to the Moon or to Mars.
+
 [NARRATOR]: A Starship in orbit can be fully refueled by launching special Tanker Starships, which will rendezvous with the ship that's carrying payload.
+
 [NARRATOR]: There are a lot of other details here like possible fuel depots, but that's out of scope for this video.
+
 [NARRATOR]: SpaceX has a contract for a future crewed Lunar mission with NASA, and assuming the Starship program is successful and NASA solves all of its equipment challenges, we should see an uncrewed Lunar landing by SpaceX followed by a crewed Lunar landing in collaboration with NASA, sometimes around 2025.
+
 [NARRATOR]: Regardless of the Lunar mission timeline, SpaceX could start sending some uncrewed Starships to Mars as soon as the orbital refueling milestone is met, possibly even with a few Tesla Bot prototypes.
+
 [NARRATOR]: At any rate, it'll certainly be important to test landing on Mars without humans on board for obvious reasons.
+
 [NARRATOR]: In the most optimistic case, we'll probably see uncrewed missions in 2024 and crewed missions in 2026.
+
 [NARRATOR]: But more conservatively, we will likely have human boots on Mars around the end of the 2020s, either thanks to SpaceX or China.
+
 [NARRATOR]: So far, SpaceX has mostly focused on cargo missions, either for ISS resupply missions, third party satellite launches, or launches for its own satellite constellation, Starlink.
+
 [NARRATOR]: But in recent years SpaceX has begun performing crewed missions, and it currently has four such missions under its belt: Demo-2, Crew-1, Crew-2, and the recent flight that deservedly got a lot of attention, Inspiration4.
+
 [NARRATOR]: SpaceX has a bunch of planned crewed missions in the near future, including the dearMoon project, which is planning to fly a crew of around 10 people in a trajectory around the moon in 2023.
+
 [NARRATOR]: These missions not only provide extra revenue, but they're an opportunity for SpaceX to refine its strategy and skillset when it comes to life support and astronaut quarters.
+
 [NARRATOR]: While short term missions may get by with tanks of compressed oxygen for breathing, a long duration trip to Mars will most definitely require some active way of recycling the air.
+
 [NARRATOR]: Water can be split into hydrogen and oxygen using electrolysis, and the hydrogen can be recombined with the carbon dioxide exhaled by humans using the Sabatier Reaction to produce water and methane.
+
 [NARRATOR]: A system like this already exists on the ISS, so this system should also work well on Starship in principle.
+
 [NARRATOR]: Food storage and waste disposal and recycling have also been demonstrated on the ISS, and we'll gloss over those topics for brevity.
+
 [NARRATOR]: There are still major unknowns when it comes to low gravity or microgravity effects on the human body.
+
 [NARRATOR]: And while we have some data on the long term impacts of microgravity from research done on the ISS, we don't really have any data about Mars gravity, which is around 38% that of Earth's gravity.
+
 [NARRATOR]: We could in theory create rotating habitats that spin at a velocity that simulates Mars gravity so that we could begin to study the effects, but I'm not aware of any concrete plans for that yet.
+
 [NARRATOR]: For the journey though, we could potentially tether two Mars-bound Starships nose-to-nose and spin them to create artificial gravity, although nothing's been announced about this part yet.
+
 [NARRATOR]: One very relevant challenge the astronauts will face on their journey and during their extended stay is the psychological impacts of isolation from other humans.
+
 [NARRATOR]: They'll need plenty of offline-friendly forms of entertainment and regular contact with friends and family back home, and until Mars's internet infrastructure is improved, possibly through Starlink, this will be quite a difficult problem, especially since Earth entertainment is trending more and more towards cloud-based, low-latency experiences.
+
 [NARRATOR]: Let's talk a little bit about the dangers of space.
+
 [NARRATOR]: There are two types of radiation people usually talk about, solar radiation and galactic cosmic rays.
+
 [NARRATOR]: The short version is that while radiation levels will certainly be higher during the journey than on most of Earth, with some shielding and clever arrangement of the crew, we can bring that down to the level of radiation experienced on the ISS.
+
 [NARRATOR]: I've linked an article discussing the math and what safe radiation levels look like down in the description.
+
 [NARRATOR]: One other interesting thing to note is that there's a city in Iran named Ramsar with similar radiation levels to what we'd experience on Mars, and there doesn't seem to be any increase in cancer rates among the local population.
+
 [NARRATOR]: I've linked a video by Anton Petrov discussing this city and its implications on Mars colonization.
+
 [NARRATOR]: In the case of a strong solar storm during the journey to Mars, the crew could utilize a small region in the center of the living quarters shielded by the mission's water and food supplies, according to an AMA with Dr.
+
 [NARRATOR]: Robert Zubrin on the SpaceX subreddit.
+
 [NARRATOR]: I previously mentioned the Sabatier Reaction when talking about air recycling.
+
 [NARRATOR]: It becomes even more relevant, however, once the Starships has landed on Mars.
+
 [NARRATOR]: The Sabatier Reaction turns hydrogen and carbon dioxide into water and methane, the latter of which is used as propellant for Starship.
+
 [NARRATOR]: Mars's atmosphere contains plenty of carbon dioxide, it's roughly 95% CO2 by mass.
+
 [NARRATOR]: You'd either have to bring some hydrogen with you, or you'd need to find water on Mars to turn into hydrogen and oxygen with electrolysis.
+
 [NARRATOR]: To obtain water from the glaciers on Mars, you could use the Rodwell process that's used to extract water in Antarctica.
+
 [NARRATOR]: You basically pump in a small amount of warm liquid water, which then melts the surrounding ice, which can then be pumped out.
+
 [NARRATOR]: If we're able to set up an operation that utilizes this water, we would be able to produce propellant for a return trip without having to continually import more hydrogen from Earth.
+
 [NARRATOR]: The general process of using the resources at your destination rather than importing them is referred to as In-Situ Resource Utilization.
+
 [NARRATOR]: Mass to Mars will still be incredibly expensive for a long time, so reusing Mars's resources as much as possible should be a priority.
+
 [NARRATOR]: Even better, if Tesla Bots are ready in time for the uncrewed Mars missions later this decade, they could help set up the ISRU stations ahead of time so that we can send the first humans to Mars with much higher confidence that they can actually return after their mission.
+
 [NARRATOR]: While the Starship system solves the transportation issue in a very basic sense, a round trip to Mars still takes a fairly long time, especially when you consider the synodic period of 26 months, which is the amount of time between the distance between the two planets is short enough for a transfer between planets.
+
 [NARRATOR]: The journey there and back would be roughly 6 months each, but once people arrive to Mars, they'll need to wait for the next transfer window, unless ISRU hasn't produced enough Methylox, in which case they'll have to wait an additional synodic period.
+
 [NARRATOR]: In total, we're looking at around 2.5 years round trip.
+
 [NARRATOR]: We've discussed radiation concerns earlier in the video with regards to the trip to Mars, but what do we do once we're on the surface?
+
 [NARRATOR]: Mostly, we'll just go below the surface.
+
 [NARRATOR]: We could very well use the Starships themselves as habitats, as they'll likely be fairly well shielded from radiation.
+
 [NARRATOR]: However, long term, we would definitely need to start branching out and building habitats.
+
 [NARRATOR]: What process we'd build them with is a bit too much detail for this video, but in general, as long as we have a few feet of dirt, water, or ice above the habitat, we should be fairly safe.
+
 [NARRATOR]: In Dr.
+
 [NARRATOR]: Zubrin's AMA, he also addressed this question with his vision of a Mars habitat: you'd have a greenhouse on the surface utilizing sunlight, you'd have an aquarium below the greenhouse with fish intended for food, and human shelters below the aquariums.
+
 [NARRATOR]: The plants don't require shielding, and the water absorbs the radiation from the surface.
+
 [NARRATOR]: Some research here on Earth involving soil with Mars-like properties indicates that crops will likely grow in soil on Mars, but if that's not the case, we can always just fall back to hydroponics, which requires no soil.
+
 [NARRATOR]: I'll talk about this in more detail in a future video, so make sure you subscribe for future videos about the future.
+
 [NARRATOR]: That's it for this video.
+
 [NARRATOR]: Let me know if I missed anything, and I'll address it in a future video.
+
 [NARRATOR]: In the meantime, I would love it if you subscribed to my channel and told some friends about it, especially if they're into futurism and bleeding edge technology.
+
 [NARRATOR]: If you have a suggestion for a future topic, let me know in the comments, and go ahead and follow me on Twitter @futuroptimist, link in the description.
+
 [NARRATOR]: I'll see you in the next one.

--- a/video_scripts/20211115_why-augmented-reality-and-the-metaverse-will-change-everything-eventually/script.md
+++ b/video_scripts/20211115_why-augmented-reality-and-the-metaverse-will-change-everything-eventually/script.md
@@ -325,4 +325,3 @@
 [NARRATOR]: If you have a suggestion for a future topic, let me know in the comments, and go ahead and follow me on Twitter at @futuroptimist to participate in planning upcoming videos, link in the description.
 
 [NARRATOR]: I'll see you in the next one.
-

--- a/video_scripts/20220111_6-of-the-biggest-ways-starship-will-transform-the-space-industry-forever/script.md
+++ b/video_scripts/20220111_6-of-the-biggest-ways-starship-will-transform-the-space-industry-forever/script.md
@@ -3,83 +3,163 @@
 > Transcript for video `en01vo9ErpY`
 
 ## Script
+
 [NARRATOR]: What if I told you that Starship, SpaceX's upcoming fully reusable rocket, is the most transformative thing to happen in space travel so far.
+
 [NARRATOR]: That's certainly a big claim, but I think it's warranted.
+
 [NARRATOR]: Starship not only greatly reduces cost to orbit, but it also allows for much larger payloads and faster turnaround time.
+
 [NARRATOR]: In this video, I'm going to list some of the biggest ways Starship will provide value over the next few years, starting with the most obvious and delving into the unknown towards the end.
+
 [NARRATOR]: Let's start with a quick recap of Starship progress so far.
+
 [NARRATOR]: Starship is intended to be a fully and rapidly reusable rocket system where both the first and second stages land propulsively.
+
 [NARRATOR]: Well, technically on earth, they won't exactly land, but instead will be caught by gigantic mechanical chopsticks, but that's a story for another video.
+
 [NARRATOR]: Starship aims to get around 150 tons to low earth orbit and eventually reach a launch cost of one to $2 million.
+
 [NARRATOR]: It has the potential to send dozens of humans to Mars at a time, and maybe even transport hundreds of humans from point-to-point on earth someday.
+
 [NARRATOR]: If you haven't followed Starship's test campaign so far, here's the TLDW.
+
 [NARRATOR]: Sub-orbital tests of the second stage started with SN8 in December, 2020, and the most recent flight was performed by SN15 in May, 2021, and was the first to successfully land and remain unexploded.
+
 [NARRATOR]: The first orbital flight will use a first stage named B4 and a second stage named S20.
+
 [NARRATOR]: Elon swears that the numbers are coincidence, but the first stage also happens to be 69 meters tall.
+
 [NARRATOR]: Nice.
+
 [NARRATOR]: This very nice first orbital flight is expected to happen sometime after the FAA's environmental assessment is complete.
+
 [NARRATOR]: It was supposed to be completed on December 31, but the FAA just extended it to February 28, so we can expect the launch no earlier than that date.
+
 [NARRATOR]: They say the delay was due to an overwhelming number of responses, and I have absolutely no idea why that may have happened.
+
 [NARRATOR]: But that's it for the recap.
+
 [NARRATOR]: I may have missed a few important details, so reach out in the comments if you need clarification or more resources, and I'll be happy to respond.
+
 [NARRATOR]: I wanted to start by mentioning the most obvious thing that Starship enables, the colonization of Mars.
+
 [NARRATOR]: I've talked about this topic already in my video entitled "Things we need to figure out before sending humans to Mars" so I recommend checking that out if you need a deeper dive.
+
 [NARRATOR]: In general, the overarching goal with Mars colonization is redundancy.
+
 [NARRATOR]: There have been several mass extinction events throughout history due to a variety of causes, and if we want to avoid our own extinction, having a human presence on two planets is certainly better than one.
+
 [NARRATOR]: There are several concrete reasons this is the case, but I'll save that for a future video.
+
 [NARRATOR]: Elon stated that it'll take around 1,000 Starships 20 years to create a self-sustaining Mars colony, so this is of course a long-term endeavor on the order of decades.
+
 [NARRATOR]: Each Starship is intended to carry over 100 tons from low earth orbit to Mars, which is, let's say, a lot.
+
 [NARRATOR]: And a lot of payload and a lot of colonists will be needed to create that self-sustaining colony.
+
 [NARRATOR]: Elon frequently reiterate that Starship, the world's first rapidly and fully reusable rocket, is the fundamental technology needed to make life multi-planetary.
+
 [NARRATOR]: One of Elon's other major ventures is a satellite internet constellation known as Starlink.
+
 [NARRATOR]: Falcon 9 rockets can deliver around 60 V1 Starlink satellites to lower earth orbit per launch, while Starship could deliver roughly 400 V1 satellites instead.
+
 [NARRATOR]: The V1 satellites, however, are being deprecated in favor of V2 satellites, which supposedly allow for greater bandwidth and can only be economically shipped with Starship.
+
 [NARRATOR]: According to a leaked internal email from Elon to SpaceX in November, 2021, in addition to providing high-bandwidth internet to a large portion of humans in rural areas across the world, Starlink satellites likely have quite a bit of multitasking potential.
+
 [NARRATOR]: Starlink already announced plans to partner with telecom companies for data backhaul, and it is partnering with Azure to provide cloud computing services, and laser-linked Starlinks communicating directly within the user terminals makes the satellites uniquely poised to provide services like edge computing and CDNs.
+
 [NARRATOR]: Starlink satellites are designed to deorbit after five years, and this short lifespan ensures that the network can continuously be upgraded with later generation hardware, and potentially more bells and whistles like cameras and other sensors for imaging earth and the cosmos, and additional complimentary services like GPS could be integrated as well.
+
 [NARRATOR]: James Webb Space Telescope has finally launched after 25 years of development and a budget of $10 billion US.
+
 [NARRATOR]: JWST is designed to be folded 12 times to fit its launch vehicle, the Ariane 5, which has a fairing with a diameter of 4.5 meters and a length of 16 meters.
+
 [NARRATOR]: The actual telescope itself is 14 by 21 meters when fully unfolded.
+
 [NARRATOR]: It'll certainly be one of the most impressive feats of human engineering.
+
 [NARRATOR]: Starship will have a fairing with a diameter of 9 meters and a height of 18 meters, which means it could launch JWST-size telescopes in the future.
+
 [NARRATOR]: And the hull of the ship itself could very well be made into the body of a telescope.
+
 [NARRATOR]: Additionally, the rapid launch and reuse of the system means that scientists could likely design modular telescopes that are combined in orbit using multiple starships.
+
 [NARRATOR]: One of the main reasons space telescopes are so challenging is that angular resolution or the ability to resolve distant objects is limited by the overall diameter of the aperture.
+
 [NARRATOR]: Starship will hopefully lower this barrier to entry and enable a new generation of space telescopes, which can study our universe in unprecedented and increasingly more beneficial ways.
+
 [NARRATOR]: There are a number of existing and future startups that could benefit substantially from both the larger payload sizes and lower cost per ton offered by Starship.
+
 [NARRATOR]: Easier access to earth imaging satellites could enable scientists to fight climate change by identifying significant sources of greenhouse gases, like methane, and better model weather patterns and predict extreme weather events.
+
 [NARRATOR]: This can certainly be accomplished with existing rocketry, but Starship intends to reduce the cost to space by orders of magnitude.
+
 [NARRATOR]: So funding these important ventures becomes more and more realistic.
+
 [NARRATOR]: In addition to imagery, easier access to space opens the door for all sorts of manufacturing use cases in low earth orbit.
+
 [NARRATOR]: Including but not limited to the following, 3D printed organs, exotic versions of fibers for high-speed internet, carbon nanotubes, superconductors, hydroponic plants, diamonds for high precision machinery, novel drugs and medicine.
+
 [NARRATOR]: And the list goes on and on.
+
 [NARRATOR]: If you're interested in some more examples, I recommend checking out factoriesinspace.com, which lists all of the use cases I mentioned and more.
+
 [NARRATOR]: One other exciting thing that starship enables is the launch of significant amounts of payload to objects beyond Mars, particularly the moons of Jupiter and Saturn.
+
 [NARRATOR]: We could send deep sea vehicles to Europa, one of Jupiter's moons, which is hypothesized to have partially liquid oceans of water at 100 kilometers thick, which makes it a possible candidate for the discovery of life forms to beyond earth.
+
 [NARRATOR]: There are many other exciting worlds that could be explored more thoroughly, like another Galilean moon Io, which has active volcano plumes and flowing lava on the surface.
+
 [NARRATOR]: In addition to landing on planets and moons, Starship could enable a research missions to nearby asteroids, with potential for early attempts at asteroid mining.
+
 [NARRATOR]: Additionally, more payload to orbit means heavier payloads for asteroid redirection missions like the recent DART mission.
+
 [NARRATOR]: Having a planetary defense system in place will be essential for our long-term ability to protect earth from potentially catastrophic asteroid impacts.
+
 [NARRATOR]: If you want a good laugh, I recommend a recent Netflix movie called Don't Look Up, which satirically explores how society might react to an impending extinction level asteroid impact.
+
 [NARRATOR]: Currently there are only two space stations in operation, the International Space Station and the Tiangong Space Station, but there are a number of exciting proposals for new space stations as well.
+
 [NARRATOR]: Axiom space is planning to begin creating the Axiom Orbital Segment, which will begin as additional components on the ISS.
+
 [NARRATOR]: With the option of detaching later and forming its own independent space station.
+
 [NARRATOR]: Axiom will begin sending their own astronauts to the ISS starting next year.
+
 [NARRATOR]: And it will be exciting to see where that company goes in the future.
+
 [NARRATOR]: Blue Origin has also discussed plans to build their own space station dubbed the Orbital Reef, but any work towards that station will either require achieving orbital flight or hitching a ride on Starship.
+
 [NARRATOR]: I think the latter is highly unlikely, but I'm not ruling it out completely.
+
 [NARRATOR]: Beyond more immediate plans, it's fun to speculate further into the future and imagine ways that Starship could finally enable the creation of rotating habitats.
+
 [NARRATOR]: These rotating habitats would use centripetal force to create artificial gravity, which may make the barrier to permanent space habitation much lower.
+
 [NARRATOR]: Microgravity has a number of adverse effects on the human body and preserving muscle tissue requires extensive amounts of exercise.
+
 [NARRATOR]: There are a couple likely reasons we've yet to see rotating habitats.
+
 [NARRATOR]: And the most obvious is that these structures have to be sufficiently large to create artificial gravity without side effects.
+
 [NARRATOR]: Studies have shown that a rotational radius of less than 100 meters can cause motion sickness and generally a 500 meter radius is required for comfortable earth gravity.
+
 [NARRATOR]: One iterative step in that direction, however, could be the try to simulate moon gravity or Mars gravity, which could allow scientists to observe lower gravity's potential health effects and better prepare us for long-term colonization.
+
 [NARRATOR]: There's an excellent blog article by Casey Handmer that discusses this problem in depth and offers a potential solution for creating a rotating station out of a ring of starships.
+
 [NARRATOR]: I recommend you check it out.
+
 [NARRATOR]: I've added a link under the like button.
+
 [NARRATOR]: Starship is still largely unproven, but if things go according to plan, this could catapult us into a new age of space exploration and industry.
+
 [NARRATOR]: Fingers are crossed for the orbital campaign next year.
+
 [NARRATOR]: That's it for this video, please subscribe if you find topics like this interesting.
+
 [NARRATOR]: And let me know in the comments if you have any concerns or feedback.
+
 [NARRATOR]: I'll see you in the next one.

--- a/video_scripts/20250701_indoor-aquariums-tour/script.md
+++ b/video_scripts/20250701_indoor-aquariums-tour/script.md
@@ -8,17 +8,13 @@
 
 [VISUAL]: Supercut of news clips, trending memes, and an old shot of me promising "regular uploads soon" timed to the line "A lot has happened since then."
 
-
 [NARRATOR]: but I'm back! Hi, I'm Daniel and you're watching Futuroptimist.
 
-
 [NARRATOR]: Today I'm giving you a quick look at four indoor aquariums I've been tinkering with. Stick around to hear about my automation plans at the end.
-
 
 [NARRATOR]: I started the aquarium hobby 18 months ago and have been improving these tanks ever since, while bouncing between other hobbies and spending far too many hours at my day job—but let's focus on the fish.
 
 [VISUAL]: Collage of all four tanks in a 2×2 grid, then a rapid-fire montage of office work, platinum trophies and Steam achievements, a peek at my current OSRS sessions, several 3D prints (including hydroponic baskets), and quick clips of the backyard garden.
-
 
 [NARRATOR]: This 20 gallon runs the Walstad method, with garden soil under sand and a tasty layer of mulm. It's full of guppies, snails, and microfauna like scuds, Daphnia, and moina. I tried cherry shrimp, but their babies became guppy snacks.
 
@@ -28,52 +24,42 @@
 
 [VISUAL]: Macro lens close-ups of guppies, shrimp, scuds, Daphnia, and moina.
 
-
 [NARRATOR]: Early on the water turned cloudy and even took on a strong green hue—likely a mix of algae and bacteria. After a lot of digging through forums, I learned that adding a deep sand bed could give anaerobic bacteria room to work, and it cleared up almost overnight.
 
 [VISUAL]: Timelapse from green murk to clear water.
 
-
 [NARRATOR]: I replicated that deep sand bed in both 10-gallon tanks. The one next to this big tank had been cloudy from overfeeding, but the extra sand cleared it right up. Now the sloped bed and new RGB lighting make it pop.
 
-
 [NARRATOR]: Next is a 10 gallon where those original female guppies gave birth during quarantine, shortly after I acquired them at a local fish store. Their fry, now nearly adults themselves still live here while the adults moved back to the big tank.
-
 
 [NARRATOR]: Another 10 gallon sits in the back with aquasoil, sand, and plants but no fish yet. It's been cycling for nearly eight months and will probably house my first betta in quarantine. From the photo you'd think I'm gunning for a top spot on /r/stressfulaquariums—this shelf won't be its final home.
 
 [VISUAL]: Photo of the 10 gallon on its flimsy metal shelf.
 
-
 [NARRATOR]: Finally there's a tiny 5 gallon that was neglected for a bit, so right now it only holds snails and microfauna. Because three tanks are lidless, evaporation is fast. I keep two five‑gallon buckets above the tanks and siphon water down with gravity.
-
 
 [NARRATOR]: To show how each tank looks from the inside, I've waterproofed an Insta360 and dropped it into the water.
 
 [VISUAL]: Slow shot of the camera sinking into the 20 gallon, followed by 360° footage of guppies all around.
 
-
 [NARRATOR]: Next up, it tours the fry tank and that cycling betta setup.
 
 [VISUAL]: Quick montage from inside the fry tank, then the betta tank.
-
 
 [NARRATOR]: Even the little 5 gallon gets a spin—tiny but lively.
 
 [VISUAL]: 360° clip from the 5 gallon.
 
-
 [NARRATOR]: I top off those buckets often and check parameters, sometimes dosing with products like Quick Start. The guppies eat flakes, pellets, and live foods, plus the occasional pinch of nutritional yeast—mmm. I've kept guppies going for about 16 months now, but Daphnia cultures crash easily, so I'm experimenting with green water and leaf litter for stability.
 
 [VISUAL]: B-roll of siphoning from buckets, adding Quick Start, feeding flakes and yeast.
-
 
 [NARRATOR]: Long term I'd love to automate water changes and feeding with peristaltic pumps and microcontrollers, maybe even run everything off solar. The grow lights already follow a custom schedule through smart plugs, and my indoor tanks use PLA 3D‑printed baskets for hydroponic plants—they'll slowly degrade but that's fine. I'm also starting to work on some outdoor aquarium setups with similar aquaponic techniques, and work is well underway!
 
 [VISUAL]: Photos of the aluminum extrusion frame for solar panels, the panels themselves, tubs of aquatic sand with plants, plus the charge controller and battery.
 
 [NARRATOR]: Quick takeaways before we wrap up.
-[VISUAL]: On-screen list: "Deep sand beds clear cloudy water", "Macro lens B-roll shows the microfauna", "Automation coming soon".
 
+[VISUAL]: On-screen list: "Deep sand beds clear cloudy water", "Macro lens B-roll shows the microfauna", "Automation coming soon".
 
 [NARRATOR]: What do you think of my setup? I'm just an amateur trying random things, so let me know if you spot mistakes or things I could do less stupidly. This is the roughest version you'll see, of course. Stick around as I level things up and make this the most reliable and robust aquarium setup I can imagine, and don't forget to subscribe!

--- a/video_scripts/20251001_indoor-aquariums-tour/script.md
+++ b/video_scripts/20251001_indoor-aquariums-tour/script.md
@@ -8,17 +8,13 @@
 
 [VISUAL]: Supercut of news clips, trending memes, and an old shot of me promising "regular uploads soon" timed to the line "A lot has happened since then."
 
-
 [NARRATOR]: but I'm back! Hi, I'm Daniel and you're watching Futuroptimist.
 
-
 [NARRATOR]: Today I'm giving you a quick look at four indoor aquariums I've been tinkering with. Stick around to hear about my automation plans at the end.
-
 
 [NARRATOR]: I started the aquarium hobby 18 months ago and have been improving these tanks ever since, while bouncing between other hobbies and spending far too many hours at my day job—but let's focus on the fish.
 
 [VISUAL]: Collage of all four tanks in a 2×2 grid, then a rapid-fire montage of office work, platinum trophies and Steam achievements, a peek at my current OSRS sessions, several 3D prints (including hydroponic baskets), and quick clips of the backyard garden.
-
 
 [NARRATOR]: This 20 gallon runs the Walstad method, with garden soil under sand and a tasty layer of mulm. It's full of guppies, snails, and microfauna like scuds, Daphnia, and moina. I tried cherry shrimp, but their babies became guppy snacks.
 
@@ -28,52 +24,42 @@
 
 [VISUAL]: Macro lens close-ups of guppies, shrimp, scuds, Daphnia, and moina.
 
-
 [NARRATOR]: Early on the water turned cloudy and even took on a strong green hue—likely a mix of algae and bacteria. After a lot of digging through forums, I learned that adding a deep sand bed could give anaerobic bacteria room to work, and it cleared up almost overnight.
 
 [VISUAL]: Timelapse from green murk to clear water.
 
-
 [NARRATOR]: I replicated that deep sand bed in both 10-gallon tanks. The one next to this big tank had been cloudy from overfeeding, but the extra sand cleared it right up. Now the sloped bed and new RGB lighting make it pop.
 
-
 [NARRATOR]: Next is a 10 gallon where those original female guppies gave birth during quarantine, shortly after I acquired them at a local fish store. Their fry, now nearly adults themselves still live here while the adults moved back to the big tank.
-
 
 [NARRATOR]: Another 10 gallon sits in the back with aquasoil, sand, and plants but no fish yet. It's been cycling for nearly eight months and will probably house my first betta in quarantine. From the photo you'd think I'm gunning for a top spot on /r/stressfulaquariums—this shelf won't be its final home.
 
 [VISUAL]: Photo of the 10 gallon on its flimsy metal shelf.
 
-
 [NARRATOR]: Finally there's a tiny 5 gallon that was neglected for a bit, so right now it only holds snails and microfauna. Because three tanks are lidless, evaporation is fast. I keep two five‑gallon buckets above the tanks and siphon water down with gravity.
-
 
 [NARRATOR]: To show how each tank looks from the inside, I've waterproofed an Insta360 and dropped it into the water.
 
 [VISUAL]: Slow shot of the camera sinking into the 20 gallon, followed by 360° footage of guppies all around.
 
-
 [NARRATOR]: Next up, it tours the fry tank and that cycling betta setup.
 
 [VISUAL]: Quick montage from inside the fry tank, then the betta tank.
-
 
 [NARRATOR]: Even the little 5 gallon gets a spin—tiny but lively.
 
 [VISUAL]: 360° clip from the 5 gallon.
 
-
 [NARRATOR]: I top off those buckets often and check parameters, sometimes dosing with products like Quick Start. The guppies eat flakes, pellets, and live foods, plus the occasional pinch of nutritional yeast—mmm. I've kept guppies going for about 16 months now, but Daphnia cultures crash easily, so I'm experimenting with green water and leaf litter for stability.
 
 [VISUAL]: B-roll of siphoning from buckets, adding Quick Start, feeding flakes and yeast.
-
 
 [NARRATOR]: Long term I'd love to automate water changes and feeding with peristaltic pumps and microcontrollers, maybe even run everything off solar. The grow lights already follow a custom schedule through smart plugs, and my indoor tanks use PLA 3D‑printed baskets for hydroponic plants—they'll slowly degrade but that's fine. I'm also starting to work on some outdoor aquarium setups with similar aquaponic techniques, and work is well underway!
 
 [VISUAL]: Photos of the aluminum extrusion frame for solar panels, the panels themselves, tubs of aquatic sand with plants, plus the charge controller and battery.
 
 [NARRATOR]: Quick takeaways before we wrap up.
-[VISUAL]: On-screen list: "Deep sand beds clear cloudy water", "Macro lens B-roll shows the microfauna", "Automation coming soon".
 
+[VISUAL]: On-screen list: "Deep sand beds clear cloudy water", "Macro lens B-roll shows the microfauna", "Automation coming soon".
 
 [NARRATOR]: What do you think of my setup? I'm just an amateur trying random things, so let me know if you spot mistakes or things I could do less stupidly. This is the roughest version you'll see, of course. Stick around as I level things up and make this the most reliable and robust aquarium setup I can imagine, and don't forget to subscribe!

--- a/video_scripts/20260901_sugarkube/footage.md
+++ b/video_scripts/20260901_sugarkube/footage.md
@@ -1,0 +1,80 @@
+# Sugarkube Production Asset Index
+
+This is the canonical production index for [`script.md`](script.md). Detailed, nonduplicated assets live in [`production/broll.md`](production/broll.md), [`production/stock.md`](production/stock.md), and [`production/graphics.md`](production/graphics.md).
+
+## Media policy
+
+This production permits original footage, original screen recordings, manually produced graphics, and appropriately licensed or public-domain media. It permits **no AI-generated images or video**. Raw media remains in the ignored top-level `footage/` tree; do not add `assets.json` until matching footage directories exist.
+
+## Conventions
+
+Statuses are `[ ]` planned, `[-]` in progress, `[x]` approved, and `[!]` blocked. Asset IDs use `Axx` for A-roll/pickups, `Bxx` for original physical B-roll, `Cxx` for original screen capture, `Txx` for third-party media, and `Gxx` for manual graphics. Filenames use `<asset-id>_<short-description>_<take-or-version>.<ext>` in lowercase ASCII, for example `b01_rack-macro_t02.mov`.
+
+## Pre-production gates
+
+- [ ] Resolve every spoken `<...>` placeholder before final recording.
+- [ ] Reproduce and retain every AWS calculator input and the dated result.
+- [ ] Sanitize all screen recordings: secrets, tokens, private hostnames, personal data, and terminal history.
+- [ ] Clear every third-party asset and complete its rights-ledger row before edit lock.
+- [ ] Use the self-recorded **A04** reaction instead of the *Schitt’s Creek* excerpt unless **T06** is appropriately cleared.
+- [ ] Confirm all current, future, and hypothetical claims use the correct graphic label.
+
+## Chronological visual-cue coverage
+
+The cue numbers are the one-based order of the current 42 `[VISUAL]` blocks in `script.md`.
+
+| Cue | Asset IDs | Coverage |
+|---|---|---|
+| V01 | B01, T01, T02, T03, G01 | Rack macros and illustrative physical cloud infrastructure |
+| V02 | B01, G01 | Rack hero and node lower third |
+| V03 | A01, B03 | Desk thesis and meter insert |
+| V04 | A01, G01 | SRE experience disclosure |
+| V05 | C01 | GitHub, CI, terminal, verification, updates, rollback |
+| V06 | A01, C01 | Project list, just menu, joke |
+| V07 | A04, T06 | Self-recorded reaction default; optional cleared excerpt |
+| V08 | A01, C01 | Sanitized agentic-code review and tests |
+| V09 | A01, B01, G02 | Cloud/homegrown transition |
+| V10 | G03 | Kubernetes placement, restart, rolling update |
+| V11 | B01, B02 | Complete rack and office inventory |
+| V12 | B01, G04 | Nine-slot current/future/unused state |
+| V13 | C02 | Sugarkube files and just workflows |
+| V14 | G05 | Current ecosystem and labeled future projects |
+| V15 | A02, C03 | DSPACE landing/gameplay and joke |
+| V16 | A02, C03, T04, G01 | Quest domains and future 3D caveat |
+| V17 | C04, G01 | API, compute app, operator and relay roles |
+| V18 | A02, G06 | Ciphertext trust boundary |
+| V19 | A02, G07 | Nonexistent reputation hypothesis |
+| V20 | A02, C04, G01 | Privacy caveat and sanitized self-hosting evidence |
+| V21 | C05 | Three.js portfolio experience |
+| V22 | C06 | Text and keyboard experience |
+| V23 | C03, G08 | Connected ecosystem and dChat loop |
+| V24 | A03, B02, G04 | Pi/RAM lineup and six active nodes |
+| V25 | B03, C08, G01 | Disconnect nodes and capture idle/load/peak |
+| V26 | G09 | Electricity calculator |
+| V27 | B03, G10 | Measurement boundary |
+| V28 | C07, G11 | AWS calculator and Oregon failure domain |
+| V29 | G11, G16 | Six shape-matched instances |
+| V30 | G12 | Storage, IPv4, and exclusions |
+| V31 | G13 | Dated AWS pricing table |
+| V32 | A03, G16 | Always-on shape-match caveat |
+| V33 | A03, G16 | Financial, not energy, comparison |
+| V34 | B04, G14 | BOM, redacted receipts, node totals |
+| V35 | G15 | Break-even formula and chart |
+| V36 | A03, G16 | Lifecycle limitations |
+| V37 | A03, B02, G16 | Drink, fans, indirect-water caveat |
+| V38 | B03, C08, T05, G18 | Controls, scaling/shutdown, future off-grid goal |
+| V39 | C09, G01 | Four-project participation montage |
+| V40 | A04, B05, G17 | Start-small alternatives |
+| V41 | A04, T05, G18 | Future solar CTA |
+| V42 | A04, B06, C09, G19 | Closing montage, ecosystem resolve, hero |
+
+## Final audit
+
+- [ ] Every V01–V42 edit beat has approved coverage and matches the current script order.
+- [ ] All spoken placeholders and measurement/pricing placeholders are resolved.
+- [ ] AWS inputs, power readings, BOM, and redacted receipt evidence are retained with the project records.
+- [ ] Every capture passes the screen-sanitization review.
+- [ ] Every Txx item used is cleared, attributed, and recorded in the rights ledger; unused candidates are removed from the edit.
+- [ ] No AI-generated image or video, untracked binary, generated `prompter.txt`, or premature `assets.json` is committed.
+- [ ] Current behavior, future plans, and unimplemented hypotheses are visibly distinct.
+- [ ] Final export uses only approved filenames and the closing hero resolves cleanly.

--- a/video_scripts/20260901_sugarkube/production/broll.md
+++ b/video_scripts/20260901_sugarkube/production/broll.md
@@ -1,0 +1,33 @@
+# Sugarkube Original Footage Plan
+
+All items here are newly recorded, human-produced material. Use `[ ]` planned, `[-]` in progress, `[x]` approved, and `[!]` blocked.
+
+## A-roll and pickups
+
+- [ ] **A01** — Desk performance: thesis, modest goal, infrastructure caveats, SRE experience, disclosure, managed-cloud tradeoff, and agentic-code verification commentary.
+- [ ] **A02** — Ecosystem performances: DSPACE joke and unfinished caveat; token.place trust, reputation-hypothesis, and privacy caveats.
+- [ ] **A03** — Cost performances: Rampocalypse joke; AWS, financial-versus-energy, lifecycle, and comparison caveats; drink reaction.
+- [ ] **A04** — Participation and close: start-small advice, practical calls to action, subscribe/off-grid goal, conclusion, plus default self-recorded “Ew” reaction pickup.
+
+## Physical B-roll
+
+- [ ] **B01** — Rack opening macros and hero coverage: yellow tiers, LEDs, fans, Ethernet, PoE+ switch, full nine-slot rack, office placement, and clean desk/shelf angles.
+- [ ] **B02** — Hardware inventory: individual Pi 5 boards and RAM labels, storage, cabling, printed parts, onboard fans, continuously running desk fan, and all three tiers.
+- [ ] **B03** — Measurement sequence: place meter, disconnect three unused nodes, define rack/switch/fan boundary, and capture representative idle, workload, and peak readings.
+- [ ] **B04** — Cost evidence: repository BOM, real hardware lineup, and sanitized/redacted receipts; capture full-nine-node and comparable-six-node components.
+- [ ] **B05** — Alternatives: one-Pi setup, old computer, full rack, and physical start-small Kubernetes comparison.
+- [ ] **B06** — Closing hero: running LEDs/fans, deployments-in-context inserts, and bright-yellow final resolve.
+
+## Original screen recordings
+
+Every capture must use public/demo data and be sanitized before approval.
+
+- [ ] **C01** — Public GitHub project list, repository pages, CI checks, deployment/verification/update/rollback terminal output, and clean `just --list`; include diff/test verification from a real agentic-code workflow.
+- [ ] **C02** — Sugarkube repository: printable designs, image tooling, `justfile`, manifests, Helm charts, docs, and sanitized bootstrap/deploy/verify/promote/rollback commands.
+- [ ] **C03** — DSPACE landing/gameplay, quest trees, unfinished/feedback path, dChat, NPC selector, and visible “Powered by token.place” integration.
+- [ ] **C04** — token.place public API/demo, desktop compute-node app, operator flow, relay/compute documentation, privacy/self-hosting settings, and sanitized logs.
+- [ ] **C05** — danielsmith.io Three.js experience: house, avatar, both floors, backyard, project points, and tutorials.
+- [ ] **C06** — danielsmith.io text experience: keyboard navigation, conventional sections, and accessibility-focused layout without untested endorsement.
+- [ ] **C07** — Reproducible AWS calculator capture retaining the two-cluster Oregon inputs, instances, gp3 storage, IPv4, exclusions, date, and result.
+- [ ] **C08** — Operational controls: meter/logging UI, scale-down and shutdown terminal commands, rack controls, and deployment dashboards.
+- [ ] **C09** — Closing montage captures across DSPACE, danielsmith.io, token.place, and Sugarkube setup/deployment documentation.

--- a/video_scripts/20260901_sugarkube/production/graphics.md
+++ b/video_scripts/20260901_sugarkube/production/graphics.md
@@ -1,0 +1,23 @@
+# Sugarkube Manual Graphics Plan
+
+These graphics are designed and assembled manually; no generative-image or generative-video tooling is permitted. Labels must distinguish **Current behavior**, **Future plan**, and **Unimplemented hypothesis**.
+
+- [ ] **G01** — Current visual system: restrained lower thirds, experience label, illustrative-footage label, repository/action labels, and disclosure/caveat cards.
+- [ ] **G02** — Managed-cloud convenience versus homegrown Kubernetes title card.
+- [ ] **G03** — Kubernetes placement/restart/rolling-update diagram across one and several machines.
+- [ ] **G04** — Nine-slot rack state overlay: six current active nodes, one future development node, and two unused/unassigned nodes.
+- [ ] **G05** — Current ecosystem overview: Sugarkube with DSPACE, token.place, and danielsmith.io; future projects explicitly labeled.
+- [ ] **G06** — Current token.place trust boundary: client, ciphertext-blind relay, selected compute node, and plaintext endpoint.
+- [ ] **G07** — Unimplemented reputation hypothesis with diverse independent nodes and verified-work histories.
+- [ ] **G08** — Connected feedback loop: deployments, relay, token.place-powered dChat, portfolio front door, and application needs returning to infrastructure.
+- [ ] **G09** — Electricity calculator: watts → monthly kWh → monthly/annual cost, with final-measurement placeholders.
+- [ ] **G10** — Measurement boundary around rack, switch, cabling, and desk fan; router/modem/off-rack compute/GPU excluded.
+- [ ] **G11** — AWS architecture sequence: two self-managed three-node k3s clusters, one Oregon availability zone, then six shape-matched `c7g.xlarge` instances.
+- [ ] **G12** — AWS architecture additions/exclusions: six 256 GiB gp3 volumes, six IPv4 addresses, and excluded managed services.
+- [ ] **G13** — AWS July 22, 2026 pricing table: compute $635.10, storage $122.88, IPv4 $21.90, $779.88/month, $9,358.56/year, plus exclusions.
+- [ ] **G14** — BOM comparison: full nine-node and comparable six-node totals, placeholders pending final receipts.
+- [ ] **G15** — Break-even formula/chart, crossing month, and explicit no-positive-break-even state.
+- [ ] **G16** — Comparison caveats: always-on shape match, not performance match, financial not watt-for-watt, lifecycle/indirect impacts, and ignored factors.
+- [ ] **G17** — Start-small Kubernetes learning graphic comparing one Pi, old computer, and full rack.
+- [ ] **G18** — Future off-grid solar/battery/inverter CTA, labeled as a plan rather than current behavior.
+- [ ] **G19** — Final ecosystem resolve combining current deployed applications and the bright-yellow rack.

--- a/video_scripts/20260901_sugarkube/production/stock.md
+++ b/video_scripts/20260901_sugarkube/production/stock.md
@@ -1,0 +1,23 @@
+# Sugarkube Third-Party Media Plan
+
+Do not download or commit third-party media here. `Txx` items remain blocked until the rights ledger is complete and the edit stores the receipt/license outside git.
+
+## Candidate assets
+
+- [ ] **T01** — Appropriately licensed real data-center interiors, explicitly labeled illustrative.
+- [ ] **T02** — Appropriately licensed real electrical rooms/grid infrastructure, explicitly labeled illustrative.
+- [ ] **T03** — Appropriately licensed real cooling equipment and water infrastructure, explicitly labeled illustrative.
+- [ ] **T04** — Representative real footage/screenshots for DSPACE domains: 3D printing, hydroponics, composting, electronics, robotics, astronomy, and rocketry.
+- [ ] **T05** — Real solar panels, battery, and inverter footage for the clearly labeled future off-grid plan.
+- [ ] **T06** — Optional *Schitt’s Creek* Alexis Rose excerpt, rights-gated and blocked by default; use self-recorded reaction **A04** unless appropriately cleared.
+
+## Rights ledger
+
+| Asset ID | Source URL/provider | Creator | License or receipt | Download date | Attribution requirement | Clearance status |
+|---|---|---|---|---|---|---|
+| T01 | TBD | TBD | TBD | TBD | TBD | Blocked |
+| T02 | TBD | TBD | TBD | TBD | TBD | Blocked |
+| T03 | TBD | TBD | TBD | TBD | TBD | Blocked |
+| T04 | TBD | TBD | TBD | TBD | TBD | Blocked |
+| T05 | TBD | TBD | TBD | TBD | TBD | Blocked |
+| T06 | Rights holder/licensor TBD | TBD | Written license/receipt required | TBD | TBD | Blocked; A04 default |

--- a/video_scripts/20260901_sugarkube/script.md
+++ b/video_scripts/20260901_sugarkube/script.md
@@ -2,23 +2,18 @@
 
 > Draft script for video `<youtube_id>`
 
-> Draft outline
+## Outline
 
-> 0:00–0:40: physical hook, environmental concern, and honest thesis
-> 
-> 0:40–1:30: deployment tax and SRE motivation
-> 
-> 1:30–3:30: Sugarkube hardware, k3s platform, and command layer
-> 
-> 3:30–6:25: DSPACE, token.place, and danielsmith.io as a connected ecosystem
-> 
-> 6:25–10:35: measured electricity, AWS cost comparison, and the efficiency-versus-agency tension
-> 
-> 10:35–11:45: participation and concluding vision
+- 0:00–0:40: physical hook, environmental concern, and honest thesis
+- 0:40–1:30: deployment tax and SRE motivation
+- 1:30–3:30: Sugarkube hardware, k3s platform, and command layer
+- 3:30–6:25: DSPACE, token.place, and danielsmith.io as a connected ecosystem
+- 6:25–10:35: measured electricity, AWS cost comparison, and the efficiency-versus-agency tension
+- 10:35–11:45: participation and concluding vision
 
 ## Script
 
-> 0:00–0:40: Physical hook, environmental concern, and honest thesis
+### 0:00–0:40: Physical hook, environmental concern, and honest thesis
 
 [NARRATOR]: AI feels like it lives in the cloud, but the cloud is physical.
 
@@ -26,11 +21,9 @@
 
 [VISUAL]: Open on macro close-ups of the bright-yellow Sugarkube rack: LEDs blinking, fan blades spinning, Ethernet cables, PoE+ switch ports, and all three printed tiers. Cut to appropriately licensed stock footage of data-center interiors, electrical rooms, cooling equipment, and water infrastructure labeled "Illustrative cloud infrastructure footage."
 
-
 [NARRATOR]: So I built this: Sugarkube, a bright-yellow rack of nine Raspberry Pis hosting my open-source projects.
 
 [VISUAL]: Return to a clean rack hero shot on Daniel's desk or shelf. Add a restrained lower-third: "Sugarkube: 9 Raspberry Pi 5 nodes."
-
 
 [NARRATOR]: My goal is modest.
 
@@ -40,8 +33,7 @@
 
 [VISUAL]: A-roll of Daniel at his desk with the rack visible nearby. Brief insert of a hand placing a power meter in frame, then back to A-roll for the caveat.
 
-
-> 0:40–1:30: The deployment tax and my SRE motivation
+### 0:40–1:30: The deployment tax and my SRE motivation
 
 [NARRATOR]: I’ve spent more than a decade building production software, including nearly seven years as a site reliability engineer at YouTube.
 
@@ -49,11 +41,9 @@
 
 [VISUAL]: A-roll. Use a simple on-screen label for experience only, without showing private or internal Google or YouTube material.
 
-
 [NARRATOR]: My personal projects run at a much smaller scale, but they still need packaging, deployment, verification, updates, and recovery when something fails.
 
 [VISUAL]: Screen recordings of public GitHub repositories, CI status checks, terminal deployment commands, verification output, update logs, and rollback commands. Blur or crop any secrets, tokens, private hostnames, or sensitive terminal history.
-
 
 [NARRATOR]: I have way too many passion projects, as you can see on my GitHub, so every one-off deployment path takes time away from improving them.
 
@@ -63,8 +53,7 @@
 
 [VISUAL]: Screen recording scrolling Daniel's public GitHub project list, then cut to a tidy terminal menu or `just --list` output. End with A-roll for the joke and thesis.
 
-
-> 1:30–3:30: What Sugarkube actually is
+### 1:30–3:30: What Sugarkube actually is
 
 [NARRATOR]: Cloud platforms already make small app deployments relatively easy, especially with a trusty LLM whispering in your ear.
 
@@ -76,7 +65,6 @@
 
 [VISUAL]: Stay on A-roll as Daniel says the disclosure, then cut on "I know" to a very brief, appropriately sourced Alexis Rose "Ew, David!" reaction clip from Schitt's Creek before returning to Daniel. If that clip cannot be sourced appropriately for the edit, Daniel should record his own quick reaction instead of using AI-generated media.
 
-
 [NARRATOR]: I get the skepticism.
 
 [NARRATOR]: For one person maintaining an ecosystem this overambitious, though, coding agents are often the difference between an idea staying in my notes and becoming working software.
@@ -85,18 +73,15 @@
 
 [VISUAL]: A-roll plus a sanitized screen recording of a real agentic-coding workflow, such as reviewing a proposed diff, inspecting tests, or verifying a change. Do not expose secrets, tokens, private hostnames, or sensitive terminal history.
 
-
 [NARRATOR]: I wanted a homegrown path built on Kubernetes.
 
 [VISUAL]: Transition from A-roll back to the bright-yellow rack, then into the Kubernetes explanation with a simple two-column title card: "Managed cloud convenience" vs "Homegrown Kubernetes path."
-
 
 [NARRATOR]: Kubernetes coordinates containerized applications across one or more machines.
 
 [NARRATOR]: You describe how an application should run, and Kubernetes places it, restarts it after failures, and rolls out updates.
 
 [VISUAL]: Editor-made diagram showing containers distributed across one machine, then several machines. Label placement, restart after failure, and rolling update steps with simple arrows.
-
 
 [NARRATOR]: Sugarkube runs k3s, a lightweight Kubernetes distribution suited to homelabs and single-board computers.
 
@@ -105,7 +90,6 @@
 [NARRATOR]: One unmanaged PoE+ switch provides power and networking.
 
 [VISUAL]: Wide shot and close-ups of the full rack, individual Pi 5 boards, three PLA tiers, the PoE+ switch, Ethernet cables, storage hardware, onboard fans, desk fan, and office placement.
-
 
 [NARRATOR]: Only six Pis are active right now.
 
@@ -119,7 +103,6 @@
 
 [VISUAL]: Overlay a nine-slot rack diagram on the real rack: three active staging nodes, three active production nodes, one planned development node styled as future, and two unassigned nodes styled distinctly as unused. Keep active, future, and unassigned states visually different.
 
-
 [NARRATOR]: The repository includes the printable designs, tooling for a Raspberry Pi OS image with cloud-init and k3s preinstalled, and a command layer built around `just`.
 
 [NARRATOR]: Its `justfile` packages commands into recipes that bootstrap clusters, onboard applications, deploy and verify them, promote artifacts to production, and roll them back.
@@ -128,8 +111,7 @@
 
 [VISUAL]: Screen recordings of the Sugarkube repository showing printable design files, image-building tooling, `justfile`, manifests, Helm charts, and documentation. Show representative sanitized `just` commands for bootstrap, deploy, verify, promote, and rollback.
 
-
-> 3:30–6:25: The ecosystem running through it
+### 3:30–6:25: The ecosystem running through it
 
 [NARRATOR]: The rack is only interesting if it runs something.
 
@@ -139,13 +121,11 @@
 
 [VISUAL]: Simple editor-made ecosystem diagram with Sugarkube at the center and three current deployed projects around it. Add a small "future projects" placeholder clearly labeled as future.
 
-
 [NARRATOR]: First is DSPACE at democratized.space, a space exploration idle game that, incidentally, hasn’t made it to space yet.
 
 [NARRATOR]: My wildly overambitious goal is to turn as much of the space exploration technology tree and its dependencies as I can into something educational and fun.
 
 [VISUAL]: Screen recording of the live DSPACE game landing page and core gameplay. Include A-roll or a small comedic cutaway on "hasn’t made it to space yet."
-
 
 [NARRATOR]: Its quests span 3D printing, hydroponics, composting, electronics, robotics, astronomy, rocketry, and much more.
 
@@ -155,7 +135,6 @@
 
 [VISUAL]: Show DSPACE quest trees and representative real footage or screenshots for 3D printing, hydroponics, composting, electronics, robotics, astronomy, and rocketry. Use A-roll for the unfinished caveat and label any 3D-version reference as "Future concept, not implemented."
 
-
 [NARRATOR]: Second is token.place, my open-source distributed LLM inference platform.
 
 [NARRATOR]: Its rate-limited public API currently requires no account, API key, or payment.
@@ -163,7 +142,6 @@
 [NARRATOR]: Sugarkube hosts the relay, while people contribute spare compute by running models on consumer machines through a desktop app.
 
 [VISUAL]: Screen recording of the token.place public API documentation or demo, the desktop compute-node application, and a real operator workflow. Add a label: "Sugarkube hosts relay. Operators run compute nodes."
-
 
 [NARRATOR]: Requests are end-to-end encrypted between the client and the selected compute node.
 
@@ -173,7 +151,6 @@
 
 [VISUAL]: Simple custom diagram with client, relay, and selected compute node. Animate ciphertext passing through the relay and plaintext appearing only at the selected compute node. Cut to A-roll for "changes the trust boundary instead of eliminating trust."
 
-
 [NARRATOR]: Today, more nodes mostly mean more capacity.
 
 [NARRATOR]: My long-term hypothesis is that a larger, more diverse pool of independently operated nodes, combined with verifiable work histories and Sybil resistance, could make it harder for a bad actor to dominate node selection.
@@ -182,13 +159,11 @@
 
 [VISUAL]: A-roll with on-screen text: "That reputation system does not exist yet." Use a clearly labeled conceptual diagram, "Future hypothesis," showing diverse independent nodes accumulating verified work histories. Do not present it as current functionality.
 
-
 [NARRATOR]: By default, the official desktop app keeps prompt and response plaintext in memory and writes only redacted metadata to its logs.
 
 [NARRATOR]: Compute nodes and relays can both be self-hosted, so the strongest privacy story is running hardware you control.
 
 [VISUAL]: A-roll for the privacy caveat. Insert real repository documentation or settings screens for self-hosted relay and compute-node options where public interfaces exist. Keep logs sanitized and show redaction labels.
-
 
 [NARRATOR]: Third is danielsmith.io.
 
@@ -202,13 +177,11 @@
 
 [VISUAL]: Screen recording of danielsmith.io showing the Three.js house, avatar movement, both floors, backyard, project points of interest, and tutorial prompts.
 
-
 [NARRATOR]: A dedicated text version serves visitors who prefer a conventional page or use screen readers.
 
 [NARRATOR]: It gives hiring managers and recruiters a memorable first impression while whimsically capturing my interests in graphics programming and game development.
 
 [VISUAL]: Separate screen recording of the dedicated text version, keyboard navigation, conventional sections, and accessibility-focused layout. Avoid implying a screen reader endorsement unless actually tested.
-
 
 [NARRATOR]: Together, these projects form a feedback loop.
 
@@ -222,8 +195,7 @@
 
 [VISUAL]: Editor-made connected ecosystem diagram: Sugarkube deploys DSPACE, token.place, and danielsmith.io; Sugarkube hosts the token.place relay; token.place powers DSPACE dChat; danielsmith.io is the front door. Animate a feedback loop from application needs back to infrastructure improvements. Include a brief DSPACE dChat and NPC selector screen recording with visible "Powered by token.place" integration where practical.
 
-
-> 6:25–10:35: Electricity measurement and the efficiency-versus-agency tension
+### 6:25–10:35: Electricity measurement and the efficiency-versus-agency tension
 
 [NARRATOR]: My nine Raspberry Pi 5s each have 8 gigabytes of RAM, but only six are active, and even those are probably overkill for my traffic.
 
@@ -231,20 +203,17 @@
 
 [VISUAL]: Close-up lineup of Pi 5 boards and RAM labels, then the nine-slot overlay again with only six active nodes highlighted. Use A-roll for the Rampocalypse joke.
 
-
 [NARRATOR]: For a fair comparison, I disconnected the three unused Pis and measured the PoE+ switch, along with any external cooling used during normal operation, through a `<power meter model>`.
 
 [NARRATOR]: Over `<measurement duration>` during `<representative conditions or workload>`, the setup averaged `<average watts>` watts, peaked at `<peak watts>` watts, and consumed `<measured kilowatt-hours>` kilowatt-hours.
 
 [VISUAL]: Show the three unused Pis being disconnected, then the PoE+ switch and continuously running desk fan connected inside the measurement boundary. Capture the power meter display or logging interface at representative idle and workload moments. Add measured values as on-screen text placeholders matching the narration until final numbers are supplied.
 
-
 [NARRATOR]: Across an average 730-hour month, that becomes `<monthly kilowatt-hours>` kilowatt-hours.
 
 [NARRATOR]: At my marginal electricity rate of `<electricity rate>` per kilowatt-hour, it costs `<monthly electricity cost>` per month, or `<annual electricity cost>` per year.
 
 [VISUAL]: Simple calculator-style graphic: watts to monthly kWh to monthly and annual cost. Keep placeholders visible and clearly marked "final measured values pending."
-
 
 [NARRATOR]: That includes the switch, PoE losses, and cooling used during the test.
 
@@ -254,13 +223,11 @@
 
 [VISUAL]: Boundary diagram around the rack, PoE+ switch, cabling, and continuously running desk fan. Put router, modem, off-rack token.place compute nodes, and separate GPU computer outside the boundary with "excluded" labels.
 
-
 [NARRATOR]: For the cloud comparison, I modeled self-managed three-node staging and production clusters in one availability zone in AWS’s Oregon region.
 
 [NARRATOR]: The single availability zone mirrors the rack’s single-site failure domain.
 
 [VISUAL]: Screen recording of the AWS calculator or a clean editor-made architecture diagram showing two self-managed three-node k3s clusters in one Oregon availability zone. Label the single-site failure domain.
-
 
 [NARRATOR]: The model uses six on-demand Linux `c7g.xlarge` instances.
 
@@ -268,13 +235,11 @@
 
 [VISUAL]: Architecture card showing six `c7g.xlarge` instances with labels: "4 Arm vCPU" and "8 GiB memory." Add a qualification label: "Shape-matched, not performance-matched."
 
-
 [NARRATOR]: Each instance gets a 256 GiB gp3 volume and a public IPv4 address.
 
 [NARRATOR]: I kept k3s and Cloudflare Tunnel, excluding EKS, a managed load balancer, a NAT gateway, RDS, and managed observability.
 
 [VISUAL]: Add six 256 GiB gp3 volumes and six public IPv4 addresses to the AWS diagram. Include an on-screen exclusions list: EKS, managed load balancer, NAT gateway, RDS, managed observability.
-
 
 [NARRATOR]: Using AWS’s public rates from July 22, 2026, compute costs $635.10 per month, storage costs $122.88, and IPv4 addresses cost $21.90.
 
@@ -282,18 +247,15 @@
 
 [VISUAL]: Readable table or animated stack labeled "AWS pricing snapshot: July 22, 2026." Rows: compute $635.10, storage $122.88, IPv4 $21.90, total $779.88/month and $9,358.56/year. Add concise exclusions: taxes, data transfer, snapshots, expanded monitoring, backups, support.
 
-
 [NARRATOR]: Discounts, smaller instances, or shutting staging down could lower that bill substantially, but would change this always-on, shape-matched comparison.
 
 [VISUAL]: A-roll for the caveat with on-screen text: "Always-on, shape-matched comparison."
-
 
 [NARRATOR]: AWS does not publish the direct power consumption of an individual instance, so this compares cost rather than watts.
 
 [NARRATOR]: Its newer hardware and data-center economies may win on performance per watt, but this experiment did not prove that.
 
 [VISUAL]: A-roll. Add two simple labels: "Financial comparison" and "Not a watt-for-watt energy comparison."
-
 
 [NARRATOR]: The full nine-node build cost me `<full nine-node BOM total>`.
 
@@ -303,7 +265,6 @@
 
 [VISUAL]: Show real hardware, printed parts, cabling, redacted receipts, and the repository BOM. Create a simple comparison card for full nine-node total versus comparable six-node total, keeping placeholders until Daniel supplies final numbers.
 
-
 [NARRATOR]: If local electricity costs less than $779.88 per month, simple cash break-even occurs after `<break-even months>` months.
 
 [NARRATOR]: That is the comparable six-node cost divided by the monthly savings over AWS, rounded up.
@@ -312,20 +273,17 @@
 
 [VISUAL]: Show the formula: `comparable six-node cost / (AWS monthly cost - local monthly electricity cost)`. Optionally add a cumulative-cost line chart with the crossing point at the break-even month, plus a clear "No positive break-even" case when local monthly operating cost is greater than or equal to AWS.
 
-
 [NARRATOR]: This calculation also ignores my labor, failures, replacement parts, internet service, AWS discounts, and the value of managed infrastructure.
 
 [NARRATOR]: A real lifecycle comparison would need to include manufacturing, shipping, embodied energy, and indirect water use on both sides.
 
 [VISUAL]: A-roll for lifecycle limitations. Add a concise on-screen list of ignored factors without implying either side has zero indirect impact.
 
-
 [NARRATOR]: The rack itself uses no cooling water, unless you count what I drank while assembling it.
 
 [NARRATOR]: There is no dedicated air conditioning, humidity control, or liquid cooling; just onboard fans and a desk fan.
 
 [VISUAL]: Real shot of Daniel taking a drink for the joke, then close-ups of onboard fans and the continuously running desk fan. Avoid suggesting there is no indirect water use from electricity or manufacturing.
-
 
 [NARRATOR]: Running locally gives me more agency over energy use.
 
@@ -335,8 +293,7 @@
 
 [VISUAL]: Show the power meter, rack controls, terminal commands powering down or scaling environments, and deployment dashboards. Use licensed stock or real footage of solar panels, battery, and inverter only with a label: "Future off-grid goal."
 
-
-> 10:35–11:45: Participation and concluding vision
+### 10:35–11:45: Participation and concluding vision
 
 [NARRATOR]: All four projects are open source.
 
@@ -345,7 +302,6 @@
 [NARRATOR]: Even testing the documentation and telling me where it breaks would help.
 
 [VISUAL]: Screen montage of the four public repositories and apps: DSPACE gameplay and quest feedback path, danielsmith.io, token.place compute node or relay docs, and Sugarkube setup docs. Use restrained lower-thirds for each action.
-
 
 [NARRATOR]: Very few people need a micro data center at home.
 
@@ -357,13 +313,11 @@
 
 [VISUAL]: A-roll for the caveat, then practical shots of one Raspberry Pi, an old computer, the full yellow rack, and a simple Kubernetes learning diagram.
 
-
 [NARRATOR]: Long term, I plan to run Sugarkube from a dedicated off-grid solar, battery, and inverter system.
 
 [NARRATOR]: Subscribe if you want to see that process!
 
 [VISUAL]: Real or appropriately licensed stock footage of solar panels, battery, and inverter hardware labeled "Future plan." Pair the subscribe call to action with restrained on-screen text.
-
 
 [NARRATOR]: I started Sugarkube because deploying my projects kept getting in the way of building them.
 

--- a/video_scripts/README.md
+++ b/video_scripts/README.md
@@ -1,0 +1,40 @@
+# Video script workflow
+
+Each episode's `script.md` is the canonical editorial source. It is parsed into the normalized object validated by `schemas/video_script.schema.json`; use `python src/video_script_format.py --check video_scripts` (or `make check_scripts`) to validate all nested scripts and `--write` (or `make format_scripts`) to migrate supported legacy structure.
+
+## Canonical Markdown
+
+```markdown
+# Video title
+
+> Draft script for video `video-id-or-placeholder`
+
+## Outline
+
+- Optional outline entry
+
+## Script
+
+### Optional section heading
+
+[NARRATOR]: One complete spoken thought.
+
+[VISUAL]: The visual direction supporting that narration.
+```
+
+`Transcript` may replace `Draft script`; outline, section, and visual blocks are optional. Every body block is a one-line `###` section, `[NARRATOR]:`, or `[VISUAL]:` block separated by one blank line. Inline emphasis and narrator timing comments remain in `script.md`.
+
+## Prompter exports
+
+`prompter.txt` is generated and ignored, never canonical. Run:
+
+```bash
+python video_scripts/export_prompter.py --slug 20260901_sugarkube --allow-placeholders
+make prompter SLUG=20260901_sugarkube ALLOW_PLACEHOLDERS=1
+```
+
+The exporter removes directions and Markdown presentation syntax. Blank lines separate Prompter chapters. Scripts with visuals—including Sugarkube—group each narration run by the following visual beat; transcript-only scripts use one narrator segment per chapter. Normal exports reject spoken `<...>` placeholders; `--allow-placeholders` is for rehearsal only. Use `OUTPUT=path` or `--output PATH` for a custom destination.
+
+## Production planning
+
+An episode's `footage.md` is its production-plan master index and may link focused files under `production/`. Raw media stays in the ignored top-level `footage/` tree. Do not add `assets.json` before matching media directories exist.

--- a/video_scripts/drafts/3d-printed-rover/script.md
+++ b/video_scripts/drafts/3d-printed-rover/script.md
@@ -1,5 +1,6 @@
 # 3D-Printed Rover (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 

--- a/video_scripts/drafts/lunar-greenhouses/script.md
+++ b/video_scripts/drafts/lunar-greenhouses/script.md
@@ -1,5 +1,6 @@
 # Lunar Greenhouses (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 

--- a/video_scripts/drafts/micro-solar-desalination/script.md
+++ b/video_scripts/drafts/micro-solar-desalination/script.md
@@ -1,5 +1,6 @@
 # Micro Solar Desalination (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 

--- a/video_scripts/drafts/solar-aquaponic-mosquito-fighters/script.md
+++ b/video_scripts/drafts/solar-aquaponic-mosquito-fighters/script.md
@@ -1,5 +1,6 @@
 # Solar-Powered Aquaponic Mosquito Fighters (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 
@@ -14,4 +15,3 @@
 [NARRATOR]: Mosquito-eating fish like Gambusia keep larvae in check.
 
 [VISUAL]: Close-up of fish snapping up larvae near the surface.
-

--- a/video_scripts/drafts/solarpunk-weather-station/script.md
+++ b/video_scripts/drafts/solarpunk-weather-station/script.md
@@ -1,5 +1,6 @@
 # Solarpunk Weather Station (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 

--- a/video_scripts/export_prompter.py
+++ b/video_scripts/export_prompter.py
@@ -1,0 +1,89 @@
+"""Export canonical video narration as plain-text Prompter chapters."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.video_script_format import (  # noqa: E402
+    ScriptFormatError,
+    parse_script,
+    validate_document,
+)
+
+PLACEHOLDER_RE = re.compile(r"<[^>\n]+>")
+COMMENT_RE = re.compile(r"<!--.*?-->")
+LINK_RE = re.compile(r"!?\[([^]]+)\]\([^)]+\)")
+
+
+def plain_text(text: str) -> str:
+    """Remove non-spoken Markdown while retaining its visible text."""
+    text = COMMENT_RE.sub("", text)
+    text = LINK_RE.sub(r"\1", text)
+    text = text.replace("`", "")
+    text = re.sub(r"(\*\*|__|\*|_)(.+?)\1", r"\2", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def build_chapters(document: dict) -> tuple[list[str], int]:
+    narrators = [
+        segment for segment in document["segments"] if segment["type"] == "narrator"
+    ]
+    if not any(segment["type"] == "visual" for segment in document["segments"]):
+        return [plain_text(segment["text"]) for segment in narrators], len(narrators)
+    chapters: list[str] = []
+    current: list[str] = []
+    count = 0
+    for segment in document["segments"]:
+        if segment["type"] == "narrator":
+            current.append(plain_text(segment["text"]))
+            count += 1
+        elif segment["type"] == "visual" and current:
+            chapters.append(" ".join(current))
+            current = []
+    if current:
+        chapters.append(" ".join(current))
+    return chapters, count
+
+
+def export(
+    script: Path, output: Path, *, allow_placeholders: bool = False
+) -> tuple[int, int]:
+    document = parse_script(script.read_text(encoding="utf-8"))
+    validate_document(document)
+    chapters, narrator_count = build_chapters(document)
+    rendered = "\n\n".join(chapters) + "\n"
+    placeholders = sorted(set(PLACEHOLDER_RE.findall(rendered)))
+    if placeholders and not allow_placeholders:
+        raise ValueError("unresolved placeholders: " + ", ".join(placeholders))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+    return len(chapters), narrator_count
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--slug")
+    source.add_argument("--script", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--allow-placeholders", action="store_true")
+    args = parser.parse_args(argv)
+    script = args.script or REPO_ROOT / "video_scripts" / args.slug / "script.md"
+    output = args.output or script.parent / "prompter.txt"
+    try:
+        chapters, _ = export(script, output, allow_placeholders=args.allow_placeholders)
+    except (OSError, ValueError, ScriptFormatError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(f"Wrote {output} ({chapters} chapters)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/video_scripts/export_prompter.py
+++ b/video_scripts/export_prompter.py
@@ -8,7 +8,8 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from src.video_script_format import (  # noqa: E402
     ScriptFormatError,
@@ -26,7 +27,8 @@ def plain_text(text: str) -> str:
     text = COMMENT_RE.sub("", text)
     text = LINK_RE.sub(r"\1", text)
     text = text.replace("`", "")
-    text = re.sub(r"(\*\*|__|\*|_)(.+?)\1", r"\2", text)
+    text = re.sub(r"(?<!\w)(\*\*|__)(?=\S)(.+?)(?<=\S)\1(?!\w)", r"\2", text)
+    text = re.sub(r"(?<!\w)(\*|_)(?=\S)(.+?)(?<=\S)\1(?!\w)", r"\2", text)
     return re.sub(r"\s+", " ", text).strip()
 
 
@@ -57,6 +59,13 @@ def export(
     document = parse_script(script.read_text(encoding="utf-8"))
     validate_document(document)
     chapters, narrator_count = build_chapters(document)
+    empty_narrators = [
+        segment
+        for segment in document["segments"]
+        if segment["type"] == "narrator" and not plain_text(segment["text"])
+    ]
+    if empty_narrators and not allow_placeholders:
+        raise ValueError("narration is empty after removing non-spoken Markdown")
     rendered = "\n\n".join(chapters) + "\n"
     placeholders = sorted(set(PLACEHOLDER_RE.findall(rendered)))
     if placeholders and not allow_placeholders:

--- a/video_scripts/export_prompter.py
+++ b/video_scripts/export_prompter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -26,9 +27,10 @@ def plain_text(text: str) -> str:
     """Remove non-spoken Markdown while retaining its visible text."""
     text = COMMENT_RE.sub("", text)
     text = LINK_RE.sub(r"\1", text)
-    text = text.replace("`", "")
+    text = re.sub(r"`([^`]+)`", r"\1", text)
     text = re.sub(r"(?<!\w)(\*\*|__)(?=\S)(.+?)(?<=\S)\1(?!\w)", r"\2", text)
     text = re.sub(r"(?<!\w)(\*|_)(?=\S)(.+?)(?<=\S)\1(?!\w)", r"\2", text)
+    text = re.sub(r"(?<!~)~~(?=\S)(.+?)(?<=\S)~~(?!~)", r"\1", text)
     return re.sub(r"\s+", " ", text).strip()
 
 
@@ -64,14 +66,24 @@ def export(
         for segment in document["segments"]
         if segment["type"] == "narrator" and not plain_text(segment["text"])
     ]
-    if empty_narrators and not allow_placeholders:
+    if empty_narrators:
         raise ValueError("narration is empty after removing non-spoken Markdown")
     rendered = "\n\n".join(chapters) + "\n"
     placeholders = sorted(set(PLACEHOLDER_RE.findall(rendered)))
     if placeholders and not allow_placeholders:
         raise ValueError("unresolved placeholders: " + ", ".join(placeholders))
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(rendered, encoding="utf-8")
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=output.parent, delete=False
+        ) as handle:
+            handle.write(rendered)
+            temporary = Path(handle.name)
+        temporary.replace(output)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
     return len(chapters), narrator_count
 
 


### PR DESCRIPTION
### Motivation

- Enforce a single, auditable canonical format for `video_scripts/**/script.md` so tooling can parse/validate scripts deterministically. 
- Provide a reusable Prompter exporter that generates rehearsal-ready plain text from the canonical representation while protecting against unresolved spoken placeholders. 
- Include an explicit, rights-aware production plan for the Sugarkube episode that maps every visual beat to concrete asset IDs and checklists.

### Description

- Add a Draft-07 JSON schema for normalized scripts at `schemas/video_script.schema.json` and a shared parser/validator/formatter CLI at `src/video_script_format.py` that supports `--check` (read-only) and `--write` (migrate/format) modes and validates metadata `youtube_id` when present. 
- Add Prompter exporter `video_scripts/export_prompter.py` that reuses the script parser, groups narrator segments by visual beats (or falls back to one-chapter-per-segment), strips Markdown/timing/comments, rejects unresolved `<...>` placeholders by default, and supports `--allow-placeholders` and custom `--output` paths. Added `.gitignore` rule to ignore generated `prompter.txt`. 
- Add Sugarkube production planning files under `video_scripts/20260901_sugarkube/`: `footage.md` (master index with media policy, pre-production gates, V01–V42 chronological mapping, and audit checklist) and `production/{broll.md,stock.md,graphics.md}` with exhaustive non-duplicated asset checklists and rights-ledger guidance; tests verify mapping completeness and unique asset IDs. 
- Update script-generating helpers to emit canonical output (`src/srt_to_markdown.py`, `src/generate_scripts_from_subtitles.py`, `src/scaffold_videos.py`) and add `video_scripts/README.md` documenting canonical format and exporter usage. 
- Add Makefile targets `check_scripts`, `format_scripts`, and `prompter` and a read-only pre-commit hook to run script validation. 
- Add unit/CLI tests: `tests/test_video_script_format.py`, `tests/test_export_prompter.py`, and `tests/test_sugarkube_production_assets.py` plus minor adjustments so existing generation/indexing helpers use the shared parser. 

### Testing

- Ran canonical format migration and validation: `python src/video_script_format.py --write video_scripts` (scripts migrated/normalized) and `python src/video_script_format.py --check video_scripts` (report/read-only validation) — succeeded. 
- Exercised Prompter exporter on Sugarkube: `python video_scripts/export_prompter.py --slug 20260901_sugarkube --allow-placeholders --output /tmp/sugarkube-prompter.txt` — produced `42` chapters (Sugarkube invariant); default export without `--allow-placeholders` exited nonzero and printed the unresolved placeholders without leaving a partial output file. 
- Ran the repository test suite and linters on changed code: `make check_scripts` plus `make test` / `pytest -q` — full suite completed successfully (`389 passed`, 2 non-failing warnings reported during the run); focused unit tests for the new code passed (added tests exercised parsing/formatting, Prompter grouping, placeholder behavior, idempotence, and production-asset validations). 
- Ran style checks: `black --check` and `ruff check` on changed files — passed. 

If reviewers want a targeted follow-up, I can split the formatter, exporter, and Sugarkube production documents into separate PRs, or tighten CLI UX (e.g. explicit `--chapters-by-visual` flag) — but this change keeps a single shared parser to avoid duplicated parsing logic and preserves all narrator/visual text, punctuation, and inline timing comments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6416095d5c832fbf622bccd7a96fe0)