### PR TITLE
Add canonical video-script schema, formatter, Prompter exporter, and Sugarkube production plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build/
 
 # rendered media outputs (keep source scripts in git)
 video_scripts/*/rendered*/
+video_scripts/**/prompter.txt
 
 # reference files fetched via collect_sources
 # per-video sources directories

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
         entry: python scripts/validate_outages.py
         language: system
         pass_filenames: false
+      - id: video-script-format
+        name: validate canonical video scripts
+        entry: python src/video_script_format.py --check video_scripts
+        language: system
+        pass_filenames: false
       - id: ruff
         name: ruff
         entry: python -m ruff check --fix .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@ Avoid adding setup, asset, or automation instructions there; link to `docs/repos
 
 ## Script Format
 
+`script.md` is the canonical editorial source and must pass `python
+src/video_script_format.py --check video_scripts`; use `--write` to normalize
+structural formatting. Its parsed representation is validated against
+`schemas/video_script.schema.json`.
+
 Video scripts (`video_scripts/YYYYMMDD_slug/script.md`) combine narration and stage
 directions. Use `[NARRATOR]:` for spoken lines and `[VISUAL]:` for b-roll or
 graphics cues. Insert `[VISUAL]` lines directly after the dialogue they support
@@ -63,7 +68,8 @@ instead of collecting them at the end.
 - Each script folder must include a `metadata.json` file conforming to `schemas/video_metadata.schema.json`. Optional fields like `slug`, `thumbnail`, `transcript_file`, and `summary` enrich automation but aren't required.
 - Each script folder may include an `assets.json` file conforming to `schemas/assets_manifest.schema.json` that lists associated `footage/` directories, optional label files, tags, and capture date.
 - Each script folder may include a `sources.txt` file with one URL per line. Any downloaded articles or clips are for reference only—check usage rights and cite sources in **APA style** rather than redistributing content.
-- Each script folder may also contain a `footage.md` checklist to track B-roll or CGI shots to gather. Note existing archive vs new footage, and flag generative AI segments so they don't look like "AI slop".
+- Each script folder may also contain a canonical `footage.md` production index with linked detailed planning files. Raw media remains in the ignored top-level `footage/` tree.
+- `prompter.txt` is generated and ignored. The exporter groups narration by visual beat when cues exist (including Sugarkube), while transcript-only narration becomes one chapter per segment; blank lines separate chapters.
 - Large photos or video files belong in a local `footage/` folder (ignored by git).
   Run `python src/index_local_media.py` whenever assets change to rebuild
   `footage_index.json` for quick lookup during editing. Use `--exclude PATH`
@@ -149,4 +155,3 @@ Tests under `tests/` cover folder naming (`test_folder_names.py`), schema valida
 
 ---
 *For creative context, tone, and thematic constraints refer to [`llms.txt`](llms.txt).* 
-

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 
 VENV := .venv
 ifeq ($(OS),Windows_NT)
-    PY := $(VENV)/Scripts/python
+	PY := $(if $(wildcard $(VENV)/Scripts/python.exe),$(VENV)/Scripts/python,python)
     REMOVE := rmdir /s /q
     CLEANCACHE := del /s /q **\__pycache__
 else
-    PY := $(VENV)/bin/python
+	PY := $(if $(wildcard $(VENV)/bin/python),$(VENV)/bin/python,python)
     REMOVE := rm -rf
     CLEANCACHE := find . -name '__pycache__' -type d -exec rm -rf {} +
 endif
@@ -14,9 +14,9 @@ PIP := uv pip
 
 # NOTE: Keep recipe indentation as tabs; GNU Make treats spaces as errors.
 .PHONY: help setup test subtitles clean fmt index_footage index_assets describe_images \
-        convert_assets verify_assets convert_missing convert_all report_funnel newsletter \
-        process update_metadata scripts_from_subtitles assets_manifest render upload_video \
-        format lint typecheck serve serve-http
+	convert_assets verify_assets convert_missing convert_all report_funnel newsletter \
+	process update_metadata scripts_from_subtitles assets_manifest render upload_video \
+	format lint typecheck serve serve-http check_scripts format_scripts prompter
 
 help:
 	@echo "Targets:"
@@ -32,12 +32,25 @@ help:
 	@echo "  verify_assets  Verify converted/ matches originals/ dimensions/aspect"
 	@echo "  convert_missing Convert only missing items from verify_report.json"
 	@echo "  scripts_from_subtitles Generate script.md files from subtitles"
-        @echo "  convert_all    Convert images+videos for all footage (or SLUG=...)"
-        @echo "  report_funnel  Write selections.json for a slug (use SLUG=...)"
-        @echo "  assets_manifest Generate assets.json from footage (SLUG=... OVERWRITE=1)"
-        @echo "  newsletter    Generate newsletter markdown (SINCE=YYYY-MM-DD STATUS=live OUTPUT=path)"
+	@echo "  convert_all    Convert images+videos for all footage (or SLUG=...)"
+	@echo "  report_funnel  Write selections.json for a slug (use SLUG=...)"
+	@echo "  assets_manifest Generate assets.json from footage (SLUG=... OVERWRITE=1)"
+	@echo "  newsletter    Generate newsletter markdown (SINCE=YYYY-MM-DD STATUS=live OUTPUT=path)"
 	@echo "  update_metadata  Refresh metadata via YouTube API (SLUG=...)"
 	@echo "  process       One-command: convert+verify+report (requires SLUG=...)"
+	@echo "  check_scripts Validate canonical video scripts (read-only)"
+	@echo "  format_scripts Canonically format every video script"
+	@echo "  prompter      Export narration (requires SLUG=...)"
+
+check_scripts:
+	$(PY) src/video_script_format.py --check video_scripts
+
+format_scripts:
+	$(PY) src/video_script_format.py --write video_scripts
+
+prompter:
+	@if [ -z "$(SLUG)" ]; then echo "Usage: make prompter SLUG=YYYYMMDD_slug [OUTPUT=path] [ALLOW_PLACEHOLDERS=1]"; exit 1; fi
+	$(PY) video_scripts/export_prompter.py --slug $(SLUG) $(if $(OUTPUT),--output $(OUTPUT),) $(if $(ALLOW_PLACEHOLDERS),--allow-placeholders,)
 
 setup:
 	python -m venv $(VENV)
@@ -50,16 +63,16 @@ subtitles:
 	$(PY) src/fetch_subtitles.py
 
 fmt:
-        $(PY) -m black .
-        $(PY) -m ruff check --fix .
+	$(PY) -m black .
+	$(PY) -m ruff check --fix .
 
 format: fmt
 
 lint:
-        $(PY) -m ruff check tools/youtube_mcp tests
+	$(PY) -m ruff check tools/youtube_mcp tests
 
 typecheck:
-        $(PY) -m mypy tools/youtube_mcp
+	$(PY) -m mypy tools/youtube_mcp
 
 clean:
 	@$(REMOVE) $(VENV) 2>/dev/null || true
@@ -100,16 +113,16 @@ report_funnel:
 	$(PY) src/report_funnel.py --slug $(SLUG) $(if $(SELECTS),--selects-file $(SELECTS),)
 
 assets_manifest:
-        $(PY) src/generate_assets_manifest.py \
-                $(if $(SLUG),--slug $(SLUG),) \
-                $(if $(FOOTAGE),--footage-root $(FOOTAGE),) \
-                $(if $(OVERWRITE),--overwrite,) \
-                $(if $(DRY_RUN),--dry-run,)
+	$(PY) src/generate_assets_manifest.py \
+	        $(if $(SLUG),--slug $(SLUG),) \
+	        $(if $(FOOTAGE),--footage-root $(FOOTAGE),) \
+	        $(if $(OVERWRITE),--overwrite,) \
+	        $(if $(DRY_RUN),--dry-run,)
 
 newsletter:
-        $(PY) src/newsletter_builder.py \
-                $(if $(OUTPUT),--output $(OUTPUT),) \
-                $(if $(SINCE),--since $(SINCE),) \
+	$(PY) src/newsletter_builder.py \
+	        $(if $(OUTPUT),--output $(OUTPUT),) \
+	        $(if $(SINCE),--since $(SINCE),) \
 		$(if $(STATUS),--status $(STATUS),) \
 		$(if $(LIMIT),--limit $(LIMIT),) \
 		$(if $(DATE),--date $(DATE),)
@@ -123,23 +136,23 @@ process:
 	$(PY) src/report_funnel.py --slug $(SLUG) $(if $(SELECTS),--selects-file $(SELECTS),)
 
 render:
-        @if [ -z "$(VIDEO)" ]; then echo "Usage: make render VIDEO=YYYYMMDD_slug [CAPTIONS=path]"; exit 1; fi
-        $(PY) src/render_video.py \
-                --slug $(VIDEO) \
-                $(if $(FOOTAGE),--footage-root $(FOOTAGE),) \
-                $(if $(OUTPUT),--output-dir $(OUTPUT),) \
-                $(if $(CAPTIONS),--captions $(CAPTIONS),)
+	@if [ -z "$(VIDEO)" ]; then echo "Usage: make render VIDEO=YYYYMMDD_slug [CAPTIONS=path]"; exit 1; fi
+	$(PY) src/render_video.py \
+	        --slug $(VIDEO) \
+	        $(if $(FOOTAGE),--footage-root $(FOOTAGE),) \
+	        $(if $(OUTPUT),--output-dir $(OUTPUT),) \
+	        $(if $(CAPTIONS),--captions $(CAPTIONS),)
 
 upload_video:
-        @if [ -z "$(SLUG)" ]; then echo "Usage: make upload_video SLUG=YYYYMMDD_slug [VIDEO=path] [CLIENT=client.json] [TOKEN=token.json]"; exit 1; fi
-        $(PY) src/upload_to_youtube.py \
-                --slug $(SLUG) \
-                $(if $(VIDEO),--video $(VIDEO),) \
-                $(if $(CLIENT),--client-secrets $(CLIENT),) \
-                $(if $(TOKEN),--credentials $(TOKEN),)
+	@if [ -z "$(SLUG)" ]; then echo "Usage: make upload_video SLUG=YYYYMMDD_slug [VIDEO=path] [CLIENT=client.json] [TOKEN=token.json]"; exit 1; fi
+	$(PY) src/upload_to_youtube.py \
+	        --slug $(SLUG) \
+	        $(if $(VIDEO),--video $(VIDEO),) \
+	        $(if $(CLIENT),--client-secrets $(CLIENT),) \
+	        $(if $(TOKEN),--credentials $(TOKEN),)
 
 serve:
-        $(PY) tools/youtube_mcp/mcp_server.py
+	$(PY) tools/youtube_mcp/mcp_server.py
 
 serve-http:
-        $(PY) -m tools.youtube_mcp $(if $(HOST),--host $(HOST),) $(if $(PORT),--port $(PORT),)
+	$(PY) -m tools.youtube_mcp $(if $(HOST),--host $(HOST),) $(if $(PORT),--port $(PORT),)

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -167,3 +167,11 @@ Before committing, format code, run focused tests, and scan staged changes for c
 ```bash
 git diff --cached | ./scripts/scan-secrets.py
 ```
+
+## Canonical scripts, Prompter, and production plans
+
+Video `script.md` files are canonical and validated with `make check_scripts`; use `make format_scripts` for deterministic structural normalization. See [`video_scripts/README.md`](../video_scripts/README.md) for the schema and format.
+
+Generate a disposable Prompter file with `make prompter SLUG=YYYYMMDD_slug`. Set `OUTPUT=path` for a custom destination and `ALLOW_PLACEHOLDERS=1` only for rehearsal. Blank lines delimit chapters; cue-bearing scripts such as Sugarkube group narration by visual beat. Generated `prompter.txt` files are ignored.
+
+Production planning lives in each video's `footage.md` and its linked `production/` checklists. Raw media remains in the ignored top-level `footage/` tree.

--- a/llms.txt
+++ b/llms.txt
@@ -19,6 +19,9 @@ Every commit is public training data—write informative commit messages.
 - Use `pathlib` for cross-platform paths; keep dependencies minimal.
 
 Script format:
+- `video_scripts/**/script.md` is canonical and checked/formatted with `src/video_script_format.py` against `schemas/video_script.schema.json`.
+- Generated `prompter.txt` files are ignored; blank-line-separated chapters group narration by visual beat, or by narrator segment for transcripts.
+- Production planning belongs in `footage.md` and linked `production/` files; raw media remains in the ignored top-level `footage/` tree.
 - `srt_to_markdown.py` converts `.srt` captions into Futuroptimist script format, handling
   italics and bold tags (`<i>/<em>` and `<b>/<strong>`, even with attributes), line breaks,
   emoji, case-insensitive HTML tags, removing speaker prefixes, stripping other tags,
@@ -51,7 +54,7 @@ Script format:
 - Leave a blank line between narration and visuals.
 - Each script folder includes a `metadata.json` validated against `schemas/video_metadata.schema.json`.
 - Each script folder may also contain a `sources.txt` file with one URL per line. Downloaded articles or clips are for citation/reference only—check usage rights and cite in **APA style** rather than redistributing.
-- Each script folder may also have a `footage.md` file listing required shots (archive vs new, CGI or generative). Mark generative items to avoid obvious "AI slop".
+- Each script folder may also have a canonical `footage.md` production index with linked detailed planning files.
 - Run `python src/index_local_media.py` to rebuild `footage_index.json`, which lists
   file paths, UTC modification times, file sizes, **and a `kind`
   classification (`image`, `video`, `audio`, or `other`)** for assets stored

--- a/schemas/video_script.schema.json
+++ b/schemas/video_script.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/futuroptimist/futuroptimist/schemas/video_script.schema.json",
+  "title": "Normalized Futuroptimist video script",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "title", "document_kind", "video_id", "segments"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "title": {"type": "string", "minLength": 1},
+    "document_kind": {"enum": ["draft", "transcript"]},
+    "video_id": {"type": "string", "minLength": 1},
+    "outline": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "segments": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "type": "object", "additionalProperties": false,
+            "required": ["type", "text"],
+            "properties": {"type": {"enum": ["section", "visual"]}, "text": {"type": "string", "minLength": 1}}
+          },
+          {
+            "type": "object", "additionalProperties": false,
+            "required": ["type", "text"],
+            "properties": {"type": {"const": "narrator"}, "text": {"type": "string", "minLength": 1}, "timing": {"type": "string", "minLength": 1}}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/generate_scripts_from_subtitles.py
+++ b/src/generate_scripts_from_subtitles.py
@@ -86,10 +86,7 @@ def generate_scripts(
         entries = srt_to_markdown.parse_srt(transcript_path)
         title = str(data.get("title") or slug_dir.name.replace("_", " ").title())
         markdown = srt_to_markdown.to_markdown(entries, title, youtube_id)
-        if not markdown.endswith("\n"):
-            markdown += "\n"
-        if not markdown.endswith("\n\n"):
-            markdown += "\n"
+        markdown = markdown.rstrip("\n") + "\n"
         if dry_run:
             written.append(script_path)
             continue

--- a/src/scaffold_videos.py
+++ b/src/scaffold_videos.py
@@ -17,6 +17,7 @@ TEMPLATE_MD = """# {title}
 ## Script
 
 [NARRATOR]: <!-- narrator lines here -->
+
 [VISUAL]: <!-- b-roll, graphics, or stage directions -->
 """
 

--- a/src/video_script_format.py
+++ b/src/video_script_format.py
@@ -1,0 +1,219 @@
+"""Parse, validate, and canonically format Futuroptimist video scripts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "schemas" / "video_script.schema.json"
+SOURCE_RE = re.compile(r"^> (Draft script|Transcript) for video `([^`]+)`$")
+LEGACY_SOURCE_RE = re.compile(r"^> YouTube ID:\s*(\S+)\s*$")
+TAG_RE = re.compile(r"^\[(NARRATOR|VISUAL)\]:\s?(.*)$")
+TIMING_RE = re.compile(r"\s*<!--\s*(.*?)\s*-->\s*$")
+
+
+class ScriptFormatError(ValueError):
+    """An actionable script parsing or validation error."""
+
+    def __init__(self, line: int, message: str):
+        super().__init__(message)
+        self.line = line
+
+
+@dataclass
+class ParsedScript:
+    data: dict
+
+
+def parse_script(text: str, *, migrate: bool = False) -> ParsedScript:
+    """Parse Markdown into the normalized schema representation."""
+    lines = text.splitlines()
+    if not lines or not lines[0].startswith("# ") or not lines[0][2:].strip():
+        raise ScriptFormatError(1, "expected one nonempty '# Video title' heading")
+    title = lines[0][2:]
+    source_index = next(
+        (i for i, line in enumerate(lines[1:], 1) if line.strip()), None
+    )
+    if source_index is None:
+        raise ScriptFormatError(2, "missing canonical source blockquote")
+    source = SOURCE_RE.fullmatch(lines[source_index])
+    if source:
+        kind = "draft" if source.group(1) == "Draft script" else "transcript"
+        video_id = source.group(2)
+    elif migrate and (legacy := LEGACY_SOURCE_RE.fullmatch(lines[source_index])):
+        kind, video_id = "draft", legacy.group(1)
+    else:
+        raise ScriptFormatError(
+            source_index + 1, "expected canonical Draft script or Transcript blockquote"
+        )
+    if not video_id.strip():
+        raise ScriptFormatError(source_index + 1, "video identifier must not be empty")
+
+    script_index = next(
+        (i for i, line in enumerate(lines) if line == "## Script"), None
+    )
+    if script_index is None:
+        raise ScriptFormatError(1, "missing '## Script' heading")
+    outline: list[str] = []
+    outline_index = next(
+        (i for i, line in enumerate(lines) if line == "## Outline"), None
+    )
+    if outline_index is not None:
+        if outline_index > script_index:
+            raise ScriptFormatError(outline_index + 1, "Outline must precede Script")
+        for i in range(outline_index + 1, script_index):
+            line = lines[i]
+            if not line:
+                continue
+            if not line.startswith("- ") or not line[2:].strip():
+                raise ScriptFormatError(
+                    i + 1, "outline entries must use '- nonempty text'"
+                )
+            outline.append(line[2:])
+    elif migrate:
+        between = lines[source_index + 1 : script_index]
+        if any(line == "> Draft outline" for line in between):
+            for line in between:
+                if line.startswith("> ") and line != "> Draft outline":
+                    value = line[2:].strip()
+                    if value:
+                        outline.append(value)
+    elif any(line.strip() for line in lines[source_index + 1 : script_index]):
+        line_no = source_index + 2
+        raise ScriptFormatError(line_no, "unexpected content before '## Script'")
+
+    segments: list[dict] = []
+    for i in range(script_index + 1, len(lines)):
+        line = lines[i]
+        if not line:
+            continue
+        if line.startswith("### ") and line[4:].strip():
+            segments.append({"type": "section", "text": line[4:]})
+            continue
+        if migrate and line.startswith("> ") and line[2:].strip():
+            segments.append({"type": "section", "text": line[2:]})
+            continue
+        match = TAG_RE.fullmatch(line)
+        if not match:
+            raise ScriptFormatError(
+                i + 1, "script body must be a section, [NARRATOR]:, or [VISUAL]: block"
+            )
+        segment_type = match.group(1).lower()
+        value = match.group(2)
+        if not value.strip():
+            raise ScriptFormatError(i + 1, f"empty {segment_type} segment")
+        segment: dict[str, str] = {"type": segment_type, "text": value}
+        if segment_type == "narrator" and (timing := TIMING_RE.search(value)):
+            segment["timing"] = timing.group(1)
+        segments.append(segment)
+    if not segments:
+        raise ScriptFormatError(
+            script_index + 1, "script must contain at least one segment"
+        )
+    data: dict = {
+        "schema_version": "1.0",
+        "title": title,
+        "document_kind": kind,
+        "video_id": video_id,
+        "segments": segments,
+    }
+    if outline:
+        data["outline"] = outline
+    return ParsedScript(data)
+
+
+def format_script(parsed: ParsedScript) -> str:
+    """Render a parsed script in deterministic canonical Markdown."""
+    data = parsed.data
+    label = "Draft script" if data["document_kind"] == "draft" else "Transcript"
+    blocks = [f"# {data['title']}", f"> {label} for video `{data['video_id']}`"]
+    if data.get("outline"):
+        blocks.extend(
+            ["## Outline", "\n".join(f"- {item}" for item in data["outline"])]
+        )
+    blocks.append("## Script")
+    for segment in data["segments"]:
+        if segment["type"] == "section":
+            blocks.append(f"### {segment['text']}")
+        else:
+            blocks.append(f"[{segment['type'].upper()}]: {segment['text']}")
+    return "\n\n".join(blocks) + "\n"
+
+
+def validate_script(path: Path, *, migrate: bool = False) -> tuple[ParsedScript, str]:
+    text = path.read_text(encoding="utf-8")
+    parsed = parse_script(text, migrate=migrate)
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = sorted(
+        Draft7Validator(schema).iter_errors(parsed.data),
+        key=lambda error: list(error.path),
+    )
+    if errors:
+        raise ScriptFormatError(1, f"schema: {errors[0].message}")
+    metadata_path = path.with_name("metadata.json")
+    if metadata_path.exists():
+        metadata_id = str(
+            json.loads(metadata_path.read_text(encoding="utf-8")).get("youtube_id", "")
+        ).strip()
+        if metadata_id and parsed.data["video_id"] not in {
+            metadata_id,
+            "draft",
+            "<youtube_id>",
+        }:
+            raise ScriptFormatError(
+                source_line(path),
+                f"video identifier does not match metadata.json ({metadata_id})",
+            )
+    return parsed, text
+
+
+def source_line(path: Path) -> int:
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if line.startswith("> "):
+            return number
+    return 1
+
+
+def discover_scripts(path: Path) -> list[Path]:
+    return [path] if path.is_file() else sorted(path.rglob("script.md"))
+
+
+def run(paths: list[Path], *, write: bool) -> int:
+    failed = False
+    for path in paths:
+        try:
+            parsed, original = validate_script(path, migrate=write)
+            canonical = format_script(parsed)
+            if write:
+                if canonical != original:
+                    path.write_text(canonical, encoding="utf-8")
+                    print(f"formatted {path}")
+            elif canonical != original:
+                raise ScriptFormatError(
+                    1, "file is not canonically formatted; run with --write"
+                )
+        except (ScriptFormatError, json.JSONDecodeError) as exc:
+            failed = True
+            print(f"{path}:{getattr(exc, 'line', 1)}: {exc}", file=sys.stderr)
+    return int(failed)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true")
+    mode.add_argument("--write", action="store_true")
+    parser.add_argument("path", type=Path)
+    args = parser.parse_args(argv)
+    return run(discover_scripts(args.path), write=args.write)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_export_prompter.py
+++ b/tests/test_export_prompter.py
@@ -1,0 +1,63 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from src.video_script_format import parse_script
+from video_scripts.export_prompter import build_chapters, plain_text
+
+
+def test_cleanup_and_visual_grouping():
+    text = """# T
+
+> Draft script for video `draft`
+
+## Script
+
+[NARRATOR]: **Hello** [world](https://example.test). <!-- time -->
+
+[NARRATOR]: `Code`.
+
+[VISUAL]: Cue.
+"""
+    chapters, count = build_chapters(parse_script(text).data)
+    assert chapters == ["Hello world. Code."]
+    assert count == 2
+    assert plain_text("_one_ ~~two~~") == "one two"
+
+
+def test_transcript_fallback():
+    text = (
+        "# T\n\n> Transcript for video `id`\n\n## Script\n\n"
+        "[NARRATOR]: One.\n\n[NARRATOR]: Two.\n"
+    )
+    assert build_chapters(parse_script(text).data)[0] == ["One.", "Two."]
+
+
+def test_cli_placeholders_custom_paths_and_no_partial_output(tmp_path):
+    script = tmp_path / "script.md"
+    output = tmp_path / "out.txt"
+    script.write_text(
+        "# T\n\n> Draft script for video `draft`\n\n## Script\n\n[NARRATOR]: Say <name>.\n"
+    )
+    cmd = [
+        sys.executable,
+        "video_scripts/export_prompter.py",
+        "--script",
+        str(script),
+        "--output",
+        str(output),
+    ]
+    failed = subprocess.run(cmd, capture_output=True, text=True)
+    assert failed.returncode and "<name>" in failed.stderr and not output.exists()
+    assert not subprocess.run([*cmd, "--allow-placeholders"]).returncode
+    assert output.read_text() == "Say <name>.\n"
+
+
+def test_sugarkube_invariant():
+    path = Path("video_scripts/20260901_sugarkube/script.md")
+    chapters, count = build_chapters(parse_script(path.read_text()).data)
+    assert (len(chapters), count) == (42, 109)
+    output = "\n\n".join(chapters) + "\n"
+    assert all(
+        marker not in output for marker in ("[NARRATOR]", "[VISUAL]", "<!--", "## ")
+    )

--- a/tests/test_sugarkube_production.py
+++ b/tests/test_sugarkube_production.py
@@ -1,0 +1,21 @@
+import re
+from pathlib import Path
+
+
+def test_production_coverage_and_asset_definitions():
+    root = Path("video_scripts/20260901_sugarkube")
+    master = (root / "footage.md").read_text()
+    details = ["production/broll.md", "production/stock.md", "production/graphics.md"]
+    assert all(f"]({path})" in master for path in details)
+    cues = re.findall(r"^\| (V\d{2}) \|", master, re.MULTILINE)
+    assert cues == [f"V{i:02}" for i in range(1, 43)]
+    definitions = []
+    for relative in details:
+        definitions += re.findall(
+            r"^- \[.\] \*\*([ABCTG]\d{2})\*\*",
+            (root / relative).read_text(),
+            re.MULTILINE,
+        )
+    assert len(definitions) == len(set(definitions))
+    references = set(re.findall(r"`([ABCTG]\d{2})`", master))
+    assert references == set(definitions)

--- a/tests/test_video_script_format.py
+++ b/tests/test_video_script_format.py
@@ -1,0 +1,77 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.video_script_format import ScriptFormatError, format_script, parse_script
+
+BASE = """# Title
+
+> Draft script for video `draft`
+
+## Script
+
+[NARRATOR]: Hello. <!-- 00:00 -> 00:01 -->
+
+[VISUAL]: Wave.
+"""
+
+
+def test_valid_variants_and_round_trip():
+    parsed = parse_script(BASE)
+    assert parsed.data["segments"][0]["timing"] == "00:00 -> 00:01"
+    assert format_script(parsed) == BASE
+    transcript = BASE.replace("Draft script", "Transcript").replace(
+        "\n[VISUAL]: Wave.\n", "\n"
+    )
+    assert parse_script(transcript).data["document_kind"] == "transcript"
+    outlined = BASE.replace(
+        "## Script", "## Outline\n\n- Hook\n\n## Script\n\n### Opening"
+    )
+    assert parse_script(outlined).data["outline"] == ["Hook"]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "# Title\n\n## Script\n\n[NARRATOR]: Hi.\n",
+        "# Title\n\n> Draft script for video `draft`\n",
+        BASE.replace("[NARRATOR]: Hello. <!-- 00:00 -> 00:01 -->", "[NARRATOR]:"),
+        BASE.replace("[NARRATOR]", "[SPEAKER]"),
+        BASE.replace("[VISUAL]: Wave.", "plain prose"),
+    ],
+)
+def test_invalid_documents(text):
+    with pytest.raises(ScriptFormatError):
+        parse_script(text)
+
+
+def test_legacy_migration_is_idempotent_and_preserves_text():
+    legacy = (
+        "# T\n> YouTube ID: draft\n\n## Script\n> 0:00 Intro\n"
+        "[NARRATOR]: Exact *words*.\n[VISUAL]: Exact cue.\n"
+    )
+    once = format_script(parse_script(legacy, migrate=True))
+    assert format_script(parse_script(once, migrate=True)) == once
+    assert "Exact *words*." in once and "Exact cue." in once
+
+
+def test_cli_check_write_recursive_and_metadata_mismatch(tmp_path):
+    script = tmp_path / "drafts" / "x" / "script.md"
+    script.parent.mkdir(parents=True)
+    script.write_text("# T\n> YouTube ID: draft\n## Script\n[NARRATOR]: Hi.\n")
+    tool = Path("src/video_script_format.py")
+    assert subprocess.run([sys.executable, tool, "--check", tmp_path]).returncode
+    assert not subprocess.run([sys.executable, tool, "--write", tmp_path]).returncode
+    assert not subprocess.run([sys.executable, tool, "--check", tmp_path]).returncode
+    script.with_name("metadata.json").write_text(json.dumps({"youtube_id": "real"}))
+    script.write_text(script.read_text().replace("`draft`", "`wrong`"))
+    assert subprocess.run([sys.executable, tool, "--check", tmp_path]).returncode
+
+
+def test_all_repository_scripts_are_canonical():
+    for path in Path("video_scripts").rglob("script.md"):
+        assert format_script(parse_script(path.read_text())) == path.read_text()

--- a/video_scripts/20210917_how-tesla-bots-could-benefit-humanity/script.md
+++ b/video_scripts/20210917_how-tesla-bots-could-benefit-humanity/script.md
@@ -4,7 +4,6 @@
 
 ## Script
 
-
 [NARRATOR]: Elon Musk unveiled Tesla's upcoming humanoid robot, dubbed Tesla Bot, at Tesla AI Day on August 19th, 2021.
 
 [NARRATOR]: While the bot is only a concept right now, they'll supposedly have a prototype arrive as soon as 2022.

--- a/video_scripts/20211001_why-tesla-s-full-self-driving-is-taking-so-long/script.md
+++ b/video_scripts/20211001_why-tesla-s-full-self-driving-is-taking-so-long/script.md
@@ -157,4 +157,3 @@
 [NARRATOR]: That's it for this video. I'd greatly appreciate if you smashed that subscribe button and let me know in the comments if you have any criticisms or suggestions for future videos.
 
 [NARRATOR]: I'll see you in the next one.
-

--- a/video_scripts/20211015_things-we-need-to-figure-out-before-sending-humans-to-mars-starship-microgravity-and-radiation/script.md
+++ b/video_scripts/20211015_things-we-need-to-figure-out-before-sending-humans-to-mars-starship-microgravity-and-radiation/script.md
@@ -1,76 +1,147 @@
 # Things we need to figure out before sending humans to Mars - Starship, microgravity, and radiation
+
 > Transcript for video `whafgZUxj0Q`
 
 ## Script
 
 [NARRATOR]: Every single human that's ever lived has been limited to this one pale blue dot in a universe teeming with mystery and opportunity.
+
 [NARRATOR]: In order to expand the scope of human consciousness, we must journey beyond the orbit of our planet and become multiplanetary.
+
 [NARRATOR]: For a variety of reasons, the planet Mars is the next logical step in our cosmic journey, and we'll likely see the first human boot on Mars before the end of the decade.
+
 [NARRATOR]: However, before we make the difficult journey to the red planet, there are a number of challenges that must be solved, and I'll talk about most of them in this video.
+
 [NARRATOR]: This is not an exhaustive list, but I'll attempt to cover as much ground as possible.
+
 [NARRATOR]: We'll talk about the transportation side, the hazards humans will face along the way, as well as what we'll need to do to ensure a return trip.
+
 [NARRATOR]: Let's start with the very obvious first step, SpaceX's Starship rocket, which is likely to be the first rocket to get humans to Mars.
+
 [NARRATOR]: The Starship system is most notably going to be the world's first rapidly and fully reusable orbital rocket, which, in Elon's words, is the fundamental technology revolution needed to make life multiplanetary.
+
 [NARRATOR]: We're currently still waiting for the first orbital flight of the Starship system, consisting of the first stage, named B4, and the second stage, named S20.
+
 [NARRATOR]: S20 recently underwent a Cryo Proof test and is awaiting static fires along with B4, and we're still blocked on the FAA's Environmental Assessment of the launch site.
+
 [NARRATOR]: However, B5 and S21 are already nearing completion, and the momentum at Starbase, Texas, doesn't seem like it's going to stop anytime soon.
+
 [NARRATOR]: Once Starship is able to achieve orbit, reentry, and landing, the next milestone for the program is orbital refueling.
+
 [NARRATOR]: This is critical for getting a non-trivial amount of payload to the Moon or to Mars.
+
 [NARRATOR]: A Starship in orbit can be fully refueled by launching special Tanker Starships, which will rendezvous with the ship that's carrying payload.
+
 [NARRATOR]: There are a lot of other details here like possible fuel depots, but that's out of scope for this video.
+
 [NARRATOR]: SpaceX has a contract for a future crewed Lunar mission with NASA, and assuming the Starship program is successful and NASA solves all of its equipment challenges, we should see an uncrewed Lunar landing by SpaceX followed by a crewed Lunar landing in collaboration with NASA, sometimes around 2025.
+
 [NARRATOR]: Regardless of the Lunar mission timeline, SpaceX could start sending some uncrewed Starships to Mars as soon as the orbital refueling milestone is met, possibly even with a few Tesla Bot prototypes.
+
 [NARRATOR]: At any rate, it'll certainly be important to test landing on Mars without humans on board for obvious reasons.
+
 [NARRATOR]: In the most optimistic case, we'll probably see uncrewed missions in 2024 and crewed missions in 2026.
+
 [NARRATOR]: But more conservatively, we will likely have human boots on Mars around the end of the 2020s, either thanks to SpaceX or China.
+
 [NARRATOR]: So far, SpaceX has mostly focused on cargo missions, either for ISS resupply missions, third party satellite launches, or launches for its own satellite constellation, Starlink.
+
 [NARRATOR]: But in recent years SpaceX has begun performing crewed missions, and it currently has four such missions under its belt: Demo-2, Crew-1, Crew-2, and the recent flight that deservedly got a lot of attention, Inspiration4.
+
 [NARRATOR]: SpaceX has a bunch of planned crewed missions in the near future, including the dearMoon project, which is planning to fly a crew of around 10 people in a trajectory around the moon in 2023.
+
 [NARRATOR]: These missions not only provide extra revenue, but they're an opportunity for SpaceX to refine its strategy and skillset when it comes to life support and astronaut quarters.
+
 [NARRATOR]: While short term missions may get by with tanks of compressed oxygen for breathing, a long duration trip to Mars will most definitely require some active way of recycling the air.
+
 [NARRATOR]: Water can be split into hydrogen and oxygen using electrolysis, and the hydrogen can be recombined with the carbon dioxide exhaled by humans using the Sabatier Reaction to produce water and methane.
+
 [NARRATOR]: A system like this already exists on the ISS, so this system should also work well on Starship in principle.
+
 [NARRATOR]: Food storage and waste disposal and recycling have also been demonstrated on the ISS, and we'll gloss over those topics for brevity.
+
 [NARRATOR]: There are still major unknowns when it comes to low gravity or microgravity effects on the human body.
+
 [NARRATOR]: And while we have some data on the long term impacts of microgravity from research done on the ISS, we don't really have any data about Mars gravity, which is around 38% that of Earth's gravity.
+
 [NARRATOR]: We could in theory create rotating habitats that spin at a velocity that simulates Mars gravity so that we could begin to study the effects, but I'm not aware of any concrete plans for that yet.
+
 [NARRATOR]: For the journey though, we could potentially tether two Mars-bound Starships nose-to-nose and spin them to create artificial gravity, although nothing's been announced about this part yet.
+
 [NARRATOR]: One very relevant challenge the astronauts will face on their journey and during their extended stay is the psychological impacts of isolation from other humans.
+
 [NARRATOR]: They'll need plenty of offline-friendly forms of entertainment and regular contact with friends and family back home, and until Mars's internet infrastructure is improved, possibly through Starlink, this will be quite a difficult problem, especially since Earth entertainment is trending more and more towards cloud-based, low-latency experiences.
+
 [NARRATOR]: Let's talk a little bit about the dangers of space.
+
 [NARRATOR]: There are two types of radiation people usually talk about, solar radiation and galactic cosmic rays.
+
 [NARRATOR]: The short version is that while radiation levels will certainly be higher during the journey than on most of Earth, with some shielding and clever arrangement of the crew, we can bring that down to the level of radiation experienced on the ISS.
+
 [NARRATOR]: I've linked an article discussing the math and what safe radiation levels look like down in the description.
+
 [NARRATOR]: One other interesting thing to note is that there's a city in Iran named Ramsar with similar radiation levels to what we'd experience on Mars, and there doesn't seem to be any increase in cancer rates among the local population.
+
 [NARRATOR]: I've linked a video by Anton Petrov discussing this city and its implications on Mars colonization.
+
 [NARRATOR]: In the case of a strong solar storm during the journey to Mars, the crew could utilize a small region in the center of the living quarters shielded by the mission's water and food supplies, according to an AMA with Dr.
+
 [NARRATOR]: Robert Zubrin on the SpaceX subreddit.
+
 [NARRATOR]: I previously mentioned the Sabatier Reaction when talking about air recycling.
+
 [NARRATOR]: It becomes even more relevant, however, once the Starships has landed on Mars.
+
 [NARRATOR]: The Sabatier Reaction turns hydrogen and carbon dioxide into water and methane, the latter of which is used as propellant for Starship.
+
 [NARRATOR]: Mars's atmosphere contains plenty of carbon dioxide, it's roughly 95% CO2 by mass.
+
 [NARRATOR]: You'd either have to bring some hydrogen with you, or you'd need to find water on Mars to turn into hydrogen and oxygen with electrolysis.
+
 [NARRATOR]: To obtain water from the glaciers on Mars, you could use the Rodwell process that's used to extract water in Antarctica.
+
 [NARRATOR]: You basically pump in a small amount of warm liquid water, which then melts the surrounding ice, which can then be pumped out.
+
 [NARRATOR]: If we're able to set up an operation that utilizes this water, we would be able to produce propellant for a return trip without having to continually import more hydrogen from Earth.
+
 [NARRATOR]: The general process of using the resources at your destination rather than importing them is referred to as In-Situ Resource Utilization.
+
 [NARRATOR]: Mass to Mars will still be incredibly expensive for a long time, so reusing Mars's resources as much as possible should be a priority.
+
 [NARRATOR]: Even better, if Tesla Bots are ready in time for the uncrewed Mars missions later this decade, they could help set up the ISRU stations ahead of time so that we can send the first humans to Mars with much higher confidence that they can actually return after their mission.
+
 [NARRATOR]: While the Starship system solves the transportation issue in a very basic sense, a round trip to Mars still takes a fairly long time, especially when you consider the synodic period of 26 months, which is the amount of time between the distance between the two planets is short enough for a transfer between planets.
+
 [NARRATOR]: The journey there and back would be roughly 6 months each, but once people arrive to Mars, they'll need to wait for the next transfer window, unless ISRU hasn't produced enough Methylox, in which case they'll have to wait an additional synodic period.
+
 [NARRATOR]: In total, we're looking at around 2.5 years round trip.
+
 [NARRATOR]: We've discussed radiation concerns earlier in the video with regards to the trip to Mars, but what do we do once we're on the surface?
+
 [NARRATOR]: Mostly, we'll just go below the surface.
+
 [NARRATOR]: We could very well use the Starships themselves as habitats, as they'll likely be fairly well shielded from radiation.
+
 [NARRATOR]: However, long term, we would definitely need to start branching out and building habitats.
+
 [NARRATOR]: What process we'd build them with is a bit too much detail for this video, but in general, as long as we have a few feet of dirt, water, or ice above the habitat, we should be fairly safe.
+
 [NARRATOR]: In Dr.
+
 [NARRATOR]: Zubrin's AMA, he also addressed this question with his vision of a Mars habitat: you'd have a greenhouse on the surface utilizing sunlight, you'd have an aquarium below the greenhouse with fish intended for food, and human shelters below the aquariums.
+
 [NARRATOR]: The plants don't require shielding, and the water absorbs the radiation from the surface.
+
 [NARRATOR]: Some research here on Earth involving soil with Mars-like properties indicates that crops will likely grow in soil on Mars, but if that's not the case, we can always just fall back to hydroponics, which requires no soil.
+
 [NARRATOR]: I'll talk about this in more detail in a future video, so make sure you subscribe for future videos about the future.
+
 [NARRATOR]: That's it for this video.
+
 [NARRATOR]: Let me know if I missed anything, and I'll address it in a future video.
+
 [NARRATOR]: In the meantime, I would love it if you subscribed to my channel and told some friends about it, especially if they're into futurism and bleeding edge technology.
+
 [NARRATOR]: If you have a suggestion for a future topic, let me know in the comments, and go ahead and follow me on Twitter @futuroptimist, link in the description.
+
 [NARRATOR]: I'll see you in the next one.

--- a/video_scripts/20211115_why-augmented-reality-and-the-metaverse-will-change-everything-eventually/script.md
+++ b/video_scripts/20211115_why-augmented-reality-and-the-metaverse-will-change-everything-eventually/script.md
@@ -325,4 +325,3 @@
 [NARRATOR]: If you have a suggestion for a future topic, let me know in the comments, and go ahead and follow me on Twitter at @futuroptimist to participate in planning upcoming videos, link in the description.
 
 [NARRATOR]: I'll see you in the next one.
-

--- a/video_scripts/20220111_6-of-the-biggest-ways-starship-will-transform-the-space-industry-forever/script.md
+++ b/video_scripts/20220111_6-of-the-biggest-ways-starship-will-transform-the-space-industry-forever/script.md
@@ -3,83 +3,163 @@
 > Transcript for video `en01vo9ErpY`
 
 ## Script
+
 [NARRATOR]: What if I told you that Starship, SpaceX's upcoming fully reusable rocket, is the most transformative thing to happen in space travel so far.
+
 [NARRATOR]: That's certainly a big claim, but I think it's warranted.
+
 [NARRATOR]: Starship not only greatly reduces cost to orbit, but it also allows for much larger payloads and faster turnaround time.
+
 [NARRATOR]: In this video, I'm going to list some of the biggest ways Starship will provide value over the next few years, starting with the most obvious and delving into the unknown towards the end.
+
 [NARRATOR]: Let's start with a quick recap of Starship progress so far.
+
 [NARRATOR]: Starship is intended to be a fully and rapidly reusable rocket system where both the first and second stages land propulsively.
+
 [NARRATOR]: Well, technically on earth, they won't exactly land, but instead will be caught by gigantic mechanical chopsticks, but that's a story for another video.
+
 [NARRATOR]: Starship aims to get around 150 tons to low earth orbit and eventually reach a launch cost of one to $2 million.
+
 [NARRATOR]: It has the potential to send dozens of humans to Mars at a time, and maybe even transport hundreds of humans from point-to-point on earth someday.
+
 [NARRATOR]: If you haven't followed Starship's test campaign so far, here's the TLDW.
+
 [NARRATOR]: Sub-orbital tests of the second stage started with SN8 in December, 2020, and the most recent flight was performed by SN15 in May, 2021, and was the first to successfully land and remain unexploded.
+
 [NARRATOR]: The first orbital flight will use a first stage named B4 and a second stage named S20.
+
 [NARRATOR]: Elon swears that the numbers are coincidence, but the first stage also happens to be 69 meters tall.
+
 [NARRATOR]: Nice.
+
 [NARRATOR]: This very nice first orbital flight is expected to happen sometime after the FAA's environmental assessment is complete.
+
 [NARRATOR]: It was supposed to be completed on December 31, but the FAA just extended it to February 28, so we can expect the launch no earlier than that date.
+
 [NARRATOR]: They say the delay was due to an overwhelming number of responses, and I have absolutely no idea why that may have happened.
+
 [NARRATOR]: But that's it for the recap.
+
 [NARRATOR]: I may have missed a few important details, so reach out in the comments if you need clarification or more resources, and I'll be happy to respond.
+
 [NARRATOR]: I wanted to start by mentioning the most obvious thing that Starship enables, the colonization of Mars.
+
 [NARRATOR]: I've talked about this topic already in my video entitled "Things we need to figure out before sending humans to Mars" so I recommend checking that out if you need a deeper dive.
+
 [NARRATOR]: In general, the overarching goal with Mars colonization is redundancy.
+
 [NARRATOR]: There have been several mass extinction events throughout history due to a variety of causes, and if we want to avoid our own extinction, having a human presence on two planets is certainly better than one.
+
 [NARRATOR]: There are several concrete reasons this is the case, but I'll save that for a future video.
+
 [NARRATOR]: Elon stated that it'll take around 1,000 Starships 20 years to create a self-sustaining Mars colony, so this is of course a long-term endeavor on the order of decades.
+
 [NARRATOR]: Each Starship is intended to carry over 100 tons from low earth orbit to Mars, which is, let's say, a lot.
+
 [NARRATOR]: And a lot of payload and a lot of colonists will be needed to create that self-sustaining colony.
+
 [NARRATOR]: Elon frequently reiterate that Starship, the world's first rapidly and fully reusable rocket, is the fundamental technology needed to make life multi-planetary.
+
 [NARRATOR]: One of Elon's other major ventures is a satellite internet constellation known as Starlink.
+
 [NARRATOR]: Falcon 9 rockets can deliver around 60 V1 Starlink satellites to lower earth orbit per launch, while Starship could deliver roughly 400 V1 satellites instead.
+
 [NARRATOR]: The V1 satellites, however, are being deprecated in favor of V2 satellites, which supposedly allow for greater bandwidth and can only be economically shipped with Starship.
+
 [NARRATOR]: According to a leaked internal email from Elon to SpaceX in November, 2021, in addition to providing high-bandwidth internet to a large portion of humans in rural areas across the world, Starlink satellites likely have quite a bit of multitasking potential.
+
 [NARRATOR]: Starlink already announced plans to partner with telecom companies for data backhaul, and it is partnering with Azure to provide cloud computing services, and laser-linked Starlinks communicating directly within the user terminals makes the satellites uniquely poised to provide services like edge computing and CDNs.
+
 [NARRATOR]: Starlink satellites are designed to deorbit after five years, and this short lifespan ensures that the network can continuously be upgraded with later generation hardware, and potentially more bells and whistles like cameras and other sensors for imaging earth and the cosmos, and additional complimentary services like GPS could be integrated as well.
+
 [NARRATOR]: James Webb Space Telescope has finally launched after 25 years of development and a budget of $10 billion US.
+
 [NARRATOR]: JWST is designed to be folded 12 times to fit its launch vehicle, the Ariane 5, which has a fairing with a diameter of 4.5 meters and a length of 16 meters.
+
 [NARRATOR]: The actual telescope itself is 14 by 21 meters when fully unfolded.
+
 [NARRATOR]: It'll certainly be one of the most impressive feats of human engineering.
+
 [NARRATOR]: Starship will have a fairing with a diameter of 9 meters and a height of 18 meters, which means it could launch JWST-size telescopes in the future.
+
 [NARRATOR]: And the hull of the ship itself could very well be made into the body of a telescope.
+
 [NARRATOR]: Additionally, the rapid launch and reuse of the system means that scientists could likely design modular telescopes that are combined in orbit using multiple starships.
+
 [NARRATOR]: One of the main reasons space telescopes are so challenging is that angular resolution or the ability to resolve distant objects is limited by the overall diameter of the aperture.
+
 [NARRATOR]: Starship will hopefully lower this barrier to entry and enable a new generation of space telescopes, which can study our universe in unprecedented and increasingly more beneficial ways.
+
 [NARRATOR]: There are a number of existing and future startups that could benefit substantially from both the larger payload sizes and lower cost per ton offered by Starship.
+
 [NARRATOR]: Easier access to earth imaging satellites could enable scientists to fight climate change by identifying significant sources of greenhouse gases, like methane, and better model weather patterns and predict extreme weather events.
+
 [NARRATOR]: This can certainly be accomplished with existing rocketry, but Starship intends to reduce the cost to space by orders of magnitude.
+
 [NARRATOR]: So funding these important ventures becomes more and more realistic.
+
 [NARRATOR]: In addition to imagery, easier access to space opens the door for all sorts of manufacturing use cases in low earth orbit.
+
 [NARRATOR]: Including but not limited to the following, 3D printed organs, exotic versions of fibers for high-speed internet, carbon nanotubes, superconductors, hydroponic plants, diamonds for high precision machinery, novel drugs and medicine.
+
 [NARRATOR]: And the list goes on and on.
+
 [NARRATOR]: If you're interested in some more examples, I recommend checking out factoriesinspace.com, which lists all of the use cases I mentioned and more.
+
 [NARRATOR]: One other exciting thing that starship enables is the launch of significant amounts of payload to objects beyond Mars, particularly the moons of Jupiter and Saturn.
+
 [NARRATOR]: We could send deep sea vehicles to Europa, one of Jupiter's moons, which is hypothesized to have partially liquid oceans of water at 100 kilometers thick, which makes it a possible candidate for the discovery of life forms to beyond earth.
+
 [NARRATOR]: There are many other exciting worlds that could be explored more thoroughly, like another Galilean moon Io, which has active volcano plumes and flowing lava on the surface.
+
 [NARRATOR]: In addition to landing on planets and moons, Starship could enable a research missions to nearby asteroids, with potential for early attempts at asteroid mining.
+
 [NARRATOR]: Additionally, more payload to orbit means heavier payloads for asteroid redirection missions like the recent DART mission.
+
 [NARRATOR]: Having a planetary defense system in place will be essential for our long-term ability to protect earth from potentially catastrophic asteroid impacts.
+
 [NARRATOR]: If you want a good laugh, I recommend a recent Netflix movie called Don't Look Up, which satirically explores how society might react to an impending extinction level asteroid impact.
+
 [NARRATOR]: Currently there are only two space stations in operation, the International Space Station and the Tiangong Space Station, but there are a number of exciting proposals for new space stations as well.
+
 [NARRATOR]: Axiom space is planning to begin creating the Axiom Orbital Segment, which will begin as additional components on the ISS.
+
 [NARRATOR]: With the option of detaching later and forming its own independent space station.
+
 [NARRATOR]: Axiom will begin sending their own astronauts to the ISS starting next year.
+
 [NARRATOR]: And it will be exciting to see where that company goes in the future.
+
 [NARRATOR]: Blue Origin has also discussed plans to build their own space station dubbed the Orbital Reef, but any work towards that station will either require achieving orbital flight or hitching a ride on Starship.
+
 [NARRATOR]: I think the latter is highly unlikely, but I'm not ruling it out completely.
+
 [NARRATOR]: Beyond more immediate plans, it's fun to speculate further into the future and imagine ways that Starship could finally enable the creation of rotating habitats.
+
 [NARRATOR]: These rotating habitats would use centripetal force to create artificial gravity, which may make the barrier to permanent space habitation much lower.
+
 [NARRATOR]: Microgravity has a number of adverse effects on the human body and preserving muscle tissue requires extensive amounts of exercise.
+
 [NARRATOR]: There are a couple likely reasons we've yet to see rotating habitats.
+
 [NARRATOR]: And the most obvious is that these structures have to be sufficiently large to create artificial gravity without side effects.
+
 [NARRATOR]: Studies have shown that a rotational radius of less than 100 meters can cause motion sickness and generally a 500 meter radius is required for comfortable earth gravity.
+
 [NARRATOR]: One iterative step in that direction, however, could be the try to simulate moon gravity or Mars gravity, which could allow scientists to observe lower gravity's potential health effects and better prepare us for long-term colonization.
+
 [NARRATOR]: There's an excellent blog article by Casey Handmer that discusses this problem in depth and offers a potential solution for creating a rotating station out of a ring of starships.
+
 [NARRATOR]: I recommend you check it out.
+
 [NARRATOR]: I've added a link under the like button.
+
 [NARRATOR]: Starship is still largely unproven, but if things go according to plan, this could catapult us into a new age of space exploration and industry.
+
 [NARRATOR]: Fingers are crossed for the orbital campaign next year.
+
 [NARRATOR]: That's it for this video, please subscribe if you find topics like this interesting.
+
 [NARRATOR]: And let me know in the comments if you have any concerns or feedback.
+
 [NARRATOR]: I'll see you in the next one.

--- a/video_scripts/20250701_indoor-aquariums-tour/script.md
+++ b/video_scripts/20250701_indoor-aquariums-tour/script.md
@@ -8,17 +8,13 @@
 
 [VISUAL]: Supercut of news clips, trending memes, and an old shot of me promising "regular uploads soon" timed to the line "A lot has happened since then."
 
-
 [NARRATOR]: but I'm back! Hi, I'm Daniel and you're watching Futuroptimist.
 
-
 [NARRATOR]: Today I'm giving you a quick look at four indoor aquariums I've been tinkering with. Stick around to hear about my automation plans at the end.
-
 
 [NARRATOR]: I started the aquarium hobby 18 months ago and have been improving these tanks ever since, while bouncing between other hobbies and spending far too many hours at my day job—but let's focus on the fish.
 
 [VISUAL]: Collage of all four tanks in a 2×2 grid, then a rapid-fire montage of office work, platinum trophies and Steam achievements, a peek at my current OSRS sessions, several 3D prints (including hydroponic baskets), and quick clips of the backyard garden.
-
 
 [NARRATOR]: This 20 gallon runs the Walstad method, with garden soil under sand and a tasty layer of mulm. It's full of guppies, snails, and microfauna like scuds, Daphnia, and moina. I tried cherry shrimp, but their babies became guppy snacks.
 
@@ -28,52 +24,42 @@
 
 [VISUAL]: Macro lens close-ups of guppies, shrimp, scuds, Daphnia, and moina.
 
-
 [NARRATOR]: Early on the water turned cloudy and even took on a strong green hue—likely a mix of algae and bacteria. After a lot of digging through forums, I learned that adding a deep sand bed could give anaerobic bacteria room to work, and it cleared up almost overnight.
 
 [VISUAL]: Timelapse from green murk to clear water.
 
-
 [NARRATOR]: I replicated that deep sand bed in both 10-gallon tanks. The one next to this big tank had been cloudy from overfeeding, but the extra sand cleared it right up. Now the sloped bed and new RGB lighting make it pop.
 
-
 [NARRATOR]: Next is a 10 gallon where those original female guppies gave birth during quarantine, shortly after I acquired them at a local fish store. Their fry, now nearly adults themselves still live here while the adults moved back to the big tank.
-
 
 [NARRATOR]: Another 10 gallon sits in the back with aquasoil, sand, and plants but no fish yet. It's been cycling for nearly eight months and will probably house my first betta in quarantine. From the photo you'd think I'm gunning for a top spot on /r/stressfulaquariums—this shelf won't be its final home.
 
 [VISUAL]: Photo of the 10 gallon on its flimsy metal shelf.
 
-
 [NARRATOR]: Finally there's a tiny 5 gallon that was neglected for a bit, so right now it only holds snails and microfauna. Because three tanks are lidless, evaporation is fast. I keep two five‑gallon buckets above the tanks and siphon water down with gravity.
-
 
 [NARRATOR]: To show how each tank looks from the inside, I've waterproofed an Insta360 and dropped it into the water.
 
 [VISUAL]: Slow shot of the camera sinking into the 20 gallon, followed by 360° footage of guppies all around.
 
-
 [NARRATOR]: Next up, it tours the fry tank and that cycling betta setup.
 
 [VISUAL]: Quick montage from inside the fry tank, then the betta tank.
-
 
 [NARRATOR]: Even the little 5 gallon gets a spin—tiny but lively.
 
 [VISUAL]: 360° clip from the 5 gallon.
 
-
 [NARRATOR]: I top off those buckets often and check parameters, sometimes dosing with products like Quick Start. The guppies eat flakes, pellets, and live foods, plus the occasional pinch of nutritional yeast—mmm. I've kept guppies going for about 16 months now, but Daphnia cultures crash easily, so I'm experimenting with green water and leaf litter for stability.
 
 [VISUAL]: B-roll of siphoning from buckets, adding Quick Start, feeding flakes and yeast.
-
 
 [NARRATOR]: Long term I'd love to automate water changes and feeding with peristaltic pumps and microcontrollers, maybe even run everything off solar. The grow lights already follow a custom schedule through smart plugs, and my indoor tanks use PLA 3D‑printed baskets for hydroponic plants—they'll slowly degrade but that's fine. I'm also starting to work on some outdoor aquarium setups with similar aquaponic techniques, and work is well underway!
 
 [VISUAL]: Photos of the aluminum extrusion frame for solar panels, the panels themselves, tubs of aquatic sand with plants, plus the charge controller and battery.
 
 [NARRATOR]: Quick takeaways before we wrap up.
-[VISUAL]: On-screen list: "Deep sand beds clear cloudy water", "Macro lens B-roll shows the microfauna", "Automation coming soon".
 
+[VISUAL]: On-screen list: "Deep sand beds clear cloudy water", "Macro lens B-roll shows the microfauna", "Automation coming soon".
 
 [NARRATOR]: What do you think of my setup? I'm just an amateur trying random things, so let me know if you spot mistakes or things I could do less stupidly. This is the roughest version you'll see, of course. Stick around as I level things up and make this the most reliable and robust aquarium setup I can imagine, and don't forget to subscribe!

--- a/video_scripts/20251001_indoor-aquariums-tour/script.md
+++ b/video_scripts/20251001_indoor-aquariums-tour/script.md
@@ -8,17 +8,13 @@
 
 [VISUAL]: Supercut of news clips, trending memes, and an old shot of me promising "regular uploads soon" timed to the line "A lot has happened since then."
 
-
 [NARRATOR]: but I'm back! Hi, I'm Daniel and you're watching Futuroptimist.
 
-
 [NARRATOR]: Today I'm giving you a quick look at four indoor aquariums I've been tinkering with. Stick around to hear about my automation plans at the end.
-
 
 [NARRATOR]: I started the aquarium hobby 18 months ago and have been improving these tanks ever since, while bouncing between other hobbies and spending far too many hours at my day job—but let's focus on the fish.
 
 [VISUAL]: Collage of all four tanks in a 2×2 grid, then a rapid-fire montage of office work, platinum trophies and Steam achievements, a peek at my current OSRS sessions, several 3D prints (including hydroponic baskets), and quick clips of the backyard garden.
-
 
 [NARRATOR]: This 20 gallon runs the Walstad method, with garden soil under sand and a tasty layer of mulm. It's full of guppies, snails, and microfauna like scuds, Daphnia, and moina. I tried cherry shrimp, but their babies became guppy snacks.
 
@@ -28,52 +24,42 @@
 
 [VISUAL]: Macro lens close-ups of guppies, shrimp, scuds, Daphnia, and moina.
 
-
 [NARRATOR]: Early on the water turned cloudy and even took on a strong green hue—likely a mix of algae and bacteria. After a lot of digging through forums, I learned that adding a deep sand bed could give anaerobic bacteria room to work, and it cleared up almost overnight.
 
 [VISUAL]: Timelapse from green murk to clear water.
 
-
 [NARRATOR]: I replicated that deep sand bed in both 10-gallon tanks. The one next to this big tank had been cloudy from overfeeding, but the extra sand cleared it right up. Now the sloped bed and new RGB lighting make it pop.
 
-
 [NARRATOR]: Next is a 10 gallon where those original female guppies gave birth during quarantine, shortly after I acquired them at a local fish store. Their fry, now nearly adults themselves still live here while the adults moved back to the big tank.
-
 
 [NARRATOR]: Another 10 gallon sits in the back with aquasoil, sand, and plants but no fish yet. It's been cycling for nearly eight months and will probably house my first betta in quarantine. From the photo you'd think I'm gunning for a top spot on /r/stressfulaquariums—this shelf won't be its final home.
 
 [VISUAL]: Photo of the 10 gallon on its flimsy metal shelf.
 
-
 [NARRATOR]: Finally there's a tiny 5 gallon that was neglected for a bit, so right now it only holds snails and microfauna. Because three tanks are lidless, evaporation is fast. I keep two five‑gallon buckets above the tanks and siphon water down with gravity.
-
 
 [NARRATOR]: To show how each tank looks from the inside, I've waterproofed an Insta360 and dropped it into the water.
 
 [VISUAL]: Slow shot of the camera sinking into the 20 gallon, followed by 360° footage of guppies all around.
 
-
 [NARRATOR]: Next up, it tours the fry tank and that cycling betta setup.
 
 [VISUAL]: Quick montage from inside the fry tank, then the betta tank.
-
 
 [NARRATOR]: Even the little 5 gallon gets a spin—tiny but lively.
 
 [VISUAL]: 360° clip from the 5 gallon.
 
-
 [NARRATOR]: I top off those buckets often and check parameters, sometimes dosing with products like Quick Start. The guppies eat flakes, pellets, and live foods, plus the occasional pinch of nutritional yeast—mmm. I've kept guppies going for about 16 months now, but Daphnia cultures crash easily, so I'm experimenting with green water and leaf litter for stability.
 
 [VISUAL]: B-roll of siphoning from buckets, adding Quick Start, feeding flakes and yeast.
-
 
 [NARRATOR]: Long term I'd love to automate water changes and feeding with peristaltic pumps and microcontrollers, maybe even run everything off solar. The grow lights already follow a custom schedule through smart plugs, and my indoor tanks use PLA 3D‑printed baskets for hydroponic plants—they'll slowly degrade but that's fine. I'm also starting to work on some outdoor aquarium setups with similar aquaponic techniques, and work is well underway!
 
 [VISUAL]: Photos of the aluminum extrusion frame for solar panels, the panels themselves, tubs of aquatic sand with plants, plus the charge controller and battery.
 
 [NARRATOR]: Quick takeaways before we wrap up.
-[VISUAL]: On-screen list: "Deep sand beds clear cloudy water", "Macro lens B-roll shows the microfauna", "Automation coming soon".
 
+[VISUAL]: On-screen list: "Deep sand beds clear cloudy water", "Macro lens B-roll shows the microfauna", "Automation coming soon".
 
 [NARRATOR]: What do you think of my setup? I'm just an amateur trying random things, so let me know if you spot mistakes or things I could do less stupidly. This is the roughest version you'll see, of course. Stick around as I level things up and make this the most reliable and robust aquarium setup I can imagine, and don't forget to subscribe!

--- a/video_scripts/20260901_sugarkube/footage.md
+++ b/video_scripts/20260901_sugarkube/footage.md
@@ -1,0 +1,80 @@
+# Sugarkube Footage and Production Index
+
+This is the canonical master index for the [script](script.md), [original production checklist](production/broll.md), [third-party stock ledger](production/stock.md), and [manual graphics checklist](production/graphics.md).
+
+## Media policy
+
+This production permits original footage, original screen recordings, manually produced graphics, and appropriately licensed or public-domain media. It permits **no AI-generated images or video**. Raw media stays in the ignored top-level `footage/` tree; no `assets.json` is created until matching footage directories exist.
+
+## Conventions
+
+- Statuses: `[ ]` planned, `[~]` captured/drafted but not cleared, `[x]` final and cleared, `[!]` blocked.
+- Asset IDs are globally unique: `Axx` A-roll/pickups, `Bxx` physical B-roll, `Cxx` screen recordings, `Txx` third-party media, and `Gxx` manually produced graphics.
+- Filename: `sugarkube_<asset-id-lower>_<take-or-version>.<ext>` (for example `sugarkube_b01_take03.mov`).
+- `V01`–`V42` are the current `[VISUAL]` cues in one-based chronological order; they are cue references, not asset definitions.
+
+## Pre-production gates
+
+- [ ] Resolve every spoken `<...>` placeholder before final recording.
+- [ ] Reproduce the AWS calculator estimate and retain/export every calculator input with the project records.
+- [ ] Sanitize all screen recordings: secrets, tokens, private hosts, terminal history, personal data, and receipts.
+- [ ] Clear every third-party asset and complete its rights-ledger row before editing it in.
+- [ ] Use the self-recorded `A02` reaction instead of the *Schitt’s Creek* excerpt unless `T05` is appropriately cleared.
+- [ ] Confirm current, future-plan, and unimplemented-hypothesis labels against the script.
+
+## Chronological visual coverage
+
+| Cue | Planned asset IDs |
+|---|---|
+| V01 | `B01`, `T01`, `T02`, `T03`, `G01` |
+| V02 | `B01`, `G01` |
+| V03 | `A01`, `B03` |
+| V04 | `A01`, `G01` |
+| V05 | `C01` |
+| V06 | `C01`, `A01` |
+| V07 | `A02`, `T05` |
+| V08 | `A02`, `C02` |
+| V09 | `A01`, `B01`, `G02` |
+| V10 | `G03` |
+| V11 | `B02` |
+| V12 | `B01`, `G04` |
+| V13 | `C03` |
+| V14 | `G05` |
+| V15 | `C04`, `A02` |
+| V16 | `C04`, `T04`, `A02`, `G07` |
+| V17 | `C05`, `G01` |
+| V18 | `G06`, `A03` |
+| V19 | `A03`, `G07` |
+| V20 | `A03`, `C05` |
+| V21 | `C06` |
+| V22 | `C06` |
+| V23 | `G08`, `C04` |
+| V24 | `B02`, `A03`, `G04` |
+| V25 | `B03`, `C08` |
+| V26 | `G09` |
+| V27 | `G10` |
+| V28 | `C07`, `G11` |
+| V29 | `G11`, `G15` |
+| V30 | `G11` |
+| V31 | `G12` |
+| V32 | `A03`, `G15` |
+| V33 | `A03`, `G15` |
+| V34 | `B04`, `G13` |
+| V35 | `G14` |
+| V36 | `A04`, `G15` |
+| V37 | `A04`, `B02` |
+| V38 | `B03`, `B06`, `C08`, `T06`, `G17` |
+| V39 | `C09` |
+| V40 | `A04`, `B05`, `G16` |
+| V41 | `A04`, `T06`, `G17` |
+| V42 | `A04`, `B01`, `B06`, `C09`, `G08` |
+
+## Final audit
+
+- [ ] Every V01–V42 cue has captured/drafted coverage and every referenced ID is defined once.
+- [ ] Narration placeholders and measured-value graphics use final verified numbers.
+- [ ] AWS inputs, pricing date, exclusions, receipts, BOM, and power readings are retained and reproducible.
+- [ ] Every screen and receipt is sanitized; every Txx item is cleared and attributed as required.
+- [ ] No AI-generated image/video or uncleared television excerpt appears in the timeline.
+- [ ] Future plans and unimplemented hypotheses cannot be mistaken for current behavior.
+- [ ] Final export includes the intended lower thirds, caveats, accessibility review, audio mix, captions, and closing hero.

--- a/video_scripts/20260901_sugarkube/production/broll.md
+++ b/video_scripts/20260901_sugarkube/production/broll.md
@@ -1,0 +1,31 @@
+# Sugarkube Original Production Checklist
+
+All material here is recorded by the production; sanitize every screen and receipt before clearance.
+
+## A-roll and pickups
+
+- [ ] **A01** — Desk introduction, disclosure, experience caveat, modest thesis, and cloud/homegrown transition; rack visible.
+- [ ] **A02** — Self-recorded “Ew” reaction (the default edit), agentic-code verification explanation, and unfinished/future caveats.
+- [ ] **A03** — Trust-boundary, reputation-hypothesis, privacy, accessibility, Rampocalypse, and comparison caveats.
+- [ ] **A04** — Lifecycle/water caveats, drink reaction, participation/start-small advice, off-grid CTA, and closing performance.
+
+## Physical B-roll
+
+- [ ] **B01** — Rack opening macros and hero coverage: LEDs, fans, Ethernet, PoE+ ports, all three yellow tiers, desk/shelf placement, and closing hero.
+- [ ] **B02** — Full rack inventory: nine individual Pi 5 boards/RAM labels, storage, printed parts, cabling, onboard and desk fans, switch, and office placement.
+- [ ] **B03** — Power-meter setup including switch and desk fan; disconnect three unused nodes; record representative idle, load, and peak readings.
+- [ ] **B04** — BOM, hardware, redacted receipts, full-nine and comparable-six totals, with no private purchasing data.
+- [ ] **B05** — One-Pi and old-computer alternatives beside the complete rack; practical start-small coverage.
+- [ ] **B06** — Controls and physical shutdown/scaling actions; closing rack/application montage pickups.
+
+## Original screen recordings
+
+- [ ] **C01** — Public GitHub, CI checks, terminal deploy/verify/update/rollback, `just --list`, and sanitized logs/history.
+- [ ] **C02** — Real agentic-code workflow: proposed diff, tests, review, and independent verification.
+- [ ] **C03** — Sugarkube design files, image tooling, justfile, manifests, Helm charts, docs, and bootstrap/deploy/verify/promote/rollback commands.
+- [ ] **C04** — DSPACE landing/gameplay, quest trees, dChat/NPC selector, “Powered by token.place,” and feedback path.
+- [ ] **C05** — token.place public API/docs, desktop compute-node application, operator flow, relay/privacy/self-host settings, and sanitized logs.
+- [ ] **C06** — danielsmith.io Three.js house/avatar/floors/backyard/POIs/tutorial and separate text/keyboard/accessibility experience.
+- [ ] **C07** — AWS calculator inputs/results retained with the project; Oregon single-AZ six-instance/storage/IPv4 architecture sequence.
+- [ ] **C08** — Power logging at idle/load/peak plus operational deployment dashboards and scale-down/shutdown terminal commands.
+- [ ] **C09** — Final public-repository/app montage: DSPACE, danielsmith.io, token.place, Sugarkube, deployment verification, and docs.

--- a/video_scripts/20260901_sugarkube/production/graphics.md
+++ b/video_scripts/20260901_sugarkube/production/graphics.md
@@ -1,0 +1,21 @@
+# Sugarkube Manually Produced Graphics Checklist
+
+Create these graphics manually with ordinary editing/design tools. Do not use generative-image or generative-video tooling. Labels must distinguish **Current behavior**, **Future plan**, and **Unimplemented hypothesis**.
+
+- [ ] **G01** — Restrained lower-third/visual system, “Illustrative cloud infrastructure,” and Sugarkube nine-node identification.
+- [ ] **G02** — Managed-cloud convenience versus homegrown Kubernetes title card.
+- [ ] **G03** — Kubernetes placement, restart-after-failure, and rolling-update diagram.
+- [ ] **G04** — Nine-slot rack overlay: six current active, one future development, two unused; reusable six-node highlight state.
+- [ ] **G05** — Current ecosystem overview with Sugarkube, three deployed projects, and explicitly future project placeholder.
+- [ ] **G06** — token.place client/relay/compute trust boundary: relay ciphertext and compute-node plaintext (current behavior).
+- [ ] **G07** — Reputation graphic labeled “Future hypothesis—does not exist yet” (unimplemented hypothesis).
+- [ ] **G08** — Connected feedback loop and final ecosystem resolve, including current dChat/token.place relationship.
+- [ ] **G09** — Electricity calculator from watts through monthly kWh/cost and annual cost; pending-values state.
+- [ ] **G10** — Measurement boundary: rack/switch/cabling/fan included; router/modem/off-rack compute/GPU excluded.
+- [ ] **G11** — AWS architecture sequence: two self-managed three-node k3s clusters, Oregon single-AZ failure domain, six c7g.xlarge, gp3, IPv4, exclusions.
+- [ ] **G12** — AWS July 22, 2026 pricing table and annual total with exclusions.
+- [ ] **G13** — BOM comparison: real full-nine versus comparable-six totals; placeholders until verified.
+- [ ] **G14** — Break-even formula/chart, crossing point, and no-positive-break-even case.
+- [ ] **G15** — Comparison qualifications: always-on/shape-matched, not performance- or watt-matched, lifecycle and indirect-impact caveats.
+- [ ] **G16** — Start-small Kubernetes learning graphic for one Pi or an old computer.
+- [ ] **G17** — Future off-grid solar/battery/inverter labels and subscribe CTA (future plan).

--- a/video_scripts/20260901_sugarkube/production/stock.md
+++ b/video_scripts/20260901_sugarkube/production/stock.md
@@ -1,0 +1,21 @@
+# Sugarkube Third-Party Asset Checklist
+
+Do not download or commit third-party media. Every selected item remains blocked until its rights-ledger row is complete and cleared.
+
+- [ ] **T01** — Licensed/public-domain real data-center interiors.
+- [ ] **T02** — Licensed/public-domain real electrical rooms and grid infrastructure.
+- [ ] **T03** — Licensed/public-domain real cooling equipment and water infrastructure.
+- [ ] **T04** — Representative real 3D-printing, hydroponics, composting, electronics, robotics, astronomy, and rocketry footage for DSPACE; label illustrative material.
+- [ ] **T05** — Optional *Schitt’s Creek* excerpt, rights-gated and used only if appropriately cleared; **A02 is the default**.
+- [ ] **T06** — Licensed/public-domain real solar panels, battery, and inverter footage, labeled “Future plan/goal.”
+
+## Rights ledger
+
+| Asset ID | Source URL/provider | Creator | License or receipt | Download date | Attribution requirement | Clearance status |
+|---|---|---|---|---|---|---|
+| T01 | TBD | TBD | TBD | TBD | TBD | Blocked |
+| T02 | TBD | TBD | TBD | TBD | TBD | Blocked |
+| T03 | TBD | TBD | TBD | TBD | TBD | Blocked |
+| T04 | TBD | TBD | TBD | TBD | TBD | Blocked |
+| T05 | Rights holder/distributor, TBD | Rights holder, TBD | Written clip clearance required | Not downloaded | Per clearance | Blocked; omit by default |
+| T06 | TBD | TBD | TBD | TBD | TBD | Blocked |

--- a/video_scripts/20260901_sugarkube/script.md
+++ b/video_scripts/20260901_sugarkube/script.md
@@ -2,23 +2,18 @@
 
 > Draft script for video `<youtube_id>`
 
-> Draft outline
+## Outline
 
-> 0:00–0:40: physical hook, environmental concern, and honest thesis
-> 
-> 0:40–1:30: deployment tax and SRE motivation
-> 
-> 1:30–3:30: Sugarkube hardware, k3s platform, and command layer
-> 
-> 3:30–6:25: DSPACE, token.place, and danielsmith.io as a connected ecosystem
-> 
-> 6:25–10:35: measured electricity, AWS cost comparison, and the efficiency-versus-agency tension
-> 
-> 10:35–11:45: participation and concluding vision
+- 0:00–0:40: physical hook, environmental concern, and honest thesis
+- 0:40–1:30: deployment tax and SRE motivation
+- 1:30–3:30: Sugarkube hardware, k3s platform, and command layer
+- 3:30–6:25: DSPACE, token.place, and danielsmith.io as a connected ecosystem
+- 6:25–10:35: measured electricity, AWS cost comparison, and the efficiency-versus-agency tension
+- 10:35–11:45: participation and concluding vision
 
 ## Script
 
-> 0:00–0:40: Physical hook, environmental concern, and honest thesis
+### 0:00–0:40: Physical hook, environmental concern, and honest thesis
 
 [NARRATOR]: AI feels like it lives in the cloud, but the cloud is physical.
 
@@ -26,11 +21,9 @@
 
 [VISUAL]: Open on macro close-ups of the bright-yellow Sugarkube rack: LEDs blinking, fan blades spinning, Ethernet cables, PoE+ switch ports, and all three printed tiers. Cut to appropriately licensed stock footage of data-center interiors, electrical rooms, cooling equipment, and water infrastructure labeled "Illustrative cloud infrastructure footage."
 
-
 [NARRATOR]: So I built this: Sugarkube, a bright-yellow rack of nine Raspberry Pis hosting my open-source projects.
 
 [VISUAL]: Return to a clean rack hero shot on Daniel's desk or shelf. Add a restrained lower-third: "Sugarkube: 9 Raspberry Pi 5 nodes."
-
 
 [NARRATOR]: My goal is modest.
 
@@ -40,8 +33,7 @@
 
 [VISUAL]: A-roll of Daniel at his desk with the rack visible nearby. Brief insert of a hand placing a power meter in frame, then back to A-roll for the caveat.
 
-
-> 0:40–1:30: The deployment tax and my SRE motivation
+### 0:40–1:30: The deployment tax and my SRE motivation
 
 [NARRATOR]: I’ve spent more than a decade building production software, including nearly seven years as a site reliability engineer at YouTube.
 
@@ -49,11 +41,9 @@
 
 [VISUAL]: A-roll. Use a simple on-screen label for experience only, without showing private or internal Google or YouTube material.
 
-
 [NARRATOR]: My personal projects run at a much smaller scale, but they still need packaging, deployment, verification, updates, and recovery when something fails.
 
 [VISUAL]: Screen recordings of public GitHub repositories, CI status checks, terminal deployment commands, verification output, update logs, and rollback commands. Blur or crop any secrets, tokens, private hostnames, or sensitive terminal history.
-
 
 [NARRATOR]: I have way too many passion projects, as you can see on my GitHub, so every one-off deployment path takes time away from improving them.
 
@@ -63,8 +53,7 @@
 
 [VISUAL]: Screen recording scrolling Daniel's public GitHub project list, then cut to a tidy terminal menu or `just --list` output. End with A-roll for the joke and thesis.
 
-
-> 1:30–3:30: What Sugarkube actually is
+### 1:30–3:30: What Sugarkube actually is
 
 [NARRATOR]: Cloud platforms already make small app deployments relatively easy, especially with a trusty LLM whispering in your ear.
 
@@ -76,7 +65,6 @@
 
 [VISUAL]: Stay on A-roll as Daniel says the disclosure, then cut on "I know" to a very brief, appropriately sourced Alexis Rose "Ew, David!" reaction clip from Schitt's Creek before returning to Daniel. If that clip cannot be sourced appropriately for the edit, Daniel should record his own quick reaction instead of using AI-generated media.
 
-
 [NARRATOR]: I get the skepticism.
 
 [NARRATOR]: For one person maintaining an ecosystem this overambitious, though, coding agents are often the difference between an idea staying in my notes and becoming working software.
@@ -85,18 +73,15 @@
 
 [VISUAL]: A-roll plus a sanitized screen recording of a real agentic-coding workflow, such as reviewing a proposed diff, inspecting tests, or verifying a change. Do not expose secrets, tokens, private hostnames, or sensitive terminal history.
 
-
 [NARRATOR]: I wanted a homegrown path built on Kubernetes.
 
 [VISUAL]: Transition from A-roll back to the bright-yellow rack, then into the Kubernetes explanation with a simple two-column title card: "Managed cloud convenience" vs "Homegrown Kubernetes path."
-
 
 [NARRATOR]: Kubernetes coordinates containerized applications across one or more machines.
 
 [NARRATOR]: You describe how an application should run, and Kubernetes places it, restarts it after failures, and rolls out updates.
 
 [VISUAL]: Editor-made diagram showing containers distributed across one machine, then several machines. Label placement, restart after failure, and rolling update steps with simple arrows.
-
 
 [NARRATOR]: Sugarkube runs k3s, a lightweight Kubernetes distribution suited to homelabs and single-board computers.
 
@@ -105,7 +90,6 @@
 [NARRATOR]: One unmanaged PoE+ switch provides power and networking.
 
 [VISUAL]: Wide shot and close-ups of the full rack, individual Pi 5 boards, three PLA tiers, the PoE+ switch, Ethernet cables, storage hardware, onboard fans, desk fan, and office placement.
-
 
 [NARRATOR]: Only six Pis are active right now.
 
@@ -119,7 +103,6 @@
 
 [VISUAL]: Overlay a nine-slot rack diagram on the real rack: three active staging nodes, three active production nodes, one planned development node styled as future, and two unassigned nodes styled distinctly as unused. Keep active, future, and unassigned states visually different.
 
-
 [NARRATOR]: The repository includes the printable designs, tooling for a Raspberry Pi OS image with cloud-init and k3s preinstalled, and a command layer built around `just`.
 
 [NARRATOR]: Its `justfile` packages commands into recipes that bootstrap clusters, onboard applications, deploy and verify them, promote artifacts to production, and roll them back.
@@ -128,8 +111,7 @@
 
 [VISUAL]: Screen recordings of the Sugarkube repository showing printable design files, image-building tooling, `justfile`, manifests, Helm charts, and documentation. Show representative sanitized `just` commands for bootstrap, deploy, verify, promote, and rollback.
 
-
-> 3:30–6:25: The ecosystem running through it
+### 3:30–6:25: The ecosystem running through it
 
 [NARRATOR]: The rack is only interesting if it runs something.
 
@@ -139,13 +121,11 @@
 
 [VISUAL]: Simple editor-made ecosystem diagram with Sugarkube at the center and three current deployed projects around it. Add a small "future projects" placeholder clearly labeled as future.
 
-
 [NARRATOR]: First is DSPACE at democratized.space, a space exploration idle game that, incidentally, hasn’t made it to space yet.
 
 [NARRATOR]: My wildly overambitious goal is to turn as much of the space exploration technology tree and its dependencies as I can into something educational and fun.
 
 [VISUAL]: Screen recording of the live DSPACE game landing page and core gameplay. Include A-roll or a small comedic cutaway on "hasn’t made it to space yet."
-
 
 [NARRATOR]: Its quests span 3D printing, hydroponics, composting, electronics, robotics, astronomy, rocketry, and much more.
 
@@ -155,7 +135,6 @@
 
 [VISUAL]: Show DSPACE quest trees and representative real footage or screenshots for 3D printing, hydroponics, composting, electronics, robotics, astronomy, and rocketry. Use A-roll for the unfinished caveat and label any 3D-version reference as "Future concept, not implemented."
 
-
 [NARRATOR]: Second is token.place, my open-source distributed LLM inference platform.
 
 [NARRATOR]: Its rate-limited public API currently requires no account, API key, or payment.
@@ -163,7 +142,6 @@
 [NARRATOR]: Sugarkube hosts the relay, while people contribute spare compute by running models on consumer machines through a desktop app.
 
 [VISUAL]: Screen recording of the token.place public API documentation or demo, the desktop compute-node application, and a real operator workflow. Add a label: "Sugarkube hosts relay. Operators run compute nodes."
-
 
 [NARRATOR]: Requests are end-to-end encrypted between the client and the selected compute node.
 
@@ -173,7 +151,6 @@
 
 [VISUAL]: Simple custom diagram with client, relay, and selected compute node. Animate ciphertext passing through the relay and plaintext appearing only at the selected compute node. Cut to A-roll for "changes the trust boundary instead of eliminating trust."
 
-
 [NARRATOR]: Today, more nodes mostly mean more capacity.
 
 [NARRATOR]: My long-term hypothesis is that a larger, more diverse pool of independently operated nodes, combined with verifiable work histories and Sybil resistance, could make it harder for a bad actor to dominate node selection.
@@ -182,13 +159,11 @@
 
 [VISUAL]: A-roll with on-screen text: "That reputation system does not exist yet." Use a clearly labeled conceptual diagram, "Future hypothesis," showing diverse independent nodes accumulating verified work histories. Do not present it as current functionality.
 
-
 [NARRATOR]: By default, the official desktop app keeps prompt and response plaintext in memory and writes only redacted metadata to its logs.
 
 [NARRATOR]: Compute nodes and relays can both be self-hosted, so the strongest privacy story is running hardware you control.
 
 [VISUAL]: A-roll for the privacy caveat. Insert real repository documentation or settings screens for self-hosted relay and compute-node options where public interfaces exist. Keep logs sanitized and show redaction labels.
-
 
 [NARRATOR]: Third is danielsmith.io.
 
@@ -202,13 +177,11 @@
 
 [VISUAL]: Screen recording of danielsmith.io showing the Three.js house, avatar movement, both floors, backyard, project points of interest, and tutorial prompts.
 
-
 [NARRATOR]: A dedicated text version serves visitors who prefer a conventional page or use screen readers.
 
 [NARRATOR]: It gives hiring managers and recruiters a memorable first impression while whimsically capturing my interests in graphics programming and game development.
 
 [VISUAL]: Separate screen recording of the dedicated text version, keyboard navigation, conventional sections, and accessibility-focused layout. Avoid implying a screen reader endorsement unless actually tested.
-
 
 [NARRATOR]: Together, these projects form a feedback loop.
 
@@ -222,8 +195,7 @@
 
 [VISUAL]: Editor-made connected ecosystem diagram: Sugarkube deploys DSPACE, token.place, and danielsmith.io; Sugarkube hosts the token.place relay; token.place powers DSPACE dChat; danielsmith.io is the front door. Animate a feedback loop from application needs back to infrastructure improvements. Include a brief DSPACE dChat and NPC selector screen recording with visible "Powered by token.place" integration where practical.
 
-
-> 6:25–10:35: Electricity measurement and the efficiency-versus-agency tension
+### 6:25–10:35: Electricity measurement and the efficiency-versus-agency tension
 
 [NARRATOR]: My nine Raspberry Pi 5s each have 8 gigabytes of RAM, but only six are active, and even those are probably overkill for my traffic.
 
@@ -231,20 +203,17 @@
 
 [VISUAL]: Close-up lineup of Pi 5 boards and RAM labels, then the nine-slot overlay again with only six active nodes highlighted. Use A-roll for the Rampocalypse joke.
 
-
 [NARRATOR]: For a fair comparison, I disconnected the three unused Pis and measured the PoE+ switch, along with any external cooling used during normal operation, through a `<power meter model>`.
 
 [NARRATOR]: Over `<measurement duration>` during `<representative conditions or workload>`, the setup averaged `<average watts>` watts, peaked at `<peak watts>` watts, and consumed `<measured kilowatt-hours>` kilowatt-hours.
 
 [VISUAL]: Show the three unused Pis being disconnected, then the PoE+ switch and continuously running desk fan connected inside the measurement boundary. Capture the power meter display or logging interface at representative idle and workload moments. Add measured values as on-screen text placeholders matching the narration until final numbers are supplied.
 
-
 [NARRATOR]: Across an average 730-hour month, that becomes `<monthly kilowatt-hours>` kilowatt-hours.
 
 [NARRATOR]: At my marginal electricity rate of `<electricity rate>` per kilowatt-hour, it costs `<monthly electricity cost>` per month, or `<annual electricity cost>` per year.
 
 [VISUAL]: Simple calculator-style graphic: watts to monthly kWh to monthly and annual cost. Keep placeholders visible and clearly marked "final measured values pending."
-
 
 [NARRATOR]: That includes the switch, PoE losses, and cooling used during the test.
 
@@ -254,13 +223,11 @@
 
 [VISUAL]: Boundary diagram around the rack, PoE+ switch, cabling, and continuously running desk fan. Put router, modem, off-rack token.place compute nodes, and separate GPU computer outside the boundary with "excluded" labels.
 
-
 [NARRATOR]: For the cloud comparison, I modeled self-managed three-node staging and production clusters in one availability zone in AWS’s Oregon region.
 
 [NARRATOR]: The single availability zone mirrors the rack’s single-site failure domain.
 
 [VISUAL]: Screen recording of the AWS calculator or a clean editor-made architecture diagram showing two self-managed three-node k3s clusters in one Oregon availability zone. Label the single-site failure domain.
-
 
 [NARRATOR]: The model uses six on-demand Linux `c7g.xlarge` instances.
 
@@ -268,13 +235,11 @@
 
 [VISUAL]: Architecture card showing six `c7g.xlarge` instances with labels: "4 Arm vCPU" and "8 GiB memory." Add a qualification label: "Shape-matched, not performance-matched."
 
-
 [NARRATOR]: Each instance gets a 256 GiB gp3 volume and a public IPv4 address.
 
 [NARRATOR]: I kept k3s and Cloudflare Tunnel, excluding EKS, a managed load balancer, a NAT gateway, RDS, and managed observability.
 
 [VISUAL]: Add six 256 GiB gp3 volumes and six public IPv4 addresses to the AWS diagram. Include an on-screen exclusions list: EKS, managed load balancer, NAT gateway, RDS, managed observability.
-
 
 [NARRATOR]: Using AWS’s public rates from July 22, 2026, compute costs $635.10 per month, storage costs $122.88, and IPv4 addresses cost $21.90.
 
@@ -282,18 +247,15 @@
 
 [VISUAL]: Readable table or animated stack labeled "AWS pricing snapshot: July 22, 2026." Rows: compute $635.10, storage $122.88, IPv4 $21.90, total $779.88/month and $9,358.56/year. Add concise exclusions: taxes, data transfer, snapshots, expanded monitoring, backups, support.
 
-
 [NARRATOR]: Discounts, smaller instances, or shutting staging down could lower that bill substantially, but would change this always-on, shape-matched comparison.
 
 [VISUAL]: A-roll for the caveat with on-screen text: "Always-on, shape-matched comparison."
-
 
 [NARRATOR]: AWS does not publish the direct power consumption of an individual instance, so this compares cost rather than watts.
 
 [NARRATOR]: Its newer hardware and data-center economies may win on performance per watt, but this experiment did not prove that.
 
 [VISUAL]: A-roll. Add two simple labels: "Financial comparison" and "Not a watt-for-watt energy comparison."
-
 
 [NARRATOR]: The full nine-node build cost me `<full nine-node BOM total>`.
 
@@ -303,7 +265,6 @@
 
 [VISUAL]: Show real hardware, printed parts, cabling, redacted receipts, and the repository BOM. Create a simple comparison card for full nine-node total versus comparable six-node total, keeping placeholders until Daniel supplies final numbers.
 
-
 [NARRATOR]: If local electricity costs less than $779.88 per month, simple cash break-even occurs after `<break-even months>` months.
 
 [NARRATOR]: That is the comparable six-node cost divided by the monthly savings over AWS, rounded up.
@@ -312,20 +273,17 @@
 
 [VISUAL]: Show the formula: `comparable six-node cost / (AWS monthly cost - local monthly electricity cost)`. Optionally add a cumulative-cost line chart with the crossing point at the break-even month, plus a clear "No positive break-even" case when local monthly operating cost is greater than or equal to AWS.
 
-
 [NARRATOR]: This calculation also ignores my labor, failures, replacement parts, internet service, AWS discounts, and the value of managed infrastructure.
 
 [NARRATOR]: A real lifecycle comparison would need to include manufacturing, shipping, embodied energy, and indirect water use on both sides.
 
 [VISUAL]: A-roll for lifecycle limitations. Add a concise on-screen list of ignored factors without implying either side has zero indirect impact.
 
-
 [NARRATOR]: The rack itself uses no cooling water, unless you count what I drank while assembling it.
 
 [NARRATOR]: There is no dedicated air conditioning, humidity control, or liquid cooling; just onboard fans and a desk fan.
 
 [VISUAL]: Real shot of Daniel taking a drink for the joke, then close-ups of onboard fans and the continuously running desk fan. Avoid suggesting there is no indirect water use from electricity or manufacturing.
-
 
 [NARRATOR]: Running locally gives me more agency over energy use.
 
@@ -335,8 +293,7 @@
 
 [VISUAL]: Show the power meter, rack controls, terminal commands powering down or scaling environments, and deployment dashboards. Use licensed stock or real footage of solar panels, battery, and inverter only with a label: "Future off-grid goal."
 
-
-> 10:35–11:45: Participation and concluding vision
+### 10:35–11:45: Participation and concluding vision
 
 [NARRATOR]: All four projects are open source.
 
@@ -345,7 +302,6 @@
 [NARRATOR]: Even testing the documentation and telling me where it breaks would help.
 
 [VISUAL]: Screen montage of the four public repositories and apps: DSPACE gameplay and quest feedback path, danielsmith.io, token.place compute node or relay docs, and Sugarkube setup docs. Use restrained lower-thirds for each action.
-
 
 [NARRATOR]: Very few people need a micro data center at home.
 
@@ -357,13 +313,11 @@
 
 [VISUAL]: A-roll for the caveat, then practical shots of one Raspberry Pi, an old computer, the full yellow rack, and a simple Kubernetes learning diagram.
 
-
 [NARRATOR]: Long term, I plan to run Sugarkube from a dedicated off-grid solar, battery, and inverter system.
 
 [NARRATOR]: Subscribe if you want to see that process!
 
 [VISUAL]: Real or appropriately licensed stock footage of solar panels, battery, and inverter hardware labeled "Future plan." Pair the subscribe call to action with restrained on-screen text.
-
 
 [NARRATOR]: I started Sugarkube because deploying my projects kept getting in the way of building them.
 

--- a/video_scripts/README.md
+++ b/video_scripts/README.md
@@ -1,0 +1,41 @@
+# Video scripts
+
+`script.md` is the canonical editorial source for each video. Its Markdown is parsed into the normalized object described by [`schemas/video_script.schema.json`](../schemas/video_script.schema.json).
+
+## Canonical format
+
+```markdown
+# Video title
+
+> Draft script for video `video-id-or-placeholder`
+
+## Outline
+
+- Optional outline entry
+
+## Script
+
+### Optional section heading
+
+[NARRATOR]: One complete spoken thought.
+
+[VISUAL]: The visual direction supporting that narration.
+```
+
+Use `Transcript for video` instead of `Draft script for video` for a transcript. An outline, section headings, and visual cues are optional. Every body block must be a `###` section, narrator, or visual block; blocks have one blank line between them and files have exactly one final newline. Inline Markdown and narrator timing comments are preserved in `script.md`.
+
+Run `make check_scripts` (read-only) before committing, or `make format_scripts` to migrate structural legacy formatting. The formatter discovers nested scripts, including `drafts/`.
+
+## Prompter export
+
+Run `make prompter SLUG=20260901_sugarkube ALLOW_PLACEHOLDERS=1`, or:
+
+```bash
+python video_scripts/export_prompter.py --slug 20260901_sugarkube --allow-placeholders
+```
+
+`prompter.txt` is ignored generated output and never replaces `script.md`. Visual directions, headings, timing comments, and Markdown formatting are removed. When visual cues exist, narration preceding each cue is grouped into that visual beat (42 chapters for the current Sugarkube script); transcript-only scripts use one chapter per narrator segment. Exactly one blank line separates Prompter chapters. Exports reject spoken `<...>` placeholders unless `--allow-placeholders` is supplied. `--script PATH` and `--output PATH` select custom paths.
+
+## Production planning
+
+A video's `footage.md` is its canonical production index and may link detailed files under `production/`. Raw recordings and media stay under the ignored top-level `footage/` tree; do not add `assets.json` until corresponding footage directories exist.

--- a/video_scripts/drafts/3d-printed-rover/script.md
+++ b/video_scripts/drafts/3d-printed-rover/script.md
@@ -1,5 +1,6 @@
 # 3D-Printed Rover (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 

--- a/video_scripts/drafts/lunar-greenhouses/script.md
+++ b/video_scripts/drafts/lunar-greenhouses/script.md
@@ -1,5 +1,6 @@
 # Lunar Greenhouses (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 

--- a/video_scripts/drafts/micro-solar-desalination/script.md
+++ b/video_scripts/drafts/micro-solar-desalination/script.md
@@ -1,5 +1,6 @@
 # Micro Solar Desalination (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 

--- a/video_scripts/drafts/solar-aquaponic-mosquito-fighters/script.md
+++ b/video_scripts/drafts/solar-aquaponic-mosquito-fighters/script.md
@@ -1,5 +1,6 @@
 # Solar-Powered Aquaponic Mosquito Fighters (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 
@@ -14,4 +15,3 @@
 [NARRATOR]: Mosquito-eating fish like Gambusia keep larvae in check.
 
 [VISUAL]: Close-up of fish snapping up larvae near the surface.
-

--- a/video_scripts/drafts/solarpunk-weather-station/script.md
+++ b/video_scripts/drafts/solarpunk-weather-station/script.md
@@ -1,5 +1,6 @@
 # Solarpunk Weather Station (Draft)
-> YouTube ID: draft
+
+> Draft script for video `draft`
 
 ## Script
 

--- a/video_scripts/export_prompter.py
+++ b/video_scripts/export_prompter.py
@@ -1,0 +1,85 @@
+"""Export canonical video narration as plain-text Prompter chapters."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.video_script_format import ScriptFormatError, parse_script  # noqa: E402
+
+COMMENT_RE = re.compile(r"\s*<!--.*?-->\s*")
+LINK_RE = re.compile(r"!?\[([^]]+)]\([^)]*\)")
+PLACEHOLDER_RE = re.compile(r"<[^<>]+>")
+
+
+def plain_text(text: str) -> str:
+    """Remove Markdown presentation syntax without changing spoken words."""
+    text = COMMENT_RE.sub(" ", text)
+    text = LINK_RE.sub(r"\1", text)
+    text = text.replace("`", "")
+    text = re.sub(r"(?<!\\)[*_~]", "", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def build_chapters(data: dict) -> tuple[list[str], int]:
+    """Return visual-aligned chapters (or one chapter per transcript segment)."""
+    narrators = [
+        segment for segment in data["segments"] if segment["type"] == "narrator"
+    ]
+    has_visuals = any(segment["type"] == "visual" for segment in data["segments"])
+    if not has_visuals:
+        return [plain_text(segment["text"]) for segment in narrators], len(narrators)
+    chapters: list[str] = []
+    pending: list[str] = []
+    for segment in data["segments"]:
+        if segment["type"] == "narrator":
+            pending.append(plain_text(segment["text"]))
+        elif segment["type"] == "visual" and pending:
+            chapters.append(" ".join(pending))
+            pending = []
+    if pending:
+        chapters.append(" ".join(pending))
+    return chapters, len(narrators)
+
+
+def export(
+    script: Path, output: Path, *, allow_placeholders: bool = False
+) -> tuple[int, int]:
+    parsed = parse_script(script.read_text(encoding="utf-8"))
+    chapters, narrator_count = build_chapters(parsed.data)
+    content = "\n\n".join(chapters) + "\n"
+    placeholders = sorted(set(PLACEHOLDER_RE.findall(content)))
+    if placeholders and not allow_placeholders:
+        raise ValueError("unresolved placeholders: " + ", ".join(placeholders))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(content, encoding="utf-8")
+    return len(chapters), narrator_count
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    inputs = parser.add_mutually_exclusive_group(required=True)
+    inputs.add_argument("--slug")
+    inputs.add_argument("--script", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--allow-placeholders", action="store_true")
+    args = parser.parse_args(argv)
+    script = args.script or REPO_ROOT / "video_scripts" / args.slug / "script.md"
+    script = script.resolve()
+    output = (args.output or script.parent / "prompter.txt").resolve()
+    try:
+        chapters, _ = export(script, output, allow_placeholders=args.allow_placeholders)
+    except (OSError, ValueError, ScriptFormatError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Wrote {output} ({chapters} chapters)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Enforce a single, auditable canonical format for `video_scripts/**/script.md` so tools and humans can parse, validate, and reformat scripts deterministically. 
- Provide a reusable Prompter export that converts canonical scripts to rehearsal-friendly plain-text chapters and enforces resolution of spoken placeholders by default. 
- Capture an exhaustive, rights-aware production plan for the Sugarkube episode that maps every visual cue to explicit asset IDs and checklists. 

### Description

- Add a draft-07 normalized script schema (`schemas/video_script.schema.json`) and a shared parser/formatter/validator CLI (`src/video_script_format.py`) that discovers `video_scripts/**/script.md`, validates against the normalized object, supports `--check` and `--write`, and migrates known legacy variants. 
- Add the Prompter exporter (`video_scripts/export_prompter.py`) which reuses the shared parser to emit `prompter.txt`, groups narrator segments by visual beat (or one-per-segment for transcript-only scripts), strips Markdown/timing/comments, rejects unresolved `<...>` placeholders by default, and supports `--allow-placeholders`, `--slug`, `--script`, and `--output`. 
- Add exhaustive Sugarkube production files: `video_scripts/20260901_sugarkube/footage.md` and `production/{broll,stock,graphics}.md` that (a) state media policy (no AI-generated image/video), (b) enumerate pre-production gates, (c) enumerate V01–V42 visual cues and map each to `Axx/Bxx/Cxx/Txx/Gxx` asset IDs, and (d) include a final audit checklist. 
- Integrate workflow and infra: add `video_scripts/README.md`, Makefile targets `check_scripts`, `format_scripts`, and `prompter`, add a narrow ignore rule for generated `video_scripts/**/prompter.txt` in `.gitignore`, add a read-only pre-commit hook to run the canonical script check, and update `AGENTS.md`, `llms.txt`, and `docs/repository-guide.md` to document the new canonical format and Prompter behavior. 
- Update `src/generate_scripts_from_subtitles.py` and `src/scaffold_videos.py` to emit canonical spacing/one-final-newline output so script generators remain compatible with the shared parser. 

### Testing

- Ran the formatter and validator end-to-end: `python src/video_script_format.py --write video_scripts` then `python src/video_script_format.py --check video_scripts`, both completed with no schema or formatting failures. 
- Prompter verification: `python video_scripts/export_prompter.py --slug 20260901_sugarkube --allow-placeholders --output /tmp/sugarkube-prompter.txt` produced `42` chapters from `109` narrator segments, and the exporter failed cleanly (no partial output) when run without `--allow-placeholders` while listing unresolved placeholders. 
- Unit and integration tests: focused new tests (`tests/test_video_script_format.py`, `tests/test_export_prompter.py`, `tests/test_sugarkube_production.py`) and broader test suite were executed; focused set passed and full test suite passed (`python -m pytest -q` produced `386 passed` with two non-failing warnings). 
- Formatting and lint checks: `python -m black --check` and `python -m ruff check` were run on changed files with no remaining blocking failures, and staged changes were scanned with `./scripts/scan-secrets.py` with no secrets reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6416102e58832fab131c4c21588296)