### PR TITLE
ci: fix claude job sandbox initialization

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -211,12 +211,14 @@ jobs:
       issues: read
       actions: read
       id-token: write
+    env:
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
     steps:
       - name: Install required sandbox dependencies
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends bubblewrap
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
           if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           fi


### PR DESCRIPTION
A real @claude code-change request on sugarkube's PR #2563 revealed that the `claude` job's own internal sandbox failed to initialize (`bwrap: Can't create file at /home/.mcp.json: Permission denied`), silently blocking all Edit/Write/Bash use even though the job reported "success". Diffing against jobbot3000's proven-working job found two missing pieces: `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"` at the job level, and `socat` alongside `bubblewrap`. Same fix already applied and verified on sugarkube (#2568).