### PR TITLE
docs: remove stale companion projects table

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -1,7 +1,9 @@
 # Repo Feature Summary
 
-This page tracks the Futuroptimist automation surfaces that are currently live and highlights
-related projects that share the same tooling foundations.
+This page tracks the Futuroptimist automation surfaces that are currently live. For related
+projects, see the automatically refreshed
+[Related Projects](https://github.com/futuroptimist/futuroptimist#related-projects) section of
+the README instead of maintaining a second, hand-written list here.
 
 ## Futuroptimist automation snapshot
 | Feature | Status | Notes |
@@ -13,11 +15,3 @@ related projects that share the same tooling foundations.
 | Docs hygiene | ✅ | scripts/checks.sh runs docs-lint (see tests/test_checks_script.py). |
 | Analytics dashboard | ✅ | Streamlit dashboard renders metrics captured by analytics_ingester (see tests/test_analytics_dashboard.py). |
 | Upload packaging | ✅ | `src/prepare_youtube_upload.py` builds payloads and `src/upload_to_youtube.py` ships draft uploads (see `tests/test_prepare_youtube_upload.py`, `tests/test_upload_to_youtube.py`). |
-
-## Companion projects quick scan
-| Repo | Focus | Automation highlights |
-| ---- | ----- | --------------------- |
-| [token.place](https://github.com/futuroptimist/token.place) | Mesh | Shared prompts + AGENTS. |
-| [gabriel](https://github.com/futuroptimist/gabriel) | Security | Shared prompts + scanning. |
-| [axel](https://github.com/futuroptimist/axel) | Tracker | Codex automation triage. |
-| [jobbot](https://github.com/futuroptimist/jobbot3000) | Copilot | Mirrors Futuroptimist prompts. |


### PR DESCRIPTION
### Motivation

\`docs/repo-feature-summary.md\`'s "Companion projects quick scan" table listed token.place/gabriel/axel/jobbot3000 with no sync mechanism — \`tests/test_repo_feature_summary.py\` only guards the *other* table's structure, never this one's content. It had drifted from both \`docs/repo_list.txt\` (a different, also-narrow list kept in sync via \`tests/test_repo_list_sync.py\`) and the README's automatically-refreshed [Related Projects](https://github.com/futuroptimist/futuroptimist#related-projects) section.

### Description

- Remove the stale table.
- Point readers at the README's Related Projects section instead of maintaining a third, redundant, unsynced list.

Note: \`docs/repo_list.txt\` itself is *not* stale — it's genuinely kept in sync with \`data/prompt-docs/prompt-doc-repos.txt\` and serves a distinct, narrower purpose (repos tightly coupled to this codebase for the prompt-docs-summary generator), so it's left untouched.

### Testing

- \`npm run lint\`, \`npm run format:check\`, \`npm run docs-lint\` — all clean.
- \`pytest tests/test_repo_feature_summary.py tests/test_repo_list_sync.py tests/test_checks_script.py\` — 5/5 pass.