### PR TITLE
docs: track aquiloop in related projects

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -3,6 +3,7 @@ apa
 aquaponic
 aquaria
 aquascaping
+aquiloop
 auth
 axel
 backend
@@ -131,6 +132,7 @@ oembed
 ol
 onboarding
 openai
+openscad
 opentimelineio
 optimised
 otio

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs 
 - ✅ ⭐ 1 🔀 812 **[jobbot3000](https://github.com/futuroptimist/jobbot3000)** – self-hosted job-search copilot built on the same automation scaffold as this repo
 - ✅ ⭐ 1 🔀 51 **[pr-reaper](https://github.com/futuroptimist/pr-reaper)** – GitHub workflow for safely closing stale pull requests in bulk with dry-run support
 - ✅ ⭐ 1 🔀 277 **[wove](https://github.com/futuroptimist/wove)** – textile-learning toolkit for knitting, crochet, and CAD-to-fiber experiments
+- ✅ ⭐ 0 🔀 5 **[aquiloop](https://github.com/futuroptimist/aquiloop)** – parametric aquarium tools in OpenSCAD for makers and 3D printing
 - ❌ ([Update Repo Statuses](https://github.com/futuroptimist/futuroptimist/actions/runs/31407946844)) <!-- repo-status:failure-links --> ⭐ 0 🔀 340 **[futuroptimist](https://github.com/futuroptimist/futuroptimist)** – profile hub and production notebook for converting maker experiments into scripts, metadata, and reusable video workflows
 - ✅ ⭐ 0 🔀 1534 **[sugarkube](https://github.com/futuroptimist/sugarkube)** – solar-powered k3s platform and cube art installation for off-grid Raspberry Pi clusters
 

--- a/data/prompt-docs/prompt-doc-repos.txt
+++ b/data/prompt-docs/prompt-doc-repos.txt
@@ -2,3 +2,4 @@ futuroptimist
 jobbot3000
 pr-reaper
 danielsmith.io
+aquiloop

--- a/docs/prompts/codex/propagate.md
+++ b/docs/prompts/codex/propagate.md
@@ -18,6 +18,7 @@ Use this prompt to ask Codex to seed missing `docs/prompts/codex/*.md` files acr
    jobbot3000
    pr-reaper
    danielsmith.io
+   aquiloop
    ```
 
    Then regenerate [`docs/prompt-docs-summary.md`](../../prompt-docs-summary.md):

--- a/docs/repo_list.txt
+++ b/docs/repo_list.txt
@@ -2,3 +2,4 @@ futuroptimist
 jobbot3000
 pr-reaper
 danielsmith.io
+aquiloop


### PR DESCRIPTION
## Summary
- Add `futuroptimist/aquiloop` (parametric aquarium tools in OpenSCAD) to the `## Related Projects` dashboard in `README.md`, using live status/star/merged-PR data fetched via `src/repo_status.py`
- Append `aquiloop` to `docs/repo_list.txt` and `data/prompt-docs/prompt-doc-repos.txt` so it's covered by prompt-doc propagation tooling, keeping the two files in sync as required by `tests/test_repo_list_sync.py`

## Test plan
- [x] `pytest tests/test_repo_feature_summary.py tests/test_repo_list_sync.py tests/test_repo_status.py tests/test_update_prompt_docs_summary.py -q` (109 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)