### PR TITLE
fix: stop dashboard updater's own runs from poisoning its badge

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -88,11 +88,17 @@ SELF_STATUS_WORKFLOW_NAME = "update repo statuses"
 
 
 def _is_self_status_workflow_run(run: dict) -> bool:
-    """Return whether ``run`` belongs to this dashboard-updater workflow itself."""
+    """Return whether ``run`` belongs to this dashboard-updater workflow itself.
+
+    Trusts ``path`` exclusively when present, since a tracked repo could have
+    an unrelated workflow that merely shares this workflow's display name at a
+    different path. The name-based check only applies as a fallback when the
+    payload has no path at all.
+    """
 
     path = run.get("path")
-    if isinstance(path, str) and path == SELF_STATUS_WORKFLOW_PATH:
-        return True
+    if isinstance(path, str):
+        return path == SELF_STATUS_WORKFLOW_PATH
     name = run.get("name")
     if isinstance(name, str) and name.strip().casefold() == SELF_STATUS_WORKFLOW_NAME:
         return True

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -78,6 +78,26 @@ VERSION_LABEL_RE = re.compile(
 )
 RELEASE_EVENTS = {"push", "release", "workflow_dispatch", "repository_dispatch"}
 
+# This dashboard updater's own workflow (whichever repo it runs in). Its runs must
+# never count as CI signal for the repo it maintains: a transient failure here
+# (e.g. a GitHub API race) would otherwise mark itself as the "important" failing
+# run and keep re-pointing the badge at itself indefinitely, even once the repo's
+# real CI (tests/lint) is green again.
+SELF_STATUS_WORKFLOW_PATH = ".github/workflows/update-repo-status.yml"
+SELF_STATUS_WORKFLOW_NAME = "update repo statuses"
+
+
+def _is_self_status_workflow_run(run: dict) -> bool:
+    """Return whether ``run`` belongs to this dashboard-updater workflow itself."""
+
+    path = run.get("path")
+    if isinstance(path, str) and path == SELF_STATUS_WORKFLOW_PATH:
+        return True
+    name = run.get("name")
+    if isinstance(name, str) and name.strip().casefold() == SELF_STATUS_WORKFLOW_NAME:
+        return True
+    return False
+
 
 def status_to_emoji(conclusion: str | None) -> str:
     """Return an emoji representing the run conclusion.
@@ -668,6 +688,8 @@ def fetch_repo_status_details(
 
         runs_by_sha: dict[str, list[dict]] = {}
         for run in runs:
+            if _is_self_status_workflow_run(run):
+                continue
             run_branch = run.get("head_branch")
             if isinstance(run_branch, str) and branch and run_branch != branch:
                 continue

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1673,6 +1673,11 @@ def test_is_self_status_workflow_run_matches_path_and_name() -> None:
     assert not repo_status._is_self_status_workflow_run(
         {"path": ".github/workflows/tests.yml", "name": "Test Suite"}
     )
+    # A distinct workflow that merely shares this display name at a different
+    # path must not be excluded: path is authoritative whenever present.
+    assert not repo_status._is_self_status_workflow_run(
+        {"path": ".github/workflows/other.yml", "name": "Update Repo Statuses"}
+    )
 
 
 def test_fetch_repo_status_ignores_own_dashboard_updater_failure(

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1663,6 +1663,71 @@ def test_fetch_repo_status_bot_success_overrides_older_same_workflow_failure(
     )
 
 
+def test_is_self_status_workflow_run_matches_path_and_name() -> None:
+    assert repo_status._is_self_status_workflow_run(
+        {"path": ".github/workflows/update-repo-status.yml", "name": "anything"}
+    )
+    assert repo_status._is_self_status_workflow_run(
+        {"path": None, "name": "Update Repo Statuses"}
+    )
+    assert not repo_status._is_self_status_workflow_run(
+        {"path": ".github/workflows/tests.yml", "name": "Test Suite"}
+    )
+
+
+def test_fetch_repo_status_ignores_own_dashboard_updater_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed self-run of this dashboard updater must not poison the badge.
+
+    Regression test for the dashboard-updater workflow's own transient failure
+    (e.g. a GitHub API race) getting picked up as the "important" failing run
+    for the bot commit it happens to land on, permanently showing a red badge
+    even though the repo's real CI (tests/lint) is green.
+    """
+
+    _mock_repo_status_requests(
+        monkeypatch,
+        [
+            _workflow_run(
+                "success",
+                sha="old",
+                name="Test Suite",
+                workflow_id=1,
+                path=".github/workflows/tests.yml",
+                run_number=1,
+                run_id=1,
+            ),
+            _workflow_run(
+                "failure",
+                sha="bot",
+                name="Update Repo Statuses",
+                workflow_id=99,
+                path=".github/workflows/update-repo-status.yml",
+                run_number=5,
+                run_id=5,
+            ),
+        ],
+        commits=[
+            {
+                "sha": "bot",
+                "commit": {
+                    "message": "docs: update repo statuses",
+                    "author": {"name": "github-actions[bot]"},
+                    "committer": {"name": "github-actions[bot]"},
+                },
+                "author": {"login": "github-actions[bot]"},
+                "committer": {"login": "github-actions[bot]"},
+            },
+            _human_commit("old"),
+        ],
+    )
+
+    assert repo_status.fetch_repo_status_details("user/repo", attempts=2) == (
+        repo_status.RepoStatus("✅")
+    )
+
+
 def test_fetch_repo_status_neutral_and_skipped_are_passing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3003,6 +3068,11 @@ def test_update_readme_preserves_hand_authored_run_note_before_raw_repo(
 def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """The dashboard-updater's own runs must never drive the badge (see
+    ``_is_self_status_workflow_run``); a real "Test Suite" run on the current
+    commit is what should determine the outcome here.
+    """
+
     from datetime import datetime
 
     readme = tmp_path / "README.md"
@@ -3041,6 +3111,7 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
                         "head_branch": "main",
                         "name": "Update Repo Statuses",
                         "workflow_id": 99,
+                        "path": ".github/workflows/update-repo-status.yml",
                         "run_number": 20,
                         "run_attempt": 1,
                         "created_at": "2025-09-25T12:00:00Z",
@@ -3052,10 +3123,23 @@ def test_update_readme_flywheel_regression_suppresses_stale_failure_link(
                         "head_branch": "main",
                         "name": "Update Repo Statuses",
                         "workflow_id": 99,
+                        "path": ".github/workflows/update-repo-status.yml",
                         "run_number": 21,
                         "run_attempt": 1,
                         "created_at": "2025-09-25T13:00:00Z",
                         "html_url": "https://github.com/futuroptimist/flywheel/actions/runs/27199999999",
+                    },
+                    {
+                        "conclusion": "success",
+                        "head_sha": "new",
+                        "head_branch": "main",
+                        "name": "Test Suite",
+                        "workflow_id": 50,
+                        "path": ".github/workflows/test.yml",
+                        "run_number": 8,
+                        "run_attempt": 1,
+                        "created_at": "2025-09-25T13:05:00Z",
+                        "html_url": "https://github.com/futuroptimist/flywheel/actions/runs/27200000001",
                     },
                 ]
             }


### PR DESCRIPTION
## Summary
- The hourly `Update Repo Statuses` workflow evaluates each tracked repo's CI badge by correlating recent commits with completed workflow runs. Because that workflow runs on a schedule (not per-commit) and stamps whatever commit is HEAD at trigger time, one of its own bot commits can end up "owning" a self-check run.
- When that self-check run fails (e.g. a transient GitHub API race causing the "Non-deterministic workflow conclusion" `RuntimeError`), it gets picked up as an "important" failing run for that commit and overrides genuinely-passing test/lint signal — pinning a red ❌ on the repo until an unrelated commit eventually clears it.
- This is exactly what stuck the `futuroptimist/futuroptimist` entry on https://github.com/futuroptimist/futuroptimist/actions/runs/31407946844, even though later scheduled runs succeeded — see run history: fail/success/fail/success repeating for hours, with the README staying red the whole time.
- Fix: `_is_self_status_workflow_run()` excludes the dashboard updater's own runs (matched by workflow path `.github/workflows/update-repo-status.yml` and by name `Update Repo Statuses`, so it also covers flywheel's identically-named/pathed workflow) from ever being considered CI signal. Only real test/lint/build workflows can drive the badge now.
- Updated `tests/test_repo_status.py::test_update_readme_flywheel_regression_suppresses_stale_failure_link` to include a real `Test Suite` run alongside the self-status runs, since the self-status runs no longer supply the signal on their own; added two new regression tests (`test_is_self_status_workflow_run_matches_path_and_name`, `test_fetch_repo_status_ignores_own_dashboard_updater_failure`).

## Verification
- Ran the fixed code against live GitHub data for `futuroptimist/futuroptimist`: now resolves to `RepoStatus(emoji='✅', ...)` instead of the stale ❌.
- `pytest tests/test_repo_status.py -q` (104 passed)
- `pytest tests/test_repo_feature_summary.py tests/test_repo_list_sync.py tests/test_repo_status.py tests/test_update_prompt_docs_summary.py -q` (111 passed)
- Broader `pytest tests/ -q` (skipping modules with missing optional deps in my local venv, unrelated to this change): 343 passed, 1 unrelated failure (missing `jsonschema` locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)