### PR TITLE
docs: drop obsolete @main label from DSPACE dashboard entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Selected projects across this GitHub account, grouped as a compact portfolio map
 Status legend: ✅ latest relevant run succeeded; ❌ one or more relevant runs need attention; linked failures point to the run or asset to inspect; ❓ no completed relevant run was found or GitHub could not be queried; ⭐ shows GitHub stars; 🔀 shows total merged pull requests. Projects sort by stars descending, then alphabetically for ties; unknown star counts sort last.
 
 - ✅ ⭐ 7 🔀 766 **[token.place](https://token.place)** – peer-to-peer generative AI network for people sharing idle compute through ephemeral, encrypted tokens ([repo](https://github.com/futuroptimist/token.place))
-- ✅ ⭐ 4 🔀 2413 **[DSPACE](https://democratized.space)** @main – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/main))
+- ✅ ⭐ 4 🔀 2413 **[DSPACE](https://democratized.space)** – retro-futurist idle sim where quests teach real-world hobbies with NPC guides and offline-first progression ([repo](https://github.com/democratizedspace/dspace/tree/main))
 - ✅ ⭐ 3 🔀 488 **[flywheel](https://github.com/futuroptimist/flywheel)** – GitHub template for solo builders who want linting, tests, docs, releases, and LLM-agent workflows in one starter kit
 - ✅ ⭐ 2 🔀 129 **[f2clipboard](https://github.com/futuroptimist/f2clipboard)** – CLI for turning Codex task pages and failing GitHub logs into concise debugging reports
 - ✅ ⭐ 2 🔀 164 **[sigma](https://github.com/futuroptimist/sigma)** – open-source ESP32 AI pin with push-to-talk voice control and a 3D-printed enclosure


### PR DESCRIPTION
## Summary
- Removes the hand-authored `@main` label from the DSPACE row in the README's Related Projects dashboard. It's a leftover from when this dashboard tracked DSPACE's `v3` branch; `main` is now the permanently tracked branch, so the label was just noise.
- The underlying non-default-branch tracking capability is untouched: the `(repo)` link's `/tree/main` suffix (which `src/repo_status.py`'s branch parsing uses to target a specific branch) stays in place, so a future repo can still pin to a non-default branch and have it displayed the same way if needed.

## Test plan
- [x] `pytest tests/test_repo_status.py -q` (104 passed) — includes an existing fixture asserting DSPACE branch-parsing works from the `/tree/main` link alone, unrelated to the display label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)