### PR TITLE
fix: paginate commit lookback past long skip-worthy commit streaks

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -86,6 +86,10 @@ RELEASE_EVENTS = {"push", "release", "workflow_dispatch", "repository_dispatch"}
 SELF_STATUS_WORKFLOW_PATH = ".github/workflows/update-repo-status.yml"
 SELF_STATUS_WORKFLOW_NAME = "update repo statuses"
 
+# How many pages of 20 commits the commit lookback walk may fetch while
+# skipping past skip-worthy (e.g. bot-authored) commits before giving up.
+COMMIT_LOOKBACK_MAX_PAGES = 10
+
 
 def _is_self_status_workflow_run(run: dict) -> bool:
     """Return whether ``run`` belongs to this dashboard-updater workflow itself.
@@ -662,7 +666,7 @@ def fetch_repo_status_details(
                 type(commits_data),
             )
             return None, ()
-        commits = commits_data
+        first_page_commits = commits_data
 
         try:
             resp = requests.get(url, headers=headers, timeout=10)
@@ -704,18 +708,62 @@ def fetch_repo_status_details(
                 continue
             runs_by_sha.setdefault(sha, []).append(run)
 
+        # A repo whose default GITHUB_TOKEN pushes commits on a schedule (like
+        # this dashboard updater's own commits) can pile up many consecutive
+        # skip-worthy commits between real ones, since such pushes never
+        # trigger other workflows. `_should_skip_commit` already knows to
+        # walk past those, but a single page of commits may not be deep
+        # enough to reach the last real commit. Paginate further back, capped
+        # so a repo that is skip-worthy commits all the way down can't spin
+        # forever.
         selected_runs: list[dict] = []
-        for commit in commits:
-            sha = commit.get("sha")
-            if not isinstance(sha, str):
-                continue
-            commit_runs = runs_by_sha.get(sha, [])
-            if commit_runs:
-                selected_runs.extend(commit_runs)
-                continue
-            if _should_skip_commit(commit):
-                continue
-            break
+        hit_boundary = False
+        page_commits = first_page_commits
+        for page in range(1, COMMIT_LOOKBACK_MAX_PAGES + 1):
+            if page > 1:
+                commits_url = (
+                    f"https://api.github.com/repos/{repo}/commits"
+                    f"?sha={branch}&per_page=20&page={page}"
+                )
+                try:
+                    commits_resp = requests.get(
+                        commits_url, headers=headers, timeout=10
+                    )
+                    commits_resp.raise_for_status()
+                    commits_data = commits_resp.json()
+                except (requests.exceptions.RequestException, ValueError) as exc:
+                    LOGGER.warning(
+                        "Unable to fetch commits for %s@%s: %s", repo, branch, exc
+                    )
+                    return None, ()
+                if not isinstance(commits_data, list):
+                    LOGGER.warning(
+                        "Unexpected commits payload for %s@%s: %r",
+                        repo,
+                        branch,
+                        type(commits_data),
+                    )
+                    return None, ()
+                page_commits = commits_data
+
+            if not page_commits:
+                break
+
+            for commit in page_commits:
+                sha = commit.get("sha")
+                if not isinstance(sha, str):
+                    continue
+                commit_runs = runs_by_sha.get(sha, [])
+                if commit_runs:
+                    selected_runs.extend(commit_runs)
+                    continue
+                if _should_skip_commit(commit):
+                    continue
+                hit_boundary = True
+                break
+
+            if hit_boundary or len(page_commits) < 20:
+                break
 
         if not selected_runs:
             return None, ()

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -697,16 +697,20 @@ def fetch_repo_status_details(
             return None, ()
 
         runs_by_sha: dict[str, list[dict]] = {}
-        for run in runs:
-            if _is_self_status_workflow_run(run):
-                continue
-            run_branch = run.get("head_branch")
-            if isinstance(run_branch, str) and branch and run_branch != branch:
-                continue
-            sha = run.get("head_sha")
-            if not isinstance(sha, str):
-                continue
-            runs_by_sha.setdefault(sha, []).append(run)
+
+        def _index_runs(runs_page: Iterable[dict]) -> None:
+            for run in runs_page:
+                if _is_self_status_workflow_run(run):
+                    continue
+                run_branch = run.get("head_branch")
+                if isinstance(run_branch, str) and branch and run_branch != branch:
+                    continue
+                sha = run.get("head_sha")
+                if not isinstance(sha, str):
+                    continue
+                runs_by_sha.setdefault(sha, []).append(run)
+
+        _index_runs(runs)
 
         # A repo whose default GITHUB_TOKEN pushes commits on a schedule (like
         # this dashboard updater's own commits) can pile up many consecutive
@@ -715,7 +719,14 @@ def fetch_repo_status_details(
         # walk past those, but a single page of commits may not be deep
         # enough to reach the last real commit. Paginate further back, capped
         # so a repo that is skip-worthy commits all the way down can't spin
-        # forever.
+        # forever. Only paginate while we still have nothing to go on: once a
+        # page yields a match (or a real, un-skippable commit), stop exactly
+        # like the original single-page walk did, so repos that already
+        # resolve within page 1 see no behavior or request-count change. Each
+        # extra commit page is paired with an extra runs page so the runs
+        # window grows in step with the commit window — otherwise a commit
+        # reachable only through pagination could have runs that fell outside
+        # the first page of completed runs.
         selected_runs: list[dict] = []
         hit_boundary = False
         page_commits = first_page_commits
@@ -735,7 +746,7 @@ def fetch_repo_status_details(
                     LOGGER.warning(
                         "Unable to fetch commits for %s@%s: %s", repo, branch, exc
                     )
-                    return None, ()
+                    break
                 if not isinstance(commits_data, list):
                     LOGGER.warning(
                         "Unexpected commits payload for %s@%s: %r",
@@ -743,7 +754,39 @@ def fetch_repo_status_details(
                         branch,
                         type(commits_data),
                     )
-                    return None, ()
+                    break
+
+                runs_page_url = f"{url}&page={page}"
+                try:
+                    runs_resp = requests.get(runs_page_url, headers=headers, timeout=10)
+                    runs_resp.raise_for_status()
+                    runs_page_data = runs_resp.json()
+                except (requests.exceptions.RequestException, ValueError) as exc:
+                    LOGGER.warning(
+                        "Unable to fetch workflow runs for %s@%s: %s",
+                        repo,
+                        branch,
+                        exc,
+                    )
+                    break
+                if not isinstance(runs_page_data, dict):
+                    LOGGER.warning(
+                        "Unexpected workflow payload for %s@%s: %r",
+                        repo,
+                        branch,
+                        type(runs_page_data),
+                    )
+                    break
+                runs_page = runs_page_data.get("workflow_runs", [])
+                if not isinstance(runs_page, list):
+                    LOGGER.warning(
+                        "Unexpected workflow run list for %s@%s: %r",
+                        repo,
+                        branch,
+                        type(runs_page),
+                    )
+                    break
+                _index_runs(runs_page)
                 page_commits = commits_data
 
             if not page_commits:
@@ -762,7 +805,7 @@ def fetch_repo_status_details(
                 hit_boundary = True
                 break
 
-            if hit_boundary or len(page_commits) < 20:
+            if hit_boundary or selected_runs or len(page_commits) < 20:
                 break
 
         if not selected_runs:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -181,6 +181,19 @@ def _human_commit(sha: str, message: str = "feat: update") -> dict:
     }
 
 
+def _bot_commit(sha: str, message: str = "docs: update repo statuses") -> dict:
+    return {
+        "sha": sha,
+        "commit": {
+            "message": message,
+            "author": {"name": "github-actions[bot]"},
+            "committer": {"name": "github-actions[bot]"},
+        },
+        "author": {"login": "github-actions[bot]"},
+        "committer": {"login": "github-actions[bot]"},
+    }
+
+
 def _workflow_run(
     conclusion: str,
     *,
@@ -2030,6 +2043,84 @@ def test_fetch_repo_status_skips_bot_commit(monkeypatch: pytest.MonkeyPatch) -> 
         )
         == 2
     )
+
+
+def test_fetch_repo_status_paginates_past_long_bot_streak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 20-deep run of skip-worthy bot commits must not stop the lookback.
+
+    Regression test for the ``futuroptimist`` self-repo bug: the hourly
+    status-updater commits with the default ``GITHUB_TOKEN``, which never
+    triggers other workflows, so a long-enough streak of those commits could
+    exhaust the single 20-commit page before reaching the last real, tested
+    commit.
+    """
+
+    page_one = [_bot_commit(f"bot{i}") for i in range(20)]
+    page_two = [_human_commit("real"), *[_bot_commit(f"old{i}") for i in range(5)]]
+    calls: list[str] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
+        ):
+            return DummyResp({})
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url == (
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20&page=2"
+        ):
+            return DummyResp(page_two)
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(page_one)
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "success", "head_sha": "real", "name": "tests"}
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "✅"
+    assert (
+        "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        in calls
+    )
+    assert (
+        "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20&page=2"
+        in calls
+    )
+
+
+def test_fetch_repo_status_gives_up_after_lookback_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unbroken chain of skip-worthy commits must not paginate forever."""
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
+        ):
+            return DummyResp({})
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            # Every page is a full page of skip-worthy commits with no
+            # matching runs, forever.
+            return DummyResp([_bot_commit(f"bot-{url}-{i}") for i in range(20)])
+        return DummyResp({"workflow_runs": []})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "❓"
 
 
 def test_fetch_repo_status_skip_ci_message(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -2122,6 +2122,135 @@ def test_fetch_repo_status_gives_up_after_lookback_cap(
     assert repo_status.fetch_repo_status("user/repo") == "❓"
 
 
+def test_fetch_repo_status_stops_pagination_once_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full first page that already resolves must not fetch page 2.
+
+    Regression test for a review finding on the pagination fix: continuing
+    to paginate even after finding matching runs on page 1 would add
+    unneeded API calls and could let older, unrelated runs change an
+    already-resolved result.
+    """
+
+    page_one = [*[_bot_commit(f"bot{i}") for i in range(19)], _human_commit("abc")]
+    calls: list[str] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
+        ):
+            return DummyResp({})
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(page_one)
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "success", "head_sha": "abc", "name": "tests"}
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "✅"
+    assert not any("&page=2" in call for call in calls)
+
+
+def test_fetch_repo_status_paginates_runs_window_with_commits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A commit reachable only via pagination must be matched against runs
+    fetched for that same page, not just the first page of completed runs.
+
+    Regression test for a review finding: extending the commit lookback
+    without extending the runs lookback in step would let a real, green
+    commit resolve as unknown once it's deep enough that its runs fall
+    outside the first 100 completed runs.
+    """
+
+    page_one_commits = [_bot_commit(f"bot{i}") for i in range(20)]
+    page_two_commits = [_human_commit("old-real"), _bot_commit("older-bot")]
+    calls: list[str] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
+        ):
+            return DummyResp({})
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url == (
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20&page=2"
+        ):
+            return DummyResp(page_two_commits)
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(page_one_commits)
+        if url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            "per_page=100&status=completed&branch=main&page=2"
+        ):
+            return DummyResp(
+                {
+                    "workflow_runs": [
+                        {
+                            "conclusion": "success",
+                            "head_sha": "old-real",
+                            "name": "tests",
+                        }
+                    ]
+                }
+            )
+        # First page of runs deliberately has nothing for "old-real" — its
+        # run only shows up once the runs window is paginated alongside
+        # the commit window.
+        return DummyResp({"workflow_runs": []})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "✅"
+    assert (
+        "https://api.github.com/repos/user/repo/actions/runs?"
+        "per_page=100&status=completed&branch=main&page=2" in calls
+    )
+
+
+def test_fetch_repo_status_later_page_failure_returns_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient failure fetching a later commit page must not crash —
+    it should stop expanding and fall back to the unknown status."""
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
+        ):
+            return DummyResp({})
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url == (
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20&page=2"
+        ):
+            raise repo_status.requests.exceptions.ConnectionError("boom")
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp([_bot_commit(f"bot{i}") for i in range(20)])
+        return DummyResp({"workflow_runs": []})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "❓"
+
+
 def test_fetch_repo_status_skip_ci_message(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, headers: dict, timeout: int):
         if (

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -2089,8 +2089,7 @@ def test_fetch_repo_status_paginates_past_long_bot_streak(
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "✅"
     assert (
-        "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
-        in calls
+        "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20" in calls
     )
     assert (
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20&page=2"


### PR DESCRIPTION
## Summary
- The Related Projects dashboard shows this repo's own status as ❓, even though CI is green. Root cause: `update-repo-status.yml` pushes `docs: update repo statuses` hourly using the workflow's default `GITHUB_TOKEN`, and GitHub's anti-recursion rule means pushes made with that token never trigger other workflows — so these bot commits never get `Lint & Format` / `Test Suite` runs.
- `_should_skip_commit()` in `src/repo_status.py` already exists to walk past exactly this kind of commit and keep looking for the last real, CI-tested one, but it only had a single `per_page=20` page to search. There are currently 22+ consecutive bot commits in front of the last real commit (which already has green `Test Suite` / `Lint & Format` / `Docs Preview & Link Check` runs), so the walk exhausted its one page without ever reaching it.
- Paginate the commit walk (capped at 10 pages / 200 commits, same `per_page=20` per request) so it can reach past arbitrarily long automated-commit streaks. Falls back to the prior "unknown" result if the cap is exhausted, so this is strictly a bugfix — no behavior change for repos that already resolve within one page.
- Verified against the real repo: `fetch_repo_status_details("futuroptimist/futuroptimist")` now returns ✅ instead of ❓.

### Follow-up fixes from automated review (Greptile/Copilot/Codex)
- **Greptile (P1) / Copilot**: the commit lookback could extend to 200 commits while the runs fetch stayed capped at the first 100 completed runs, so a real commit reachable only via pagination could still resolve as unknown if its runs fell outside that single page. Fixed by fetching a matching runs page alongside every extra commits page, and by only continuing to paginate while a page has found neither a match nor a real un-skippable commit — so repos that already resolve within page 1 see no extra API calls or behavior change from this fix.
- **Codex (P2)**: a transient failure fetching a later page now stops expanding and evaluates whatever was already collected, instead of discarding it.

## Test plan
- [x] `uv run pytest tests/test_repo_status.py -q` — 109 passed (104 original + 5 new: 2 pagination regression tests, 3 covering the review-feedback fixes above)
- [x] `uv run ruff check src/repo_status.py tests/test_repo_status.py` — clean
- [x] `black --check src/repo_status.py tests/test_repo_status.py` — clean
- [x] Verified live against `futuroptimist/futuroptimist` and `futuroptimist/aquiloop` via `fetch_repo_status_details()` with a real token — both now resolve ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
