### PR TITLE
fix: recognize github-actions bot commits with unresolvable identity

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -65,6 +65,14 @@ GITHUB_MARKDOWN_LINK_RE = re.compile(
 SKIP_COMMIT_RE = re.compile(
     r"(?i)(?:\[(?:ci|actions)[-_/\s]*skip\]|\[skip[-_/\s]*(?:ci|actions)\]|skip[-_/\s]*(?:ci|actions))"
 )
+# Some workflows commit via `git config user.name github-actions` /
+# `user.email github-actions@github.com` instead of the documented
+# `github-actions[bot]` identity. GitHub can't resolve that email to a real
+# account, so its API reports the commit author as a synthetic
+# "invalid-email-address" user with no "[bot]" suffix anywhere to key off of.
+# Recognize the raw git identity directly so these still count as
+# skip-worthy automated commits.
+BOT_COMMIT_EMAILS = {"github-actions@github.com"}
 RELEASE_WORKFLOW_RE = re.compile(
     r"(?i)(release|publish|package|desktop|deploy|artifact|build)"
 )
@@ -532,10 +540,14 @@ def fetch_repo_status_details(
             return True
         for key in ("author", "committer"):
             login = (commit.get(key) or {}).get("login")
-            name = commit.get("commit", {}).get(key, {}).get("name")
+            raw_identity = commit.get("commit", {}).get(key) or {}
+            name = raw_identity.get("name")
+            email = raw_identity.get("email")
             if isinstance(login, str) and login.endswith("[bot]"):
                 return True
             if isinstance(name, str) and name.endswith("[bot]"):
+                return True
+            if isinstance(email, str) and email.strip().lower() in BOT_COMMIT_EMAILS:
                 return True
         return False
 

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -2045,6 +2045,77 @@ def test_fetch_repo_status_skips_bot_commit(monkeypatch: pytest.MonkeyPatch) -> 
     )
 
 
+def test_fetch_repo_status_skips_unresolvable_bot_identity_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A commit from `git config user.name/email github-actions` (no
+    `[bot]` suffix) must still be recognized as skip-worthy.
+
+    Regression test for `futuroptimist/flywheel`: its prompt-docs workflow
+    commits as raw git identity name "github-actions" / email
+    "github-actions@github.com" (not "github-actions[bot]"). GitHub can't
+    resolve that email to an account, so the API reports the commit's
+    resolved author/committer as a synthetic "invalid-email-address" user —
+    neither the login nor the raw git name ends in "[bot]", so the walk
+    used to treat it as a real, untested commit and stop immediately.
+    """
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
+        ):
+            return DummyResp({})
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp(
+                [
+                    {
+                        "sha": "unresolvable",
+                        "commit": {
+                            "message": "chore: update prompt docs summary",
+                            "author": {
+                                "name": "github-actions",
+                                "email": "github-actions@github.com",
+                            },
+                            "committer": {
+                                "name": "github-actions",
+                                "email": "github-actions@github.com",
+                            },
+                        },
+                        "author": {"login": "invalid-email-address"},
+                        "committer": {"login": "invalid-email-address"},
+                    },
+                    {
+                        "sha": "abc",
+                        "commit": {
+                            "message": "feat: add api",
+                            "author": {"name": "Alice", "email": "alice@example.com"},
+                            "committer": {
+                                "name": "Alice",
+                                "email": "alice@example.com",
+                            },
+                        },
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                    },
+                ]
+            )
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "success", "head_sha": "abc", "name": "tests"}
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "✅"
+
+
 def test_fetch_repo_status_paginates_past_long_bot_streak(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- The Related Projects dashboard showed `flywheel` as unknown (❓) even though its CI is green.
- Root cause: `flywheel`'s `06-prompt-docs.yml` and `convert-scad.yml` workflows commit via `git config user.name github-actions` / `user.email github-actions@github.com` — missing the `[bot]` suffix that `04-update-summary.yml` and `update-repo-status.yml` already use in the same repo. GitHub can't resolve that email to a real account, so its API reports the commit's author as a synthetic `invalid-email-address` user, with no `[bot]` suffix anywhere for `_should_skip_commit()` to key off of.
- Since that's the newest commit and (like the other bot-commit cases this function already handles) has no CI run of its own, the walk treated it as a real, untested commit and stopped immediately — never reaching flywheel's actual last human-authored, CI-tested commit.
- Recognize the raw git commit author/committer email directly, in addition to the existing login/name `[bot]`-suffix check.
- Companion fix in `futuroptimist/flywheel` (separate PR) aligns those two workflows to the repo's own `github-actions[bot]` convention, fixing the git history/attribution at the source too.

## Test plan
- [x] `uv run pytest tests/test_repo_status.py -q` — 110 passed (109 existing + 1 new regression test)
- [x] `uv run ruff check` / `black --check` — clean
- [x] Verified live: `fetch_repo_status_details("futuroptimist/flywheel")` now returns ✅ instead of ❓
- [x] Verified this isn't new breakage: checked out `repo_status.py` from before PR #452 and confirmed it *also* returns ❓ for flywheel with the current commit history — this was a pre-existing gap, not a regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)