### PR TITLE
fix: don't crash the whole batch on one transient fetch failure

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -497,8 +497,14 @@ def fetch_repo_status_details(
 
     The GitHub API occasionally returns inconsistent data if a workflow is
     updating while we query it. To catch this non-determinism we fetch the
-    status multiple times and ensure all results match. If they differ we raise
-    ``RuntimeError`` so the calling workflow fails loudly.
+    status multiple times and ensure all *resolved* results match. If two or
+    more attempts each successfully resolve a conclusion but disagree, we
+    raise ``RuntimeError`` so the calling workflow fails loudly. An attempt
+    that fails outright (e.g. a transient network/SSL error) resolves to
+    ``None`` rather than a real conclusion, and is not itself treated as
+    disagreement -- otherwise a single flaky request out of ``attempts``
+    tries, on any one of the many repos this is called for in a batch,
+    would take down the entire batch instead of just that repo's status.
     """
 
     headers = _github_headers(token)
@@ -938,17 +944,19 @@ def fetch_repo_status_details(
 
     reports = [_fetch() for _ in range(attempts)]
     conclusions = [report[0] for report in reports]
-    if len(set(conclusions)) > 1:
+    resolved_conclusions = {c for c in conclusions if c is not None}
+    if len(resolved_conclusions) > 1:
         raise RuntimeError(
             f"Non-deterministic workflow conclusion for {repo}: {conclusions}"
         )
+    final_conclusion = next(iter(resolved_conclusions), None)
     failure_links: list[StatusLink] = []
     for _, links in reports:
         for link in links:
             if link not in failure_links:
                 failure_links.append(link)
     return RepoStatus(
-        status_to_emoji(conclusions[0]),
+        status_to_emoji(final_conclusion),
         tuple(failure_links),
         metadata.stars,
         metadata.merged_prs,

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -526,6 +526,54 @@ def test_fetch_repo_status_nondeterministic(monkeypatch: pytest.MonkeyPatch) -> 
     )
 
 
+def test_fetch_repo_status_tolerates_one_failed_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient network failure on only one of the two attempts must not
+    be treated as non-determinism.
+
+    Regression test: `futuroptimist/futuroptimist`'s own hourly updater
+    crashed outright (RuntimeError, no README update at all) when a single
+    SSL error on one of two attempts for one repo produced conclusions
+    `[None, "success"]` -- previously `None` was compared for equality
+    against a real conclusion just like any other value, so a single flaky
+    request anywhere in a batch of ~16 repos x 2 attempts took down the
+    whole run instead of just leaving that repo unresolved for this pass.
+    """
+
+    run_calls = 0
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        nonlocal run_calls
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
+        ):
+            return DummyResp({})
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url.startswith(
+            "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20"
+        ):
+            return DummyResp([_human_commit("abc")])
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main"
+        )
+        run_calls += 1
+        if run_calls == 1:
+            raise repo_status.requests.exceptions.SSLError("certificate verify failed")
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {"conclusion": "success", "head_sha": "abc", "name": "tests"}
+                ]
+            }
+        )
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "✅"
+
+
 def test_fetch_repo_status_ignores_non_ci_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- The hourly `Update Repo Statuses` workflow crashed outright (no README update at all) for the last three consecutive runs, each with e.g.:
  ```
  RuntimeError: Non-deterministic workflow conclusion for futuroptimist/token.place: ['success', None]
  ```
- `fetch_repo_status_details()` fetches each repo's status twice and raises if the two attempts disagree, meant to catch genuine GitHub API eventual-consistency flakiness. But `None` isn't a real conclusion — it's what `_fetch()` returns when a request fails outright (here: a transient SSL error calling `api.github.com` from GitHub's own runner). The determinism check compared `None` against a real conclusion the same as any other mismatch, so **one** flaky request on **any one** of the ~16 tracked repos, across attempts × repos, took the entire batch down — leaving the whole README stale instead of just that one repo unresolved for the pass.
- Only compare *resolved* (non-`None`) conclusions for disagreement. A lone `None` alongside a real result now resolves to that result. Genuine disagreement between two successfully-resolved conclusions still raises `RuntimeError`, preserving the original fail-loud intent for real non-determinism.

## Test plan
- [x] `uv run pytest tests/test_repo_status.py -q` — 111 passed (110 existing + 1 new regression test simulating a transient `SSLError` on one of two attempts)
- [x] `uv run ruff check` / `black --check` — clean
- [x] Verified live: `fetch_repo_status_details()` now returns ✅ for `futuroptimist`, `flywheel`, and `token.place` (the last of which is now genuinely green again on its own, per @[the maintainer]'s in-progress Tauri fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)