### PR TITLE
fix: widen runs-page pagination independently of commits-page pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Unreleased
+- fix: widen the `update-repo-status` commit lookback's runs-page window
+  independently of its commits-page window so a real commit still on
+  commits-page 1 whose CI runs are buried behind noisy, non-CI workflow
+  traffic (e.g. the dashboard's own hourly commits, a chatty PR-comment bot)
+  no longer resolves to an unknown (❓) status.
 - feat: add `render_video` CLI to assemble rough-cut MP4s with optional subtitle
   burn-in from `footage/<slug>/converted` clips.
 - test: cover render_video clip discovery, ffmpeg command construction,

--- a/outages/2026-08-19-repo-status-runs-pagination-boundary.json
+++ b/outages/2026-08-19-repo-status-runs-pagination-boundary.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "./schema.json",
-    "date": "2026-08-19",
-    "workflow": "update-repo-status",
-    "run_url": "https://github.com/futuroptimist/futuroptimist/actions/workflows/update-repo-status.yml",
-    "root_cause": "The commit lookback in fetch_repo_status_details only fetched another /actions/runs page when it also fetched another /commits page, so a real commit still on commits-page 1 whose CI runs were buried behind frequent non-CI workflow noise (this dashboard's own hourly commits, a chatty PR-comment bot) never got a wider runs window and resolved to unknown.",
-    "resolution": "Decouple runs-page pagination from commits-page pagination: widen the runs window (up to the existing lookback cap) and retry the same unresolved commit whenever nothing has been selected yet, instead of giving up after a single runs page."
+  "$schema": "./schema.json",
+  "date": "2026-08-19",
+  "workflow": "update-repo-status",
+  "run_url": "https://github.com/futuroptimist/futuroptimist/actions/workflows/update-repo-status.yml",
+  "root_cause": "The commit lookback in fetch_repo_status_details only fetched another /actions/runs page when it also fetched another /commits page, so a real commit still on commits-page 1 whose CI runs were buried behind frequent non-CI workflow noise (this dashboard's own hourly commits, a chatty PR-comment bot) never got a wider runs window and resolved to unknown.",
+  "resolution": "Decouple runs-page pagination from commits-page pagination: widen the runs window (up to the existing lookback cap) and retry the same unresolved commit whenever nothing has been selected yet, instead of giving up after a single runs page."
 }

--- a/outages/2026-08-19-repo-status-runs-pagination-boundary.json
+++ b/outages/2026-08-19-repo-status-runs-pagination-boundary.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "./schema.json",
+    "date": "2026-08-19",
+    "workflow": "update-repo-status",
+    "run_url": "https://github.com/futuroptimist/futuroptimist/actions/workflows/update-repo-status.yml",
+    "root_cause": "The commit lookback in fetch_repo_status_details only fetched another /actions/runs page when it also fetched another /commits page, so a real commit still on commits-page 1 whose CI runs were buried behind frequent non-CI workflow noise (this dashboard's own hourly commits, a chatty PR-comment bot) never got a wider runs window and resolved to unknown.",
+    "resolution": "Decouple runs-page pagination from commits-page pagination: widen the runs window (up to the existing lookback cap) and retry the same unresolved commit whenever nothing has been selected yet, instead of giving up after a single runs page."
+}

--- a/outages/2026-08-19-repo-status-runs-pagination-boundary.md
+++ b/outages/2026-08-19-repo-status-runs-pagination-boundary.md
@@ -1,0 +1,27 @@
+# Update Repo Status showing "?" for repos with noisy Actions history
+
+- **Date**: 2026-08-19
+- **Summary**: The "Related Projects" dashboard on the `futuroptimist` GitHub profile README
+  showed ❓ for `token.place` and `flywheel` even though both repos had recent, green CI.
+- **Root Cause**: `fetch_repo_status_details()`'s commit lookback in `src/repo_status.py` only
+  fetched another page of `/actions/runs` when it also fetched another page of `/commits`. A real,
+  non-bot commit that was still on the *first* commits page but whose matching CI runs were buried
+  behind frequent, non-CI-signal workflow runs (this dashboard's own hourly commits for `flywheel`,
+  a chatty PR-comment-triggered `claude.yml` workflow for `token.place`) never triggered a wider
+  runs window, so the walk gave up and reported "unknown" immediately. Confirmed live against the
+  GitHub API: `flywheel`'s most recent merge commit had 9 completed, all-green CI runs, but they
+  only appeared on runs-page 3 of the branch's completed-runs listing.
+- **Resolution**: Track the runs-page cursor independently of the commits-page cursor. When the
+  walk reaches a real, unresolved commit and nothing has been selected yet, fetch another runs
+  page (up to the existing lookback cap) and retry that same commit before treating it as the
+  lookback boundary.
+- **Lessons**: Pagination windows that are supposed to grow together should be checked
+  independently when one side can legitimately need to grow faster than the other -- a repo's
+  automation traffic (bots, chat-driven CI, hourly jobs) can make the "runs" side much noisier
+  than the "commits" side.
+
+## Follow-up
+
+- Added regression tests covering a real commit still on commits-page 1 whose runs are buried on a
+  later runs page, and confirming the widened runs pagination still respects the shared lookback
+  cap.

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -745,9 +745,44 @@ def fetch_repo_status_details(
         # window grows in step with the commit window — otherwise a commit
         # reachable only through pagination could have runs that fell outside
         # the first page of completed runs.
+        def _fetch_runs_page(page_number: int) -> list[dict] | None:
+            runs_page_url = f"{url}&page={page_number}"
+            try:
+                runs_resp = requests.get(runs_page_url, headers=headers, timeout=10)
+                runs_resp.raise_for_status()
+                runs_page_data = runs_resp.json()
+            except (requests.exceptions.RequestException, ValueError) as exc:
+                LOGGER.warning(
+                    "Unable to fetch workflow runs for %s@%s: %s",
+                    repo,
+                    branch,
+                    exc,
+                )
+                return None
+            if not isinstance(runs_page_data, dict):
+                LOGGER.warning(
+                    "Unexpected workflow payload for %s@%s: %r",
+                    repo,
+                    branch,
+                    type(runs_page_data),
+                )
+                return None
+            runs_page = runs_page_data.get("workflow_runs", [])
+            if not isinstance(runs_page, list):
+                LOGGER.warning(
+                    "Unexpected workflow run list for %s@%s: %r",
+                    repo,
+                    branch,
+                    type(runs_page),
+                )
+                return None
+            return runs_page
+
         selected_runs: list[dict] = []
         hit_boundary = False
         page_commits = first_page_commits
+        # Page 1 of runs was already fetched and indexed above.
+        runs_page_number = 1
         for page in range(1, COMMIT_LOOKBACK_MAX_PAGES + 1):
             if page > 1:
                 commits_url = (
@@ -774,52 +809,66 @@ def fetch_repo_status_details(
                     )
                     break
 
-                runs_page_url = f"{url}&page={page}"
-                try:
-                    runs_resp = requests.get(runs_page_url, headers=headers, timeout=10)
-                    runs_resp.raise_for_status()
-                    runs_page_data = runs_resp.json()
-                except (requests.exceptions.RequestException, ValueError) as exc:
-                    LOGGER.warning(
-                        "Unable to fetch workflow runs for %s@%s: %s",
-                        repo,
-                        branch,
-                        exc,
-                    )
-                    break
-                if not isinstance(runs_page_data, dict):
-                    LOGGER.warning(
-                        "Unexpected workflow payload for %s@%s: %r",
-                        repo,
-                        branch,
-                        type(runs_page_data),
-                    )
-                    break
-                runs_page = runs_page_data.get("workflow_runs", [])
-                if not isinstance(runs_page, list):
-                    LOGGER.warning(
-                        "Unexpected workflow run list for %s@%s: %r",
-                        repo,
-                        branch,
-                        type(runs_page),
-                    )
-                    break
-                _index_runs(runs_page)
+                # Only fetch the runs page paired with this commits page if a
+                # boundary commit on an earlier commits page hasn't already
+                # pulled the runs window this far ahead (see below).
+                if runs_page_number < page:
+                    runs_page_number = page
+                    runs_page = _fetch_runs_page(page)
+                    if runs_page is None:
+                        break
+                    _index_runs(runs_page)
                 page_commits = commits_data
 
             if not page_commits:
                 break
 
-            for commit in page_commits:
+            commit_index = 0
+            while commit_index < len(page_commits):
+                commit = page_commits[commit_index]
                 sha = commit.get("sha")
                 if not isinstance(sha, str):
+                    commit_index += 1
                     continue
                 commit_runs = runs_by_sha.get(sha, [])
                 if commit_runs:
                     selected_runs.extend(commit_runs)
+                    commit_index += 1
                     continue
                 if _should_skip_commit(commit):
+                    commit_index += 1
                     continue
+
+                # A real, unresolved commit. Before treating this as the
+                # lookback boundary, try widening the *runs* window: a repo
+                # whose completed-runs listing is dominated by frequent,
+                # non-CI-signal workflow runs (this dashboard's own hourly
+                # commits, a chatty PR-comment bot, etc.) can bury a recent
+                # commit's real CI runs several runs-pages deep even though
+                # the commit itself is on the very first commits page. Only
+                # do this while nothing is selected yet -- once we've found
+                # the newest relevant run(s), a boundary commit genuinely
+                # means "stop walking further back".
+                if not selected_runs and runs_page_number < COMMIT_LOOKBACK_MAX_PAGES:
+                    runs_page_number += 1
+                    more_runs = _fetch_runs_page(runs_page_number)
+                    if more_runs is None:
+                        hit_boundary = True
+                        break
+                    _index_runs(more_runs)
+                    if len(more_runs) < 100:
+                        # No more runs exist upstream; give this commit one
+                        # final check against the now-exhausted index rather
+                        # than requesting empty pages up to the cap.
+                        commit_runs = runs_by_sha.get(sha, [])
+                        if commit_runs:
+                            selected_runs.extend(commit_runs)
+                            commit_index += 1
+                            continue
+                        hit_boundary = True
+                        break
+                    continue  # retry the same commit against the wider index
+
                 hit_boundary = True
                 break
 

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -729,6 +729,10 @@ def fetch_repo_status_details(
                 runs_by_sha.setdefault(sha, []).append(run)
 
         _index_runs(runs)
+        # A short page means GitHub has already returned the entire completed-
+        # runs listing. Remember that fact so unresolved commits do not trigger
+        # requests for pages that cannot exist.
+        runs_exhausted = len(runs) < 100
 
         # A repo whose default GITHUB_TOKEN pushes commits on a schedule (like
         # this dashboard updater's own commits) can pile up many consecutive
@@ -740,11 +744,10 @@ def fetch_repo_status_details(
         # forever. Only paginate while we still have nothing to go on: once a
         # page yields a match (or a real, un-skippable commit), stop exactly
         # like the original single-page walk did, so repos that already
-        # resolve within page 1 see no behavior or request-count change. Each
-        # extra commit page is paired with an extra runs page so the runs
-        # window grows in step with the commit window — otherwise a commit
-        # reachable only through pagination could have runs that fell outside
-        # the first page of completed runs.
+        # resolve within page 1 see no behavior or request-count change.
+        # Commit and runs cursors advance independently. A later commit page
+        # may require a matching runs page, while a boundary commit on the
+        # current commit page may widen the runs window on its own.
         def _fetch_runs_page(page_number: int) -> list[dict] | None:
             runs_page_url = f"{url}&page={page_number}"
             try:
@@ -812,12 +815,13 @@ def fetch_repo_status_details(
                 # Only fetch the runs page paired with this commits page if a
                 # boundary commit on an earlier commits page hasn't already
                 # pulled the runs window this far ahead (see below).
-                if runs_page_number < page:
+                if runs_page_number < page and not runs_exhausted:
                     runs_page_number = page
                     runs_page = _fetch_runs_page(page)
                     if runs_page is None:
                         break
                     _index_runs(runs_page)
+                    runs_exhausted = len(runs_page) < 100
                 page_commits = commits_data
 
             if not page_commits:
@@ -849,7 +853,11 @@ def fetch_repo_status_details(
                 # do this while nothing is selected yet -- once we've found
                 # the newest relevant run(s), a boundary commit genuinely
                 # means "stop walking further back".
-                if not selected_runs and runs_page_number < COMMIT_LOOKBACK_MAX_PAGES:
+                if (
+                    not selected_runs
+                    and not runs_exhausted
+                    and runs_page_number < COMMIT_LOOKBACK_MAX_PAGES
+                ):
                     runs_page_number += 1
                     more_runs = _fetch_runs_page(runs_page_number)
                     if more_runs is None:
@@ -857,6 +865,7 @@ def fetch_repo_status_details(
                         break
                     _index_runs(more_runs)
                     if len(more_runs) < 100:
+                        runs_exhausted = True
                         # No more runs exist upstream; give this commit one
                         # final check against the now-exhausted index rather
                         # than requesting empty pages up to the cap.

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -366,20 +366,28 @@ def test_fetch_repo_status_no_runs_returns_unknown(
                     }
                 ]
             )
-        assert url == (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main"
+        assert url in (
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main&page=2",
         )
         return DummyResp({"workflow_runs": []})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "❓"
+    # The lone commit has no matching run on runs-page 1. Since nothing has
+    # been selected yet, the lookback widens the runs window by one more
+    # page before giving up on that commit -- runs-page 2 comes back empty
+    # (fewer than 100 results), so it stops there instead of paginating all
+    # the way to the cap.
     assert calls == [
         "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main&page=2",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
+        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main&page=2",
     ]
 
 
@@ -2340,6 +2348,107 @@ def test_fetch_repo_status_paginates_runs_window_with_commits(
         "https://api.github.com/repos/user/repo/actions/runs?"
         "per_page=100&status=completed&branch=main&page=2" in calls
     )
+
+
+def test_fetch_repo_status_widens_runs_window_within_first_commits_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real commit *within* commits-page 1 can still need more runs pages.
+
+    Regression test for the token.place/flywheel dashboard bug: a repo whose
+    `/actions/runs` listing is dominated by frequent, non-CI-signal workflow
+    runs (this dashboard's own hourly commits, a chatty PR-comment bot, etc.)
+    can bury the newest real commit's actual CI runs several runs-pages deep,
+    even though that commit is the very first, most recent one -- so the walk
+    never advances to commits-page 2 at all. Extending the runs window only
+    when a new *commits* page is fetched (the old behavior) never kicks in
+    here, and the lookback used to give up with "unknown" immediately.
+    """
+
+    target_commit = _human_commit("real", message="Merge pull request #1")
+    page_one_commits = [target_commit, *[_bot_commit(f"bot{i}") for i in range(19)]]
+    noise_page = [
+        {"conclusion": "success", "head_sha": f"noise{i}", "name": "Claude Code"}
+        for i in range(100)
+    ]
+    real_run_page = [{"conclusion": "success", "head_sha": "real", "name": "tests"}]
+    calls: list[str] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        calls.append(url)
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
+        ):
+            return DummyResp({})
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url == "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20":
+            return DummyResp(page_one_commits)
+        if url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            "per_page=100&status=completed&branch=main"
+        ):
+            return DummyResp({"workflow_runs": []})
+        if url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            "per_page=100&status=completed&branch=main&page=2"
+        ):
+            return DummyResp({"workflow_runs": noise_page})
+        if url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            "per_page=100&status=completed&branch=main&page=3"
+        ):
+            return DummyResp({"workflow_runs": real_run_page})
+        raise AssertionError(f"unexpected request: {url}")
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "✅"
+    assert (
+        "https://api.github.com/repos/user/repo/actions/runs?"
+        "per_page=100&status=completed&branch=main&page=2" in calls
+    )
+    assert (
+        "https://api.github.com/repos/user/repo/actions/runs?"
+        "per_page=100&status=completed&branch=main&page=3" in calls
+    )
+    assert not any(
+        "commits?sha=main&per_page=20&page=2" in call for call in calls
+    )
+
+
+def test_fetch_repo_status_widening_runs_window_respects_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Widening the runs window must still respect the lookback page cap."""
+
+    target_commit = _human_commit("real", message="Merge pull request #1")
+    page_one_commits = [target_commit, *[_bot_commit(f"bot{i}") for i in range(19)]]
+    noise_page = [
+        {"conclusion": "success", "head_sha": f"noise{i}", "name": "Claude Code"}
+        for i in range(100)
+    ]
+    runs_calls: list[str] = []
+
+    def fake_get(url: str, headers: dict, timeout: int):
+        if (
+            url
+            == "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1"
+        ):
+            return DummyResp({})
+        if url == "https://api.github.com/repos/user/repo":
+            return DummyResp({"default_branch": "main"})
+        if url == "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20":
+            return DummyResp(page_one_commits)
+        # Every runs page, forever, is full of unrelated noise -- the real
+        # commit's run (if it exists at all) is never found.
+        runs_calls.append(url)
+        return DummyResp({"workflow_runs": noise_page})
+
+    monkeypatch.setattr(repo_status.requests, "get", fake_get)
+    assert repo_status.fetch_repo_status("user/repo") == "❓"
+    # One base fetch plus widening up to the shared lookback cap, per attempt.
+    assert len(runs_calls) <= repo_status.COMMIT_LOOKBACK_MAX_PAGES * 2
 
 
 def test_fetch_repo_status_later_page_failure_returns_unknown(

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -366,28 +366,23 @@ def test_fetch_repo_status_no_runs_returns_unknown(
                     }
                 ]
             )
-        assert url in (
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
-            "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main&page=2",
+        assert url == (
+            "https://api.github.com/repos/user/repo/actions/runs?"
+            "per_page=100&status=completed&branch=main"
         )
         return DummyResp({"workflow_runs": []})
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "❓"
-    # The lone commit has no matching run on runs-page 1. Since nothing has
-    # been selected yet, the lookback widens the runs window by one more
-    # page before giving up on that commit -- runs-page 2 comes back empty
-    # (fewer than 100 results), so it stops there instead of paginating all
-    # the way to the cap.
+    # The short first runs page proves that the listing is exhausted, so the
+    # unresolved commit must not trigger a pointless page-2 request.
     assert calls == [
         "https://api.github.com/search/issues?q=repo:user/repo+is:pr+is:merged&per_page=1",
         "https://api.github.com/repos/user/repo",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main&page=2",
         "https://api.github.com/repos/user/repo/commits?sha=main&per_page=20",
         "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main",
-        "https://api.github.com/repos/user/repo/actions/runs?per_page=100&status=completed&branch=main&page=2",
     ]
 
 
@@ -2337,10 +2332,21 @@ def test_fetch_repo_status_paginates_runs_window_with_commits(
                     ]
                 }
             )
-        # First page of runs deliberately has nothing for "old-real" — its
+        # First page of runs is full of unrelated noise for "old-real" — its
         # run only shows up once the runs window is paginated alongside
         # the commit window.
-        return DummyResp({"workflow_runs": []})
+        return DummyResp(
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "success",
+                        "head_sha": f"noise{i}",
+                        "name": "noise",
+                    }
+                    for i in range(100)
+                ]
+            }
+        )
 
     monkeypatch.setattr(repo_status.requests, "get", fake_get)
     assert repo_status.fetch_repo_status("user/repo") == "✅"
@@ -2389,7 +2395,7 @@ def test_fetch_repo_status_widens_runs_window_within_first_commits_page(
             "https://api.github.com/repos/user/repo/actions/runs?"
             "per_page=100&status=completed&branch=main"
         ):
-            return DummyResp({"workflow_runs": []})
+            return DummyResp({"workflow_runs": noise_page})
         if url == (
             "https://api.github.com/repos/user/repo/actions/runs?"
             "per_page=100&status=completed&branch=main&page=2"
@@ -2412,9 +2418,7 @@ def test_fetch_repo_status_widens_runs_window_within_first_commits_page(
         "https://api.github.com/repos/user/repo/actions/runs?"
         "per_page=100&status=completed&branch=main&page=3" in calls
     )
-    assert not any(
-        "commits?sha=main&per_page=20&page=2" in call for call in calls
-    )
+    assert not any("commits?sha=main&per_page=20&page=2" in call for call in calls)
 
 
 def test_fetch_repo_status_widening_runs_window_respects_cap(


### PR DESCRIPTION
## Summary
- The Related Projects dashboard on the profile README showed ❓ for `token.place` and `flywheel` even though both have recent, green CI. Root-caused live against the GitHub API: `fetch_repo_status_details()`'s commit lookback only fetched another `/actions/runs` page when it also fetched another `/commits` page, so a real commit still on commits-page 1 whose CI runs were buried behind noisy, non-CI workflow traffic (flywheel's own hourly `update-repo-status` runs; token.place's chatty `claude.yml`) never got a wider runs window and resolved to unknown.
- Fix: track the runs-page cursor independently of the commits-page cursor — widen the runs window (up to the existing lookback cap) and retry the same unresolved commit before treating it as the lookback boundary.
- Added an outage writeup (`outages/2026-08-19-repo-status-runs-pagination-boundary.{md,json}`) per repo convention, and a CHANGELOG entry.

## Test plan
- [x] `./.venv/bin/pytest tests/test_repo_status.py -q` — 113 passed, including two new regression tests for this exact scenario (real commit buried by noise within commits-page 1, and the widened-pagination cap still holding)
- [x] `ruff check src/repo_status.py tests/test_repo_status.py` — clean
- [x] `mypy src/repo_status.py` — only pre-existing, unrelated errors (verified against main via `git stash`)
- [x] Live re-fetch against the GitHub API confirms `token.place` and `flywheel` now resolve to ✅
- [x] Ran `update_readme` end-to-end against a scratch copy of the real README and diffed against the current README — only the two target rows' status emoji changed, no other regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)